### PR TITLE
DPF: update dpf-types.md

### DIFF
--- a/2025R2/dpf-operator-spec-25-r2/core-concepts/dpf-types.md
+++ b/2025R2/dpf-operator-spec-25-r2/core-concepts/dpf-types.md
@@ -144,11 +144,11 @@ In the DPF ecosystem this is called ``scoping`` the data, and is managed with ``
 
 A ``scoping`` describes a typed list of IDs. 
 
+It has a ``location``, which defines the type of entity the IDs apply to (nodes, elements, time-steps, parts...), and a list of ``ids``.
+
 It allows you to select and filter data when given as input to operators, or data description when produced as output.
 
 Each ``field`` data storage type has a ``scoping`` associated to it, describing the subset of its ``support`` that the data applies to. The data in a ``field`` is ordered the same way as the IDs in the ``scoping``.
-
-It has a ``location``, which defines the type of entity the IDs apply to (nodes, elements, time-steps, parts...), and a list of ``ids``.
 
 ### Data storage
 


### PR DESCRIPTION
The `dpf-types.md` file is where the operator documentation redirects to for pin types.

This is meant as a series of short descriptions of the types available in the standard DPF ecosystem.

Another section/page will be used to explain the overall data model of DPF (for now `core-concepts/data_containers.md`).