### PR TITLE
Add AttributeDiscrete.value validation change info

### DIFF
--- a/2025R2/scripting-toolkit-dev-portal-25r2/api/attribute-values.md
+++ b/2025R2/scripting-toolkit-dev-portal-25r2/api/attribute-values.md
@@ -456,6 +456,10 @@ Provides access to the list of strings that store the attribute’s data values,
 
 Discrete value(s) associated with this attribute.
 
+#### Versionchanged
+Changed in version 4.1: Property `value` now validates the provided value against the attribute’s allowed discrete values.
+Check [`AttributeDefinitionDiscrete.discrete_values`](attribute-definitions.md#GRANTA_MIScriptingToolkit.granta.mi_attribute_classes.AttributeDefinitionDiscrete.discrete_values) for available values. This validation is case-sensitive.
+
 * **Returns:**
   List[str] or str if not multivalued
 

--- a/2025R2/scripting-toolkit-dev-portal-25r2/changelog.md
+++ b/2025R2/scripting-toolkit-dev-portal-25r2/changelog.md
@@ -179,6 +179,13 @@ There are no changes required to upgrade from MI Scripting Toolkit Version 4.1.
 
 ### Upgrading from MI Scripting Toolkit Version 4.0
 
+<a id="attribute-values"></a>
+
+#### Attribute Values
+
+* Property [`AttributeDiscrete.value`](api/attribute-values.md#GRANTA_MIScriptingToolkit.granta.mi_attribute_value_classes.AttributeDiscrete.value) now validates the provided value against the attribute’s allowed
+  discrete values. Check [`AttributeDefinitionDiscrete.discrete_values`](api/attribute-definitions.md#GRANTA_MIScriptingToolkit.granta.mi_attribute_classes.AttributeDefinitionDiscrete.discrete_values) for available values. This validation is case-sensitive.
+
 <a id="parameters"></a>
 
 #### Parameters


### PR DESCRIPTION
Late addition to the Scripting Toolkit documentation for 2025 R2.

Add notes about AttributeDiscrete.value validation being case-sensitive from v4.1 onwards.