### PR TITLE
Add ModelCenter Component Plugin SDK docs for 2026 R1

### DIFF
--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/apis.md
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/apis.md
@@ -1,4 +1,4 @@
-# The PACZ component plug-in SDK .NET API documentation.
+# APIs
 
 - The main interfaces a plug-in must implement:
 

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/changelog.md
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/changelog.md
@@ -3,11 +3,11 @@
 ## 2026 R1
 
 - Added doc to developer page
-- Added Threading guide (previously part of Common Issues)
-- Added Glossary of terms
-- Added Examples page with BasicPaczPlugin and FMUv2Import source code
+- Added threading guide (previously part of common issues)
+- Added glossary of terms
+- Added examples page with BasicPaczPlugin and FMUv2Import source code
 - Added full .NET API reference documentation (converted from DocFX HTML to markdown)
 - Added APIs page with .NET API reference link
-- Consolidated Getting Started, New Project Overview, Testing, and Customizing into a single Getting Started guide
+- Consolidated getting started, new project overview, testing, and customizing into a single getting started guide
 - Added API links throughout documentation
 - Improved code samples (corrected language tags from java to C#)

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/docfx.json
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/docfx.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "globalMetadata": {
-      "title": "Component Plugin Software Developer's Guide (SDK) 2026 R1",
+      "title": "Component plugin software developer's guide (SDK) 2026 R1",
       "summary": "",
       "version": "2026 R1",
       "product": "ModelCenter",

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/faq.md
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/faq.md
@@ -1,10 +1,10 @@
-# Frequently Asked Questions
+# Frequently asked questions
 
 This page provides answers to frequently asked questions about developing PACZ component plug-ins.
 
 ## Variables and data types
 
-### Q1: How do I programmatically define a ModelCenter assembly in the Component Tree?
+### Q1: How do I programmatically define a ModelCenter assembly in the component tree?
 
 **A1:** Write nested variable names using "." separators:
 

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/index.md
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/index.md
@@ -1,4 +1,4 @@
-# Component Plugin Software Developer's Guide (SDK)
+# Introduction
 
 Welcome to the parametric analysis component zipped (PACZ) component plug-in 2026R1 SDK documentation. This guide is intended to help plug-in developers extend the capabilities of Ansys products by adding connections to external data and analysis tools such as Excel, databases, CAD systems, and other engineering applications.
 
@@ -32,9 +32,9 @@ This SDK is designed for:
 
 Before you begin developing component plug-ins, you should have:
 
-- **Development Environment**: Visual Studio 2019 or later (VS 2022 recommended), or a Java development environment
-- **Programming Knowledge**: Familiarity with .NET Framework 4.6.2 or Java
-- **SDK Access**: Access to the SDK ZIP file which contains the `Phoenix.ComponentPlugInSDK` NuGet package and optionally the Visual Studio template extension
+- **Development environment**: Visual Studio 2019 or later (VS 2022 recommended), or a Java development environment
+- **Programming knowledge**: Familiarity with .NET Framework 4.6.2 or Java
+- **SDK access**: Access to the SDK ZIP file which contains the `Phoenix.ComponentPlugInSDK` NuGet package and optionally the Visual Studio template extension
 
 ### Obtaining SDK access
 
@@ -55,7 +55,7 @@ This documentation covers:
 
 ## Next steps
 
-Ready to get started? Head over to the [Getting Started](started.md) guide to set up your development environment and create your first plug-in.
+Ready to get started? Head over to the [Getting started](started.md) guide to set up your development environment and create your first plug-in.
 
 If you're new to PACZ component plug-ins, review the [Glossary](glossary.md) to familiarize yourself with key terminology.
 

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/started.md
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/started.md
@@ -1,4 +1,4 @@
-# Getting Started
+# Getting started
 
 ## Overview
 

--- a/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/toc.yml
+++ b/2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/toc.yml
@@ -1,10 +1,10 @@
-- name: Component Plugin Software Developer's Guide (SDK)
+- name: Introduction
   href: index.md
-- name: Getting Started
+- name: Getting started
   href: started.md
 - name: Threading
   href: threading.md
-- name: Frequently Asked Questions
+- name: Frequently asked questions
   href: faq.md
 - name: Glossary
   href: glossary.md
@@ -12,7 +12,2318 @@
   href: examples.md
 - name: APIs
   href: apis.md
-- name: .NET API Reference
-  href: apidocs/toc.yml
+- name: .NET API reference
+  items:
+  - name: Phoenix.BuilderUIClient
+    href: apidocs/Phoenix.BuilderUIClient.md
+    items:
+    - name: Classes
+    - name: BooleanInvertConverter
+      href: apidocs/Phoenix.BuilderUIClient.BooleanInvertConverter.md
+      items:
+      - name: Methods
+      - name: Convert
+        href: apidocs/Phoenix.BuilderUIClient.BooleanInvertConverter.Convert.md
+      - name: ConvertBack
+        href: apidocs/Phoenix.BuilderUIClient.BooleanInvertConverter.ConvertBack.md
+      - name: ProvideValue
+        href: apidocs/Phoenix.BuilderUIClient.BooleanInvertConverter.ProvideValue.md
+    - name: BuilderUIClientFactory
+      href: apidocs/Phoenix.BuilderUIClient.BuilderUIClientFactory.md
+      items:
+      - name: Methods
+      - name: ConfigureServiceCollection
+        href: apidocs/Phoenix.BuilderUIClient.BuilderUIClientFactory.ConfigureServiceCollection.md
+      - name: ConfigureWithDefaultRepositories
+        href: apidocs/Phoenix.BuilderUIClient.BuilderUIClientFactory.ConfigureWithDefaultRepositories.md
+      - name: GetClient
+        href: apidocs/Phoenix.BuilderUIClient.BuilderUIClientFactory.GetClient.md
+    - name: ComponentInfoControl
+      href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControl.md
+      items:
+      - name: Constructors
+      - name: ComponentInfoControl
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControl.-ctor.md
+      - name: Properties
+      - name: ViewModel
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControl.ViewModel.md
+    - name: ComponentInfoControlModel
+      href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.md
+      items:
+      - name: Constructors
+      - name: ComponentInfoControlModel
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.-ctor.md
+      - name: Properties
+      - name: Author
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Author.md
+      - name: ComponentType
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.ComponentType.md
+      - name: Description
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Description.md
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.ExternalMetadata.md
+      - name: Files
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Files.md
+      - name: Icon
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Icon.md
+      - name: IconImage
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.IconImage.md
+      - name: Source
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Source.md
+      - name: Version
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.Version.md
+      - name: Methods
+      - name: ApplyFileChanges
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.ApplyFileChanges.md
+      - name: ExpandFile
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.ExpandFile.md
+      - name: ExportAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.ExportAsync.md
+      - name: OpenExtractionFolderAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.OpenExtractionFolderAsync.md
+      - name: SafeLoadIconAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.SafeLoadIconAsync.md
+      - name: SetIconAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlModel.SetIconAsync.md
+    - name: ComponentInfoControlViewModel
+      href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.md
+      items:
+      - name: Constructors
+      - name: ComponentInfoControlViewModel
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.-ctor.md
+      - name: Fields
+      - name: _model
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._model.md
+      - name: Properties
+      - name: Author
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Author.md
+      - name: BrowseIconCommand
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.BrowseIconCommand.md
+      - name: CanEditBuilderUI
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.CanEditBuilderUI.md
+      - name: ComponentType
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.ComponentType.md
+      - name: Description
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Description.md
+      - name: EditBuilderUILabel
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.EditBuilderUILabel.md
+      - name: EditCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.EditCommandAsync.md
+      - name: ExportCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.ExportCommandAsync.md
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.ExternalMetadata.md
+      - name: Files
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Files.md
+      - name: HasChanged
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HasChanged.md
+      - name: HasComponent
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HasComponent.md
+      - name: HelpAsyncDelegate
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HelpAsyncDelegate.md
+      - name: HelpButtonEnabled
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HelpButtonEnabled.md
+      - name: HelpCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HelpCommandAsync.md
+      - name: HideExternalMetadata
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.HideExternalMetadata.md
+      - name: Icon
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Icon.md
+      - name: IconImage
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.IconImage.md
+      - name: InWriteMode
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.InWriteMode.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.IsReadOnly.md
+      - name: OnComponentSaved
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.OnComponentSaved.md
+      - name: OpenFolderCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.OpenFolderCommandAsync.md
+      - name: SaveButtonEnabled
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.SaveButtonEnabled.md
+      - name: SaveCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.SaveCommandAsync.md
+      - name: Source
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Source.md
+      - name: Version
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.Version.md
+      - name: Methods
+      - name: ExpandFile
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.ExpandFile.md
+      - name: LoadComponentAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.LoadComponentAsync.md
+      - name: OnFileCheckChanged
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.OnFileCheckChanged.md
+      - name: OnPropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.OnPropertyChanged.md
+      - name: StartWriteMode
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.StartWriteMode.md
+      - name: UnloadComponent
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.UnloadComponent.md
+      - name: _onBrowseIcon
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._onBrowseIcon.md
+      - name: _onExport
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._onExport.md
+      - name: _onHelp
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._onHelp.md
+      - name: _onOpenFolder
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._onOpenFolder.md
+      - name: _onSave
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._onSave.md
+      - name: _showMessageBox
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel._showMessageBox.md
+      - name: Events
+      - name: PropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.PropertyChanged.md
+      - name: RequestSaveAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoControlViewModel.RequestSaveAsync.md
+    - name: ComponentInfoSessionManager
+      href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.md
+      items:
+      - name: Constructors
+      - name: ComponentInfoSessionManager
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.-ctor.md
+      - name: Fields
+      - name: OnTestRunRequested
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OnTestRunRequested.md
+      - name: Properties
+      - name: OnComponentSaved
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OnComponentSaved.md
+      - name: Methods
+      - name: DisposeAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.DisposeAsync.md
+      - name: OpenBuilderUIForComponent
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OpenBuilderUIForComponent.md
+      - name: OpenComponent
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OpenComponent.md
+      - name: OpenComponentWithLocalEditSession
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OpenComponentWithLocalEditSession.md
+      - name: OpenExistingBuilderUI
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.OpenExistingBuilderUI.md
+      - name: TrySavingExistingSessionAsync
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.TrySavingExistingSessionAsync.md
+      - name: UnloadComponent
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.UnloadComponent.md
+      - name: _promptUserToSaveLocalEdit
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager._promptUserToSaveLocalEdit.md
+      - name: Events
+      - name: BuilderSessionDisposed
+        href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.BuilderSessionDisposed.md
+    - name: FileTreeItem
+      href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.md
+      items:
+      - name: Constructors
+      - name: FileTreeItem
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.-ctor.md
+      - name: Properties
+      - name: CanChangeCheck
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.CanChangeCheck.md
+      - name: FileName
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.FileName.md
+      - name: IsChecked
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.IsChecked.md
+      - name: Items
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.Items.md
+      - name: RelativePath
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.RelativePath.md
+      - name: Methods
+      - name: Equals
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.Equals.md
+      - name: OnPropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.OnPropertyChanged.md
+      - name: ToString
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.ToString.md
+      - name: Events
+      - name: PropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.FileTreeItem.PropertyChanged.md
+    - name: NewComponentWizard
+      href: apidocs/Phoenix.BuilderUIClient.NewComponentWizard.md
+      items:
+      - name: Constructors
+      - name: NewComponentWizard
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizard.-ctor.md
+      - name: Properties
+      - name: Model
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizard.Model.md
+      - name: Methods
+      - name: OnOK
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizard.OnOK.md
+    - name: NewComponentWizardModel
+      href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.md
+      items:
+      - name: Constructors
+      - name: NewComponentWizardModel
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.-ctor.md
+      - name: Properties
+      - name: CompType
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.CompType.md
+      - name: Compressed
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.Compressed.md
+      - name: HelpAvailable
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.HelpAvailable.md
+      - name: Location
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.Location.md
+      - name: Name
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.Name.md
+      - name: OnHelp
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.OnHelp.md
+      - name: OnPickLocation
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.OnPickLocation.md
+      - name: Preview
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.Preview.md
+      - name: SelectedPath
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.SelectedPath.md
+      - name: Uncompressed
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.Uncompressed.md
+      - name: Methods
+      - name: OnPropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.OnPropertyChanged.md
+      - name: Events
+      - name: PropertyChanged
+        href: apidocs/Phoenix.BuilderUIClient.NewComponentWizardModel.PropertyChanged.md
+    - name: PaczInitializationDialog
+      href: apidocs/Phoenix.BuilderUIClient.PaczInitializationDialog.md
+      items:
+      - name: Constructors
+      - name: PaczInitializationDialog
+        href: apidocs/Phoenix.BuilderUIClient.PaczInitializationDialog.-ctor.md
+      - name: Properties
+      - name: ChosenOption
+        href: apidocs/Phoenix.BuilderUIClient.PaczInitializationDialog.ChosenOption.md
+      - name: ShowHelpCommand
+        href: apidocs/Phoenix.BuilderUIClient.PaczInitializationDialog.ShowHelpCommand.md
+      - name: Methods
+      - name: GetFromUser
+        href: apidocs/Phoenix.BuilderUIClient.PaczInitializationDialog.GetFromUser.md
+    - name: UserFriendlyBuilderSessionInitialization
+      href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.md
+      items:
+      - name: Constructors
+      - name: UserFriendlyBuilderSessionInitialization
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.-ctor.md
+      - name: Properties
+      - name: DesiredSaveLocation
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.DesiredSaveLocation.md
+      - name: FilesToCopy
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.FilesToCopy.md
+      - name: FilesToCopyBaseDir
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.FilesToCopyBaseDir.md
+      - name: FolderToConvert
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.FolderToConvert.md
+      - name: Mode
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.Mode.md
+      - name: SelectedName
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.SelectedName.md
+      - name: ShouldSaveExpanded
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.ShouldSaveExpanded.md
+      - name: Methods
+      - name: BuilderUISessionFromPaczWriter
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.BuilderUISessionFromPaczWriter.md
+      - name: CreateSession
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.CreateSession.md
+      - name: PaczWriterFromDirectory
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.PaczWriterFromDirectory.md
+      - name: PaczWriterFromFiles
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.PaczWriterFromFiles.md
+      - name: PromptUser
+        href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.PromptUser.md
+    - name: Interfaces
+    - name: IComponentInfoControlViewModel
+      href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.md
+      items:
+      - name: Properties
+      - name: Author
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Author.md
+      - name: BrowseIconCommand
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.BrowseIconCommand.md
+      - name: CanEditBuilderUI
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.CanEditBuilderUI.md
+      - name: ComponentType
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.ComponentType.md
+      - name: Description
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Description.md
+      - name: EditBuilderUILabel
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.EditBuilderUILabel.md
+      - name: EditCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.EditCommandAsync.md
+      - name: ExportCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.ExportCommandAsync.md
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.ExternalMetadata.md
+      - name: Files
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Files.md
+      - name: HasChanged
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HasChanged.md
+      - name: HasComponent
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HasComponent.md
+      - name: HelpAsyncDelegate
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HelpAsyncDelegate.md
+      - name: HelpButtonEnabled
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HelpButtonEnabled.md
+      - name: HelpCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HelpCommandAsync.md
+      - name: HideExternalMetadata
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.HideExternalMetadata.md
+      - name: Icon
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Icon.md
+      - name: IconImage
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.IconImage.md
+      - name: InWriteMode
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.InWriteMode.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.IsReadOnly.md
+      - name: OnComponentSaved
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.OnComponentSaved.md
+      - name: OpenFolderCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.OpenFolderCommandAsync.md
+      - name: SaveButtonEnabled
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.SaveButtonEnabled.md
+      - name: SaveCommandAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.SaveCommandAsync.md
+      - name: Source
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Source.md
+      - name: Version
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.Version.md
+      - name: Methods
+      - name: ExpandFile
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.ExpandFile.md
+      - name: LoadComponentAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.LoadComponentAsync.md
+      - name: StartWriteMode
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.StartWriteMode.md
+      - name: UnloadComponent
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.UnloadComponent.md
+      - name: Events
+      - name: RequestSaveAsync
+        href: apidocs/Phoenix.BuilderUIClient.IComponentInfoControlViewModel.RequestSaveAsync.md
+    - name: IDirectory
+      href: apidocs/Phoenix.BuilderUIClient.IDirectory.md
+      items:
+      - name: Methods
+      - name: EnumerateDirectories
+        href: apidocs/Phoenix.BuilderUIClient.IDirectory.EnumerateDirectories.md
+      - name: EnumerateFiles
+        href: apidocs/Phoenix.BuilderUIClient.IDirectory.EnumerateFiles.md
+      - name: Exists
+        href: apidocs/Phoenix.BuilderUIClient.IDirectory.Exists.md
+      - name: GetFileSystemEntries
+        href: apidocs/Phoenix.BuilderUIClient.IDirectory.GetFileSystemEntries.md
+    - name: IFile
+      href: apidocs/Phoenix.BuilderUIClient.IFile.md
+      items:
+      - name: Methods
+      - name: Copy
+        href: apidocs/Phoenix.BuilderUIClient.IFile.Copy.md
+    - name: IProcess
+      href: apidocs/Phoenix.BuilderUIClient.IProcess.md
+      items:
+      - name: Methods
+      - name: Start
+        href: apidocs/Phoenix.BuilderUIClient.IProcess.Start.md
+    - name: ISaveFileDialog
+      href: apidocs/Phoenix.BuilderUIClient.ISaveFileDialog.md
+      items:
+      - name: Properties
+      - name: FileName
+        href: apidocs/Phoenix.BuilderUIClient.ISaveFileDialog.FileName.md
+      - name: Filter
+        href: apidocs/Phoenix.BuilderUIClient.ISaveFileDialog.Filter.md
+      - name: Methods
+      - name: ShowDialog
+        href: apidocs/Phoenix.BuilderUIClient.ISaveFileDialog.ShowDialog.md
+    - name: Enums
+    - name: ComponentInfoSessionManager.FutureOperation
+      href: apidocs/Phoenix.BuilderUIClient.ComponentInfoSessionManager.FutureOperation.md
+    - name: UserFriendlyBuilderSessionInitialization.InitializationOption
+      href: apidocs/Phoenix.BuilderUIClient.UserFriendlyBuilderSessionInitialization.InitializationOption.md
+  - name: Phoenix.BuilderUIClient.FileDialogs
+    href: apidocs/Phoenix.BuilderUIClient.FileDialogs.md
+    items:
+    - name: Classes
+    - name: MultiSourceFileDialog
+      href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileDialog.md
+      items:
+      - name: Properties
+      - name: SelectedPath
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileDialog.SelectedPath.md
+      - name: Methods
+      - name: ShowDialog
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileDialog.ShowDialog.md
+      - name: _showMinervaDialogTask
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileDialog._showMinervaDialogTask.md
+    - name: MultiSourceFileOpenDialog
+      href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileOpenDialog.md
+      items:
+      - name: Properties
+      - name: Filter
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileOpenDialog.Filter.md
+      - name: Methods
+      - name: _showMinervaDialogTask
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileOpenDialog._showMinervaDialogTask.md
+    - name: MultiSourceFileSaveDialog
+      href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileSaveDialog.md
+      items:
+      - name: Methods
+      - name: _showMinervaDialogTask
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFileSaveDialog._showMinervaDialogTask.md
+    - name: MultiSourceFolderDialog
+      href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFolderDialog.md
+      items:
+      - name: Methods
+      - name: _showMinervaDialogTask
+        href: apidocs/Phoenix.BuilderUIClient.FileDialogs.MultiSourceFolderDialog._showMinervaDialogTask.md
+  - name: Phoenix.BuilderUIClient.Properties
+    href: apidocs/Phoenix.BuilderUIClient.Properties.md
+    items:
+    - name: Classes
+    - name: Resources
+      href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.md
+      items:
+      - name: Properties
+      - name: BuilderSessionExists
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.BuilderSessionExists.md
+      - name: BuilderSessionNotSupported
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.BuilderSessionNotSupported.md
+      - name: CannotUpdateSourceWithLocalChanges
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.CannotUpdateSourceWithLocalChanges.md
+      - name: ComponentInfoControlAuthorLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlAuthorLabel.md
+      - name: ComponentInfoControlDescriptionLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlDescriptionLabel.md
+      - name: ComponentInfoControlEditComponentLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlEditComponentLabel.md
+      - name: ComponentInfoControlExportLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlExportLabel.md
+      - name: ComponentInfoControlFilesLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlFilesLabel.md
+      - name: ComponentInfoControlIconLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlIconLabel.md
+      - name: ComponentInfoControlOpenFolderLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlOpenFolderLabel.md
+      - name: ComponentInfoControlSaveLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlSaveLabel.md
+      - name: ComponentInfoControlSourceLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlSourceLabel.md
+      - name: ComponentInfoControlVersionLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlVersionLabel.md
+      - name: ComponentInfoControlViewComponentLabel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ComponentInfoControlViewComponentLabel.md
+      - name: ConfirmCommitChanges
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ConfirmCommitChanges.md
+      - name: ConfirmSaveAs
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ConfirmSaveAs.md
+      - name: ConfirmSaveAsContentFmt
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ConfirmSaveAsContentFmt.md
+      - name: CrossDirectoryFileSelection
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.CrossDirectoryFileSelection.md
+      - name: Culture
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.Culture.md
+      - name: DirectoryIsAlreadyPacz
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.DirectoryIsAlreadyPacz.md
+      - name: ExceptionSendingEvent
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ExceptionSendingEvent.md
+      - name: ExportPaczFilter
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ExportPaczFilter.md
+      - name: IconFilter
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.IconFilter.md
+      - name: ImportedFileOutOfBounds
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ImportedFileOutOfBounds.md
+      - name: InvalidSelectionCaption
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.InvalidSelectionCaption.md
+      - name: LocalSessionExists
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.LocalSessionExists.md
+      - name: NewCompWizCancel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizCancel.md
+      - name: NewCompWizComponentName
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizComponentName.md
+      - name: NewCompWizCompressed
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizCompressed.md
+      - name: NewCompWizExpanded
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizExpanded.md
+      - name: NewCompWizHelp
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizHelp.md
+      - name: NewCompWizIntroText
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizIntroText.md
+      - name: NewCompWizLocation
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizLocation.md
+      - name: NewCompWizOK
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizOK.md
+      - name: NewCompWizSaveStyle
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizSaveStyle.md
+      - name: NewCompWizTitle
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizTitle.md
+      - name: NewCompWizWillGenerate
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.NewCompWizWillGenerate.md
+      - name: PaczInitialization
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitialization.md
+      - name: PaczInitializationButtonCancel
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationButtonCancel.md
+      - name: PaczInitializationButtonConvert
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationButtonConvert.md
+      - name: PaczInitializationButtonCreateBlank
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationButtonCreateBlank.md
+      - name: PaczInitializationButtonHelp
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationButtonHelp.md
+      - name: PaczInitializationButtonImport
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationButtonImport.md
+      - name: PaczInitializationCaption
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationCaption.md
+      - name: PaczInitializationConvertDescription
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationConvertDescription.md
+      - name: PaczInitializationCreateBlankDescrtiption
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationCreateBlankDescrtiption.md
+      - name: PaczInitializationImportDescription
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.PaczInitializationImportDescription.md
+      - name: ReadOnly
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ReadOnly.md
+      - name: ResourceManager
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.ResourceManager.md
+      - name: SaveLocalEditChangesPrompt
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.SaveLocalEditChangesPrompt.md
+      - name: StatusHelp_32x
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.StatusHelp_32x.md
+      - name: UIError
+        href: apidocs/Phoenix.BuilderUIClient.Properties.Resources.UIError.md
+  - name: Phoenix.ComponentAPI
+    href: apidocs/Phoenix.ComponentAPI.md
+    items:
+    - name: Classes
+    - name: BasicRunnerSessionOptions
+      href: apidocs/Phoenix.ComponentAPI.BasicRunnerSessionOptions.md
+      items:
+      - name: Fields
+      - name: DEFAULT
+        href: apidocs/Phoenix.ComponentAPI.BasicRunnerSessionOptions.DEFAULT.md
+    - name: ComponentRunRequest
+      href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.md
+      items:
+      - name: Constructors
+      - name: ComponentRunRequest
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.-ctor.md
+      - name: Properties
+      - name: InputValues
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.InputValues.md
+      - name: Methods
+      - name: CreateCloneFrom
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.CreateCloneFrom.md
+      - name: CreateFromConfigDefaults
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.CreateFromConfigDefaults.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.Dispose.md
+      - name: MoveStateFrom
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunRequest.MoveStateFrom.md
+    - name: ComponentRunResults
+      href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.md
+      items:
+      - name: Properties
+      - name: ResultMetadata
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.ResultMetadata.md
+      - name: ResultValues
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.ResultValues.md
+      - name: Methods
+      - name: CreateCanceled
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.CreateCanceled.md
+      - name: CreateCloneFrom
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.CreateCloneFrom.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.Dispose.md
+      - name: MoveResultsTo
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.MoveResultsTo.md
+      - name: MoveStateFrom
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResults.MoveStateFrom.md
+    - name: DebugDataKeyConstants
+      href: apidocs/Phoenix.ComponentAPI.DebugDataKeyConstants.md
+      items:
+      - name: Fields
+      - name: EXTRACT_DIR_KEY
+        href: apidocs/Phoenix.ComponentAPI.DebugDataKeyConstants.EXTRACT_DIR_KEY.md
+      - name: HOST_KEY
+        href: apidocs/Phoenix.ComponentAPI.DebugDataKeyConstants.HOST_KEY.md
+      - name: RUN_DIR_KEY
+        href: apidocs/Phoenix.ComponentAPI.DebugDataKeyConstants.RUN_DIR_KEY.md
+      - name: Methods
+      - name: DisplayNameForDebugDataKey
+        href: apidocs/Phoenix.ComponentAPI.DebugDataKeyConstants.DisplayNameForDebugDataKey.md
+    - name: LicenseException
+      href: apidocs/Phoenix.ComponentAPI.LicenseException.md
+      items:
+      - name: Constructors
+      - name: LicenseException
+        href: apidocs/Phoenix.ComponentAPI.LicenseException.-ctor.md
+    - name: Structs
+    - name: ComponentRunResultsMetadata
+      href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.md
+      items:
+      - name: Constructors
+      - name: ComponentRunResultsMetadata
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.-ctor.md
+      - name: Properties
+      - name: Error
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.Error.md
+      - name: ResultStatus
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.ResultStatus.md
+      - name: Methods
+      - name: IsValidStatus
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.IsValidStatus.md
+      - name: RequireValidStatus
+        href: apidocs/Phoenix.ComponentAPI.ComponentRunResultsMetadata.RequireValidStatus.md
+    - name: Interfaces
+    - name: IExecutionInstance
+      href: apidocs/Phoenix.ComponentAPI.IExecutionInstance.md
+      items:
+      - name: Methods
+      - name: ExecuteAsync
+        href: apidocs/Phoenix.ComponentAPI.IExecutionInstance.ExecuteAsync.md
+      - name: GetProcessesAsync
+        href: apidocs/Phoenix.ComponentAPI.IExecutionInstance.GetProcessesAsync.md
+      - name: Events
+      - name: DebugDataUpdated
+        href: apidocs/Phoenix.ComponentAPI.IExecutionInstance.DebugDataUpdated.md
+    - name: IHarnessBuilderUIClient
+      href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUIClient.md
+      items:
+      - name: Methods
+      - name: CreateNewComponentAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUIClient.CreateNewComponentAsync.md
+      - name: OpenBuilderUIForComponentAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUIClient.OpenBuilderUIForComponentAsync.md
+      - name: OpenLocalEditSessionForComponentAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUIClient.OpenLocalEditSessionForComponentAsync.md
+    - name: IHarnessBuilderUISession
+      href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.md
+      items:
+      - name: Properties
+      - name: Runner
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.Runner.md
+      - name: Methods
+      - name: ShowAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.ShowAsync.md
+      - name: TrySaveAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.TrySaveAsync.md
+      - name: Events
+      - name: ComponentChanged
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.ComponentChanged.md
+      - name: TestRunRequested
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.TestRunRequested.md
+      - name: WindowClosed
+        href: apidocs/Phoenix.ComponentAPI.IHarnessBuilderUISession.WindowClosed.md
+    - name: IHarnessLocalEditSession
+      href: apidocs/Phoenix.ComponentAPI.IHarnessLocalEditSession.md
+      items:
+      - name: Properties
+      - name: Pacz
+        href: apidocs/Phoenix.ComponentAPI.IHarnessLocalEditSession.Pacz.md
+      - name: Methods
+      - name: CancelChangesAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessLocalEditSession.CancelChangesAsync.md
+      - name: CommitChangesAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessLocalEditSession.CommitChangesAsync.md
+    - name: IHarnessRunner
+      href: apidocs/Phoenix.ComponentAPI.IHarnessRunner.md
+      items:
+      - name: Methods
+      - name: ConstructAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunner.ConstructAsync.md
+      - name: RunAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunner.RunAsync.md
+    - name: IHarnessRunnerClient
+      href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerClient.md
+      items:
+      - name: Methods
+      - name: InitializeAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerClient.InitializeAsync.md
+      - name: StartSessionForLocalExtractedPaczAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerClient.StartSessionForLocalExtractedPaczAsync.md
+      - name: StartSessionForLocalPaczAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerClient.StartSessionForLocalPaczAsync.md
+    - name: IHarnessRunnerHost
+      href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.md
+      items:
+      - name: Properties
+      - name: ComponentDirectory
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.ComponentDirectory.md
+      - name: ExtractedPacz
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.ExtractedPacz.md
+      - name: Logger
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.Logger.md
+      - name: Metadata
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.Metadata.md
+      - name: RunDirectory
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.RunDirectory.md
+      - name: Methods
+      - name: UpdateDebugData
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerHost.UpdateDebugData.md
+    - name: IHarnessRunnerReloadable
+      href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerReloadable.md
+      items:
+      - name: Methods
+      - name: PaczUpdated
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerReloadable.PaczUpdated.md
+    - name: IHarnessRunnerSession
+      href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerSession.md
+      items:
+      - name: Properties
+      - name: PlugInInstance
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerSession.PlugInInstance.md
+      - name: Methods
+      - name: CreateExecutionInstance
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerSession.CreateExecutionInstance.md
+      - name: GetPaczAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerSession.GetPaczAsync.md
+      - name: SetMetadataAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessRunnerSession.SetMetadataAsync.md
+    - name: IHarnessSaveOperations
+      href: apidocs/Phoenix.ComponentAPI.IHarnessSaveOperations.md
+      items:
+      - name: Methods
+      - name: SaveAsLocalFilesAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessSaveOperations.SaveAsLocalFilesAsync.md
+      - name: SaveAsLocalPaczAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessSaveOperations.SaveAsLocalPaczAsync.md
+      - name: SaveAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessSaveOperations.SaveAsync.md
+      - name: UpdateSourceAsync
+        href: apidocs/Phoenix.ComponentAPI.IHarnessSaveOperations.UpdateSourceAsync.md
+    - name: ILicenseFeature
+      href: apidocs/Phoenix.ComponentAPI.ILicenseFeature.md
+      items:
+      - name: Methods
+      - name: CheckInAsync
+        href: apidocs/Phoenix.ComponentAPI.ILicenseFeature.CheckInAsync.md
+    - name: ILicenseProvider
+      href: apidocs/Phoenix.ComponentAPI.ILicenseProvider.md
+      items:
+      - name: Methods
+      - name: CheckOutAsync
+        href: apidocs/Phoenix.ComponentAPI.ILicenseProvider.CheckOutAsync.md
+    - name: IProcessInfo
+      href: apidocs/Phoenix.ComponentAPI.IProcessInfo.md
+    - name: IRunnerSessionOptions
+      href: apidocs/Phoenix.ComponentAPI.IRunnerSessionOptions.md
+    - name: Enums
+    - name: RunStatus
+      href: apidocs/Phoenix.ComponentAPI.RunStatus.md
+  - name: Phoenix.ComponentBuilderAPI
+    href: apidocs/Phoenix.ComponentBuilderAPI.md
+    items:
+    - name: Interfaces
+    - name: IHarnessBuilderUI<RUNNER>
+      href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUI-1.md
+      items:
+      - name: Methods
+      - name: ConstructAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUI-1.ConstructAsync.md
+    - name: IHarnessBuilderUIBase
+      href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIBase.md
+      items:
+      - name: Properties
+      - name: HarnessType
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIBase.HarnessType.md
+      - name: Methods
+      - name: ShowAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIBase.ShowAsync.md
+      - name: TrySaveAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIBase.TrySaveAsync.md
+      - name: Events
+      - name: WindowClosed
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIBase.WindowClosed.md
+    - name: IHarnessBuilderUIHost<RUNNER>
+      href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.md
+      items:
+      - name: Properties
+      - name: ExtractedPacz
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.ExtractedPacz.md
+      - name: Logger
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.Logger.md
+      - name: Methods
+      - name: CallRunnerAsync<T>
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.CallRunnerAsync.md
+      - name: RaiseTestRunEvent
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.RaiseTestRunEvent.md
+      - name: SaveAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.IHarnessBuilderUIHost-1.SaveAsync.md
+  - name: Phoenix.ComponentBuilderAPI.Extensions
+    href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.md
+    items:
+    - name: Classes
+    - name: PaczIconExtensions
+      href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PaczIconExtensions.md
+      items:
+      - name: Methods
+      - name: GetIconBitmapAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PaczIconExtensions.GetIconBitmapAsync.md
+      - name: GetIconImageSourceAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PaczIconExtensions.GetIconImageSourceAsync.md
+    - name: PaczIconExtensions.PaczIconLoadingFailedException
+      href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PaczIconExtensions.PaczIconLoadingFailedException.md
+      items:
+      - name: Constructors
+      - name: PaczIconLoadingFailedException
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PaczIconExtensions.PaczIconLoadingFailedException.-ctor.md
+    - name: PlugInIconExtensions
+      href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PlugInIconExtensions.md
+      items:
+      - name: Methods
+      - name: GetDefaultPlugInBitmap
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PlugInIconExtensions.GetDefaultPlugInBitmap.md
+      - name: GetPlugInIconImageSourceOrDefaultAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PlugInIconExtensions.GetPlugInIconImageSourceOrDefaultAsync.md
+      - name: GetPlugInIconOrDefaultAsync
+        href: apidocs/Phoenix.ComponentBuilderAPI.Extensions.PlugInIconExtensions.GetPlugInIconOrDefaultAsync.md
+  - name: Phoenix.ComponentClient
+    href: apidocs/Phoenix.ComponentClient.md
+    items:
+    - name: Classes
+    - name: ClientFactory
+      href: apidocs/Phoenix.ComponentClient.ClientFactory.md
+      items:
+      - name: Methods
+      - name: ConfigureServiceCollection
+        href: apidocs/Phoenix.ComponentClient.ClientFactory.ConfigureServiceCollection.md
+      - name: ConfigureWithDefaultRepositories
+        href: apidocs/Phoenix.ComponentClient.ClientFactory.ConfigureWithDefaultRepositories.md
+      - name: GetClient
+        href: apidocs/Phoenix.ComponentClient.ClientFactory.GetClient.md
+    - name: OnFileDeleteFailureLogger
+      href: apidocs/Phoenix.ComponentClient.OnFileDeleteFailureLogger.md
+      items:
+      - name: Constructors
+      - name: OnFileDeleteFailureLogger
+        href: apidocs/Phoenix.ComponentClient.OnFileDeleteFailureLogger.-ctor.md
+      - name: Methods
+      - name: ConfigureServiceCollection
+        href: apidocs/Phoenix.ComponentClient.OnFileDeleteFailureLogger.ConfigureServiceCollection.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentClient.OnFileDeleteFailureLogger.Dispose.md
+  - name: Phoenix.ComponentClient.Impl
+    href: apidocs/Phoenix.ComponentClient.Impl.md
+    items:
+    - name: Classes
+    - name: NullLicenseProvider
+      href: apidocs/Phoenix.ComponentClient.Impl.NullLicenseProvider.md
+      items:
+      - name: Methods
+      - name: CheckOutAsync
+        href: apidocs/Phoenix.ComponentClient.Impl.NullLicenseProvider.CheckOutAsync.md
+  - name: Phoenix.ComponentPlugInSDK
+    href: apidocs/Phoenix.ComponentPlugInSDK.md
+    items:
+    - name: Classes
+    - name: AbstractBuilderUI<RUNNER>
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.md
+      items:
+      - name: Fields
+      - name: _window
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1._window.md
+      - name: Properties
+      - name: ComponentIcon
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.ComponentIcon.md
+      - name: ComponentName
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.ComponentName.md
+      - name: HarnessType
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.HarnessType.md
+      - name: Host
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.Host.md
+      - name: Methods
+      - name: AddAsyncMenuItem
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.AddAsyncMenuItem.md
+      - name: AddMenuItem
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.AddMenuItem.md
+      - name: ConstructAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.ConstructAsync.md
+      - name: CreateWindow
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.CreateWindow.md
+      - name: DisplayException
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.DisplayException.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.Dispose.md
+      - name: SelectVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.SelectVariables.md
+      - name: SetPaczIcon
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.SetPaczIcon.md
+      - name: ShowAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.ShowAsync.md
+      - name: TrySaveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.TrySaveAsync.md
+      - name: Events
+      - name: WindowClosed
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.WindowClosed.md
+    - name: AbstractModelBasedBuilderUI<RUNNER, MODEL>
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.md
+      items:
+      - name: Properties
+      - name: Model
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.Model.md
+      - name: Methods
+      - name: ConstructAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.ConstructAsync.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.Dispose.md
+      - name: LoadFromPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.LoadFromPaczAsync.md
+      - name: SaveToPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2.SaveToPaczAsync.md
+      - name: _saveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractModelBasedBuilderUI-2._saveAsync.md
+    - name: AbstractScriptBasedBuilderUI<RUNNER, MODEL>
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.md
+      items:
+      - name: Properties
+      - name: ComponentIcon
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.ComponentIcon.md
+      - name: ComponentName
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.ComponentName.md
+      - name: ScriptLanguage
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.ScriptLanguage.md
+      - name: Methods
+      - name: CreateWindow
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.CreateWindow.md
+      - name: GetTreeProperties
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.GetTreeProperties.md
+      - name: SetupView
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractScriptBasedBuilderUI-2.SetupView.md
+    - name: AbstractVariableBasedBuilderUI<RUNNER, MODEL>
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-2.md
+      items:
+      - name: Methods
+      - name: CreateWindow
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-2.CreateWindow.md
+      - name: GetFileLoadProperties
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-2.GetFileLoadProperties.md
+      - name: GetTreeProperties
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-2.GetTreeProperties.md
+      - name: SetupView
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-2.SetupView.md
+    - name: AbstractVariableBasedBuilderUI<RUNNER>
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableBasedBuilderUI-1.md
+    - name: AbstractVariableProvider
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.md
+      items:
+      - name: Properties
+      - name: Blacklist
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.Blacklist.md
+      - name: NameSubstitutions
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.NameSubstitutions.md
+      - name: SupportsUserVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.SupportsUserVariables.md
+      - name: Methods
+      - name: GetSubGroups
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.GetSubGroups.md
+      - name: GetSubVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.GetSubVariables.md
+      - name: ListVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.AbstractVariableProvider.ListVariables.md
+    - name: PHXLoggerToILogger
+      href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.md
+      items:
+      - name: Constructors
+      - name: PHXLoggerToILogger
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.-ctor.md
+      - name: Properties
+      - name: IsDebugEnabled
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.IsDebugEnabled.md
+      - name: IsErrorEnabled
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.IsErrorEnabled.md
+      - name: IsInfoEnabled
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.IsInfoEnabled.md
+      - name: IsTraceEnabled
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.IsTraceEnabled.md
+      - name: IsWarnEnabled
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.IsWarnEnabled.md
+      - name: Methods
+      - name: Debug
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.Debug.md
+      - name: Error
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.Error.md
+      - name: Info
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.Info.md
+      - name: Trace
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.Trace.md
+      - name: Warn
+        href: apidocs/Phoenix.ComponentPlugInSDK.PHXLoggerToILogger.Warn.md
+    - name: Delegates
+    - name: AbstractBuilderUI<RUNNER>.RoutedEventHandlerAsync
+      href: apidocs/Phoenix.ComponentPlugInSDK.AbstractBuilderUI-1.RoutedEventHandlerAsync.md
+  - name: Phoenix.ComponentPlugInSDK.Images
+    href: apidocs/Phoenix.ComponentPlugInSDK.Images.md
+    items:
+    - name: Classes
+    - name: ImageFactory
+      href: apidocs/Phoenix.ComponentPlugInSDK.Images.ImageFactory.md
+      items:
+      - name: Methods
+      - name: GetImage
+        href: apidocs/Phoenix.ComponentPlugInSDK.Images.ImageFactory.GetImage.md
+    - name: Enums
+    - name: ImageType
+      href: apidocs/Phoenix.ComponentPlugInSDK.Images.ImageType.md
+  - name: Phoenix.ComponentPlugInSDK.Models
+    href: apidocs/Phoenix.ComponentPlugInSDK.Models.md
+    items:
+    - name: Classes
+    - name: AbstractBuilderModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.md
+      items:
+      - name: Constructors
+      - name: AbstractBuilderModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.-ctor.md
+      - name: Properties
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.ExternalMetadata.md
+      - name: InputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.InputVariables.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.IsReadOnly.md
+      - name: OutputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.OutputVariables.md
+      - name: Methods
+      - name: CloneInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.CloneInputVariablesFrom.md
+      - name: CloneOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.CloneOutputVariablesFrom.md
+      - name: Dispose
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.Dispose.md
+      - name: FromPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.FromPaczAsync.md
+      - name: GetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.GetVariablesAsPHXVariable.md
+      - name: MoveInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.MoveInputVariablesFrom.md
+      - name: MoveOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.MoveOutputVariablesFrom.md
+      - name: PHXVariableToRuntimeVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.PHXVariableToRuntimeVariable.md
+      - name: PHXVariablesToRuntimeVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.PHXVariablesToRuntimeVariables.md
+      - name: RuntimeVariableToPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.RuntimeVariableToPHXVariable.md
+      - name: RuntimeVariablesToPHXVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.RuntimeVariablesToPHXVariables.md
+      - name: SetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.SetVariablesAsPHXVariable.md
+      - name: ToPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractBuilderModel.ToPaczAsync.md
+    - name: AbstractScriptLanguage
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.md
+      items:
+      - name: Properties
+      - name: DefaultText
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.DefaultText.md
+      - name: DisplayName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.DisplayName.md
+      - name: FilenameBase
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.FilenameBase.md
+      - name: FilenameExtension
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.FilenameExtension.md
+      - name: NamedVariableDisplayName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.NamedVariableDisplayName.md
+      - name: NamedVariableToken
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.NamedVariableToken.md
+      - name: SyntaxName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.SyntaxName.md
+      - name: UsesNamedVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.UsesNamedVariable.md
+      - name: Methods
+      - name: GetHighlightNames
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.GetHighlightNames.md
+      - name: GetScriptFilename
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.AbstractScriptLanguage.GetScriptFilename.md
+    - name: FileLoadProperties
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.FileLoadProperties.md
+      items:
+      - name: Constructors
+      - name: FileLoadProperties
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.FileLoadProperties.-ctor.md
+      - name: Properties
+      - name: FileFilter
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.FileLoadProperties.FileFilter.md
+      - name: FileLoadAction
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.FileLoadProperties.FileLoadAction.md
+    - name: ScriptModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.md
+      items:
+      - name: Constructors
+      - name: ScriptModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.-ctor.md
+      - name: Properties
+      - name: BodyText
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.BodyText.md
+      - name: ScriptLanguage
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.ScriptLanguage.md
+      - name: Timeout
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.Timeout.md
+      - name: Methods
+      - name: FromPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.FromPaczAsync.md
+      - name: ToPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel.ToPaczAsync.md
+    - name: ScriptModel<LANGUAGE>
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel-1.md
+      items:
+      - name: Properties
+      - name: ScriptLanguage
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.ScriptModel-1.ScriptLanguage.md
+    - name: VariableBasedBuilderModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.md
+      items:
+      - name: Fields
+      - name: FILEPATH_PROPERTYKEY
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.FILEPATH_PROPERTYKEY.md
+      - name: Properties
+      - name: ExtractionFolder
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.ExtractionFolder.md
+      - name: FilePath
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.FilePath.md
+      - name: FilePathAbsolute
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.FilePathAbsolute.md
+      - name: Methods
+      - name: FromPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.FromPaczAsync.md
+      - name: ToPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableBasedBuilderModel.ToPaczAsync.md
+    - name: VariableEditorModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.md
+      items:
+      - name: Constructors
+      - name: VariableEditorModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.-ctor.md
+      - name: Fields
+      - name: groupLineStart
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.groupLineStart.md
+      - name: variableLineStart
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.variableLineStart.md
+      - name: Properties
+      - name: VariableValueScope
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.VariableValueScope.md
+      - name: Variables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.Variables.md
+      - name: Methods
+      - name: FromString
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.FromString.md
+      - name: ToString
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.ToString.md
+    - name: VariableEditorModel.SyntaxError
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.SyntaxError.md
+      items:
+      - name: Constructors
+      - name: SyntaxError
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableEditorModel.SyntaxError.-ctor.md
+    - name: VariableTreeProperties
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.md
+      items:
+      - name: Constructors
+      - name: VariableTreeProperties
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.-ctor.md
+      - name: Properties
+      - name: CanAddRemove
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.CanAddRemove.md
+      - name: ComponentName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.ComponentName.md
+      - name: HasNamedVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.HasNamedVariables.md
+      - name: NamedVariableDisplayName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.NamedVariableDisplayName.md
+      - name: NamedVariablePickAction
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.NamedVariablePickAction.md
+      - name: NamedVariablePickText
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.NamedVariablePickText.md
+      - name: NamedVariableToken
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.VariableTreeProperties.NamedVariableToken.md
+    - name: Interfaces
+    - name: IBuilderUIModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.md
+      items:
+      - name: Properties
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.ExternalMetadata.md
+      - name: InputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.InputVariables.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.IsReadOnly.md
+      - name: OutputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.OutputVariables.md
+      - name: Methods
+      - name: CloneInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.CloneInputVariablesFrom.md
+      - name: CloneOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.CloneOutputVariablesFrom.md
+      - name: FromPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.FromPaczAsync.md
+      - name: GetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.GetVariablesAsPHXVariable.md
+      - name: MoveInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.MoveInputVariablesFrom.md
+      - name: MoveOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.MoveOutputVariablesFrom.md
+      - name: SetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.SetVariablesAsPHXVariable.md
+      - name: ToPaczAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IBuilderUIModel.ToPaczAsync.md
+    - name: IScriptLanguage
+      href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.md
+      items:
+      - name: Properties
+      - name: DefaultText
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.DefaultText.md
+      - name: DisplayName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.DisplayName.md
+      - name: FilenameExtension
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.FilenameExtension.md
+      - name: NamedVariableDisplayName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.NamedVariableDisplayName.md
+      - name: NamedVariableToken
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.NamedVariableToken.md
+      - name: SyntaxName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.SyntaxName.md
+      - name: UsesNamedVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.UsesNamedVariable.md
+      - name: Methods
+      - name: GetHighlightNames
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.GetHighlightNames.md
+      - name: GetScriptFilename
+        href: apidocs/Phoenix.ComponentPlugInSDK.Models.IScriptLanguage.GetScriptFilename.md
+  - name: Phoenix.ComponentPlugInSDK.Properties
+    href: apidocs/Phoenix.ComponentPlugInSDK.Properties.md
+    items:
+    - name: Classes
+    - name: Resources
+      href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.md
+      items:
+      - name: Properties
+      - name: Culture
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.Culture.md
+      - name: DefaultComponentName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.DefaultComponentName.md
+      - name: DefaultValueForFileVariablesNotSupported
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.DefaultValueForFileVariablesNotSupported.md
+      - name: ErrorInvalidVariableProperty
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ErrorInvalidVariableProperty.md
+      - name: ErrorNoFileOpenFunction
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ErrorNoFileOpenFunction.md
+      - name: ErrorOccurred
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ErrorOccurred.md
+      - name: ErrorOpeningFileFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ErrorOpeningFileFmt.md
+      - name: ErrorTitleFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ErrorTitleFmt.md
+      - name: Error_Invalid_Script
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.Error_Invalid_Script.md
+      - name: ExpectedAssignment
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedAssignment.md
+      - name: ExpectedColon
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedColon.md
+      - name: ExpectedGroupName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedGroupName.md
+      - name: ExpectedValueForMetaDataFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedValueForMetaDataFmt.md
+      - name: ExpectedVariableIOState
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedVariableIOState.md
+      - name: ExpectedVariableName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedVariableName.md
+      - name: ExpectedVariableType
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ExpectedVariableType.md
+      - name: FailedParseFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.FailedParseFmt.md
+      - name: InvalidEscapeSequence
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidEscapeSequence.md
+      - name: InvalidGroupName
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidGroupName.md
+      - name: InvalidTimeoutValue
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidTimeoutValue.md
+      - name: InvalidU4EscapeSequence
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidU4EscapeSequence.md
+      - name: InvalidU8EscapeSequence
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidU8EscapeSequence.md
+      - name: InvalidUserDataLabelFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidUserDataLabelFmt.md
+      - name: InvalidXEscapeSequence
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.InvalidXEscapeSequence.md
+      - name: JScript_Description
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.JScript_Description.md
+      - name: ResourceManager
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ResourceManager.md
+      - name: ScriptEditorTitle
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.ScriptEditorTitle.md
+      - name: SyntaxErrorFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.SyntaxErrorFmt.md
+      - name: UnableToUpdateHighlightingFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnableToUpdateHighlightingFmt.md
+      - name: UnknownEscapeSequenceCharFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnknownEscapeSequenceCharFmt.md
+      - name: UnrecognizedUnexpectedTokenFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnrecognizedUnexpectedTokenFmt.md
+      - name: UnrecognizedUnsupportedMetadataFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnrecognizedUnsupportedMetadataFmt.md
+      - name: UnsavedMessage
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnsavedMessage.md
+      - name: UnsavedTitle
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.UnsavedTitle.md
+      - name: VBScript_Description
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.VBScript_Description.md
+      - name: VariableEditorTitle
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.VariableEditorTitle.md
+      - name: VariableTypeNotSupportedFmt
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.VariableTypeNotSupportedFmt.md
+      - name: Window_is_not_ISaveable
+        href: apidocs/Phoenix.ComponentPlugInSDK.Properties.Resources.Window_is_not_ISaveable.md
+  - name: Phoenix.ComponentPlugInSDK.ViewModels
+    href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.md
+    items:
+    - name: Classes
+    - name: AbstractPlugInViewModel<MODEL_TYPE>
+      href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.md
+      items:
+      - name: Constructors
+      - name: AbstractPlugInViewModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.-ctor.md
+      - name: Fields
+      - name: _logger
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1._logger.md
+      - name: _showErrorAction
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1._showErrorAction.md
+      - name: Properties
+      - name: BuilderName
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.BuilderName.md
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.ExternalMetadata.md
+      - name: HasStatus
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.HasStatus.md
+      - name: InputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.InputVariables.md
+      - name: IsBusy
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.IsBusy.md
+      - name: IsDirty
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.IsDirty.md
+      - name: IsNotReadOnly
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.IsNotReadOnly.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.IsReadOnly.md
+      - name: OkCommand
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.OkCommand.md
+      - name: OutputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.OutputVariables.md
+      - name: SaveCommand
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.SaveCommand.md
+      - name: StatusColor
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.StatusColor.md
+      - name: StatusMessage
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.StatusMessage.md
+      - name: WindowIcon
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.WindowIcon.md
+      - name: WindowTitle
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.WindowTitle.md
+      - name: Methods
+      - name: CloneInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.CloneInputVariablesFrom.md
+      - name: CloneOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.CloneOutputVariablesFrom.md
+      - name: GetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.GetVariablesAsPHXVariable.md
+      - name: MoveInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.MoveInputVariablesFrom.md
+      - name: MoveOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.MoveOutputVariablesFrom.md
+      - name: OnPropertyChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.OnPropertyChanged.md
+      - name: SaveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.SaveAsync.md
+      - name: SetStatus
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.SetStatus.md
+      - name: SetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.SetVariablesAsPHXVariable.md
+      - name: _handleError
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1._handleError.md
+      - name: _onInputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1._onInputsChanged.md
+      - name: _onOutputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1._onOutputsChanged.md
+      - name: Events
+      - name: PropertyChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.AbstractPlugInViewModel-1.PropertyChanged.md
+    - name: ScriptEditorViewModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.md
+      items:
+      - name: Constructors
+      - name: ScriptEditorViewModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.-ctor.md
+      - name: Fields
+      - name: CUSTOM_OBJECT_RULE_NAME
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.CUSTOM_OBJECT_RULE_NAME.md
+      - name: CUSTOM_VARIABLE_RULE_NAME
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.CUSTOM_VARIABLE_RULE_NAME.md
+      - name: Properties
+      - name: Script
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.Script.md
+      - name: ScriptDocument
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.ScriptDocument.md
+      - name: ScriptText
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.ScriptText.md
+      - name: SyntaxHighlighting
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.SyntaxHighlighting.md
+      - name: Timeout
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel.Timeout.md
+      - name: Methods
+      - name: _onInputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel._onInputsChanged.md
+      - name: _onOutputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.ScriptEditorViewModel._onOutputsChanged.md
+    - name: VariableBasedBuilderViewModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.md
+      items:
+      - name: Constructors
+      - name: VariableBasedBuilderViewModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.-ctor.md
+      - name: Properties
+      - name: ExtractionFolder
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.ExtractionFolder.md
+      - name: FilePath
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.FilePath.md
+      - name: FilePathAbsolute
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.FilePathAbsolute.md
+      - name: FileSelectionHeader
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.FileSelectionHeader.md
+      - name: OpenFileCommand
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel.OpenFileCommand.md
+      - name: Methods
+      - name: _onInputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel._onInputsChanged.md
+      - name: _onOutputsChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.VariableBasedBuilderViewModel._onOutputsChanged.md
+    - name: Interfaces
+    - name: IPlugInViewModel
+      href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.md
+      items:
+      - name: Properties
+      - name: BuilderName
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.BuilderName.md
+      - name: InputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.InputVariables.md
+      - name: IsBusy
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.IsBusy.md
+      - name: IsDirty
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.IsDirty.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.IsReadOnly.md
+      - name: OkCommand
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.OkCommand.md
+      - name: OutputVariables
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.OutputVariables.md
+      - name: SaveCommand
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.SaveCommand.md
+      - name: WindowIcon
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.WindowIcon.md
+      - name: WindowTitle
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.WindowTitle.md
+      - name: Methods
+      - name: CloneInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.CloneInputVariablesFrom.md
+      - name: CloneOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.CloneOutputVariablesFrom.md
+      - name: GetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.GetVariablesAsPHXVariable.md
+      - name: MoveInputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.MoveInputVariablesFrom.md
+      - name: MoveOutputVariablesFrom
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.MoveOutputVariablesFrom.md
+      - name: SaveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.SaveAsync.md
+      - name: SetVariablesAsPHXVariable
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.SetVariablesAsPHXVariable.md
+      - name: Events
+      - name: PropertyChanged
+        href: apidocs/Phoenix.ComponentPlugInSDK.ViewModels.IPlugInViewModel.PropertyChanged.md
+  - name: Phoenix.ComponentPlugInSDK.Views
+    href: apidocs/Phoenix.ComponentPlugInSDK.Views.md
+    items:
+    - name: Classes
+    - name: AbstractPlugInWindow
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow.md
+      items:
+      - name: Constructors
+      - name: AbstractPlugInWindow
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow.-ctor.md
+      - name: Fields
+      - name: _forceClose
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._forceClose.md
+      - name: _logger
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._logger.md
+      - name: _variableScope
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._variableScope.md
+      - name: Properties
+      - name: _cancelButton
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._cancelButton.md
+      - name: _editVariablesButton
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._editVariablesButton.md
+      - name: _treeControl
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._treeControl.md
+      - name: _treeControlHost
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._treeControlHost.md
+      - name: Methods
+      - name: EditVariablesButton_Click
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow.EditVariablesButton_Click.md
+      - name: TreeCtrlHost_GotKeyboardFocus
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow.TreeCtrlHost_GotKeyboardFocus.md
+      - name: TrySaveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow.TrySaveAsync.md
+      - name: _programmaticClose
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._programmaticClose.md
+      - name: _showErrorDialog
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._showErrorDialog.md
+      - name: _updateAbstractWindow
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.AbstractPlugInWindow._updateAbstractWindow.md
+    - name: ScriptEditorView
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView.md
+      items:
+      - name: Constructors
+      - name: ScriptEditorView
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView.-ctor.md
+      - name: Properties
+      - name: _cancelButton
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView._cancelButton.md
+      - name: _editVariablesButton
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView._editVariablesButton.md
+      - name: _treeControl
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView._treeControl.md
+      - name: _treeControlHost
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView._treeControlHost.md
+    - name: ScriptEditorView.ScriptChangedEventArgs
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView.ScriptChangedEventArgs.md
+      items:
+      - name: Constructors
+      - name: ScriptChangedEventArgs
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView.ScriptChangedEventArgs.-ctor.md
+      - name: Properties
+      - name: ScriptModel
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ScriptEditorView.ScriptChangedEventArgs.ScriptModel.md
+    - name: VariableBasedBuilderView
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableBasedBuilderView.md
+      items:
+      - name: Constructors
+      - name: VariableBasedBuilderView
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableBasedBuilderView.-ctor.md
+      - name: Properties
+      - name: _editVariablesButton
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableBasedBuilderView._editVariablesButton.md
+      - name: _treeControl
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableBasedBuilderView._treeControl.md
+      - name: _treeControlHost
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableBasedBuilderView._treeControlHost.md
+    - name: VariableEditorView
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableEditorView.md
+      items:
+      - name: Constructors
+      - name: VariableEditorView
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.VariableEditorView.-ctor.md
+    - name: Interfaces
+    - name: ISaveableWindow
+      href: apidocs/Phoenix.ComponentPlugInSDK.Views.ISaveableWindow.md
+      items:
+      - name: Methods
+      - name: TrySaveAsync
+        href: apidocs/Phoenix.ComponentPlugInSDK.Views.ISaveableWindow.TrySaveAsync.md
+  - name: Phoenix.Pacz
+    href: apidocs/Phoenix.Pacz.md
+    items:
+    - name: Classes
+    - name: Compatibility
+      href: apidocs/Phoenix.Pacz.Compatibility.md
+      items:
+      - name: Properties
+      - name: ErrorOnLoad
+        href: apidocs/Phoenix.Pacz.Compatibility.ErrorOnLoad.md
+      - name: MajorVersion
+        href: apidocs/Phoenix.Pacz.Compatibility.MajorVersion.md
+      - name: Message
+        href: apidocs/Phoenix.Pacz.Compatibility.Message.md
+      - name: MinorVersion
+        href: apidocs/Phoenix.Pacz.Compatibility.MinorVersion.md
+      - name: VersionLessThan
+        href: apidocs/Phoenix.Pacz.Compatibility.VersionLessThan.md
+    - name: ComponentConfig
+      href: apidocs/Phoenix.Pacz.ComponentConfig.md
+      items:
+      - name: Constructors
+      - name: ComponentConfig
+        href: apidocs/Phoenix.Pacz.ComponentConfig.-ctor.md
+      - name: Properties
+      - name: ASComponent
+        href: apidocs/Phoenix.Pacz.ComponentConfig.ASComponent.md
+      - name: Author
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Author.md
+      - name: Compatibilities
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Compatibilities.md
+      - name: Description
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Description.md
+      - name: ExternalFiles
+        href: apidocs/Phoenix.Pacz.ComponentConfig.ExternalFiles.md
+      - name: HelpUrl
+        href: apidocs/Phoenix.Pacz.ComponentConfig.HelpUrl.md
+      - name: Icon
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Icon.md
+      - name: Inputs
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Inputs.md
+      - name: InstanceFiles
+        href: apidocs/Phoenix.Pacz.ComponentConfig.InstanceFiles.md
+      - name: Outputs
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Outputs.md
+      - name: PlugInId
+        href: apidocs/Phoenix.Pacz.ComponentConfig.PlugInId.md
+      - name: Properties
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Properties.md
+      - name: RequiredFeatures
+        href: apidocs/Phoenix.Pacz.ComponentConfig.RequiredFeatures.md
+      - name: RunFolderPreference
+        href: apidocs/Phoenix.Pacz.ComponentConfig.RunFolderPreference.md
+      - name: Version
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Version.md
+      - name: Methods
+      - name: AsReadOnly
+        href: apidocs/Phoenix.Pacz.ComponentConfig.AsReadOnly.md
+      - name: CloneInputsFrom
+        href: apidocs/Phoenix.Pacz.ComponentConfig.CloneInputsFrom.md
+      - name: CloneOutputsFrom
+        href: apidocs/Phoenix.Pacz.ComponentConfig.CloneOutputsFrom.md
+      - name: Dispose
+        href: apidocs/Phoenix.Pacz.ComponentConfig.Dispose.md
+      - name: FromJson
+        href: apidocs/Phoenix.Pacz.ComponentConfig.FromJson.md
+      - name: MoveInputsFrom
+        href: apidocs/Phoenix.Pacz.ComponentConfig.MoveInputsFrom.md
+      - name: MoveOutputsFrom
+        href: apidocs/Phoenix.Pacz.ComponentConfig.MoveOutputsFrom.md
+      - name: ToJson
+        href: apidocs/Phoenix.Pacz.ComponentConfig.ToJson.md
+    - name: DefaultExternalMetadata
+      href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.md
+      items:
+      - name: Constructors
+      - name: DefaultExternalMetadata
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.-ctor.md
+      - name: Fields
+      - name: METADATA_FILE_NAME
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.METADATA_FILE_NAME.md
+      - name: _metadata
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata._metadata.md
+      - name: Properties
+      - name: IsReadOnly
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.IsReadOnly.md
+      - name: Metadata
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.Metadata.md
+      - name: Name
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.Name.md
+      - name: ReadOnlyReason
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.ReadOnlyReason.md
+      - name: SourceUri
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.SourceUri.md
+      - name: Methods
+      - name: FromString
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.FromString.md
+      - name: GetMetadataValue
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.GetMetadataValue.md
+      - name: ToString
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.ToString.md
+      - name: WriteToFileAsync
+        href: apidocs/Phoenix.Pacz.DefaultExternalMetadata.WriteToFileAsync.md
+    - name: ExternalFile
+      href: apidocs/Phoenix.Pacz.ExternalFile.md
+      items:
+      - name: Constructors
+      - name: ExternalFile
+        href: apidocs/Phoenix.Pacz.ExternalFile.-ctor.md
+      - name: Properties
+      - name: Path
+        href: apidocs/Phoenix.Pacz.ExternalFile.Path.md
+      - name: Methods
+      - name: CompareTo
+        href: apidocs/Phoenix.Pacz.ExternalFile.CompareTo.md
+    - name: IconMissingException
+      href: apidocs/Phoenix.Pacz.IconMissingException.md
+      items:
+      - name: Constructors
+      - name: IconMissingException
+        href: apidocs/Phoenix.Pacz.IconMissingException.-ctor.md
+    - name: InstanceFile
+      href: apidocs/Phoenix.Pacz.InstanceFile.md
+      items:
+      - name: Constructors
+      - name: InstanceFile
+        href: apidocs/Phoenix.Pacz.InstanceFile.-ctor.md
+      - name: Properties
+      - name: PlugInIntegral
+        href: apidocs/Phoenix.Pacz.InstanceFile.PlugInIntegral.md
+      - name: RelativePath
+        href: apidocs/Phoenix.Pacz.InstanceFile.RelativePath.md
+      - name: Methods
+      - name: CompareTo
+        href: apidocs/Phoenix.Pacz.InstanceFile.CompareTo.md
+    - name: PaczFactory
+      href: apidocs/Phoenix.Pacz.PaczFactory.md
+      items:
+      - name: Fields
+      - name: LEGAL_PACJ_FILENAME
+        href: apidocs/Phoenix.Pacz.PaczFactory.LEGAL_PACJ_FILENAME.md
+      - name: PACZ_SCHEMA_VERSION_MAJOR
+        href: apidocs/Phoenix.Pacz.PaczFactory.PACZ_SCHEMA_VERSION_MAJOR.md
+      - name: PACZ_SCHEMA_VERSION_MINOR
+        href: apidocs/Phoenix.Pacz.PaczFactory.PACZ_SCHEMA_VERSION_MINOR.md
+      - name: Methods
+      - name: ConfigureServiceCollection
+        href: apidocs/Phoenix.Pacz.PaczFactory.ConfigureServiceCollection.md
+    - name: RuntimeVariable
+      href: apidocs/Phoenix.Pacz.RuntimeVariable.md
+      items:
+      - name: Constructors
+      - name: RuntimeVariable
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.-ctor.md
+      - name: Properties
+      - name: CustomMetadata
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.CustomMetadata.md
+      - name: DefaultValue
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.DefaultValue.md
+      - name: Metadata
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.Metadata.md
+      - name: Name
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.Name.md
+      - name: Methods
+      - name: CloneDefaultValueFrom
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.CloneDefaultValueFrom.md
+      - name: Dispose
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.Dispose.md
+      - name: MoveDefaultValueFrom
+        href: apidocs/Phoenix.Pacz.RuntimeVariable.MoveDefaultValueFrom.md
+    - name: SchemaCompatibilityException
+      href: apidocs/Phoenix.Pacz.SchemaCompatibilityException.md
+      items:
+      - name: Constructors
+      - name: SchemaCompatibilityException
+        href: apidocs/Phoenix.Pacz.SchemaCompatibilityException.-ctor.md
+    - name: UpdatableSortedSet<T>
+      href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.md
+      items:
+      - name: Constructors
+      - name: UpdatableSortedSet
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.-ctor.md
+      - name: Properties
+      - name: Count
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Count.md
+      - name: IsReadOnly
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IsReadOnly.md
+      - name: Methods
+      - name: Add
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Add.md
+      - name: Clear
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Clear.md
+      - name: Contains
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Contains.md
+      - name: CopyTo
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.CopyTo.md
+      - name: ExceptWith
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.ExceptWith.md
+      - name: GetEnumerator
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.GetEnumerator.md
+      - name: IntersectWith
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IntersectWith.md
+      - name: IsProperSubsetOf
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IsProperSubsetOf.md
+      - name: IsProperSupersetOf
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IsProperSupersetOf.md
+      - name: IsSubsetOf
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IsSubsetOf.md
+      - name: IsSupersetOf
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.IsSupersetOf.md
+      - name: Overlaps
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Overlaps.md
+      - name: Remove
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.Remove.md
+      - name: SetEquals
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.SetEquals.md
+      - name: SymmetricExceptWith
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.SymmetricExceptWith.md
+      - name: UnionWith
+        href: apidocs/Phoenix.Pacz.UpdatableSortedSet-1.UnionWith.md
+  - name: Phoenix.Pacz.Impl
+    href: apidocs/Phoenix.Pacz.Impl.md
+    items:
+    - name: Classes
+    - name: Extensions
+      href: apidocs/Phoenix.Pacz.Impl.Extensions.md
+      items:
+      - name: Methods
+      - name: GetComponentName
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.GetComponentName.md
+      - name: GetPaczName
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.GetPaczName.md
+      - name: GetPaczUploadLocation
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.GetPaczUploadLocation.md
+      - name: IsPaczReadOnly
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.IsPaczReadOnly.md
+      - name: OpenExtractedOrCompressedPaczFileAsync
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.OpenExtractedOrCompressedPaczFileAsync.md
+      - name: PointsToComponentPacj
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.PointsToComponentPacj.md
+      - name: StartSessionForLocalExtractedOrCompressedPaczAsync
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.StartSessionForLocalExtractedOrCompressedPaczAsync.md
+      - name: ToSafeSourceString
+        href: apidocs/Phoenix.Pacz.Impl.Extensions.ToSafeSourceString.md
+    - name: LegacyExternalMetadata
+      href: apidocs/Phoenix.Pacz.Impl.LegacyExternalMetadata.md
+      items:
+      - name: Constructors
+      - name: LegacyExternalMetadata
+        href: apidocs/Phoenix.Pacz.Impl.LegacyExternalMetadata.-ctor.md
+    - name: MinervaExternalMetadata
+      href: apidocs/Phoenix.Pacz.Impl.MinervaExternalMetadata.md
+      items:
+      - name: Constructors
+      - name: MinervaExternalMetadata
+        href: apidocs/Phoenix.Pacz.Impl.MinervaExternalMetadata.-ctor.md
+      - name: Properties
+      - name: Name
+        href: apidocs/Phoenix.Pacz.Impl.MinervaExternalMetadata.Name.md
+  - name: Phoenix.PaczAPI
+    href: apidocs/Phoenix.PaczAPI.md
+    items:
+    - name: Classes
+    - name: CommonProperties
+      href: apidocs/Phoenix.PaczAPI.CommonProperties.md
+      items:
+      - name: Fields
+      - name: AVERAGE_RUNTIME
+        href: apidocs/Phoenix.PaczAPI.CommonProperties.AVERAGE_RUNTIME.md
+      - name: TIMEOUT
+        href: apidocs/Phoenix.PaczAPI.CommonProperties.TIMEOUT.md
+    - name: VariableValueScopeExtensions
+      href: apidocs/Phoenix.PaczAPI.VariableValueScopeExtensions.md
+      items:
+      - name: Methods
+      - name: ClearAndFillFromConfig
+        href: apidocs/Phoenix.PaczAPI.VariableValueScopeExtensions.ClearAndFillFromConfig.md
+      - name: FillFromConfig
+        href: apidocs/Phoenix.PaczAPI.VariableValueScopeExtensions.FillFromConfig.md
+    - name: Interfaces
+    - name: ICompatibility
+      href: apidocs/Phoenix.PaczAPI.ICompatibility.md
+      items:
+      - name: Properties
+      - name: ErrorOnLoad
+        href: apidocs/Phoenix.PaczAPI.ICompatibility.ErrorOnLoad.md
+      - name: MajorVersion
+        href: apidocs/Phoenix.PaczAPI.ICompatibility.MajorVersion.md
+      - name: Message
+        href: apidocs/Phoenix.PaczAPI.ICompatibility.Message.md
+      - name: MinorVersion
+        href: apidocs/Phoenix.PaczAPI.ICompatibility.MinorVersion.md
+      - name: VersionLessThan
+        href: apidocs/Phoenix.PaczAPI.ICompatibility.VersionLessThan.md
+    - name: IComponentConfig
+      href: apidocs/Phoenix.PaczAPI.IComponentConfig.md
+      items:
+      - name: Properties
+      - name: ASComponent
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.ASComponent.md
+      - name: Author
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Author.md
+      - name: Compatibilities
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Compatibilities.md
+      - name: Description
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Description.md
+      - name: ExternalFiles
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.ExternalFiles.md
+      - name: HelpUrl
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.HelpUrl.md
+      - name: Icon
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Icon.md
+      - name: InstanceFiles
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.InstanceFiles.md
+      - name: PlugInId
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.PlugInId.md
+      - name: Properties
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Properties.md
+      - name: RequiredFeatures
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.RequiredFeatures.md
+      - name: RunFolderPreference
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.RunFolderPreference.md
+      - name: Version
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.Version.md
+      - name: Methods
+      - name: AsReadOnly
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.AsReadOnly.md
+      - name: CloneInputsFrom
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.CloneInputsFrom.md
+      - name: CloneOutputsFrom
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.CloneOutputsFrom.md
+      - name: MoveInputsFrom
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.MoveInputsFrom.md
+      - name: MoveOutputsFrom
+        href: apidocs/Phoenix.PaczAPI.IComponentConfig.MoveOutputsFrom.md
+    - name: IExternalFile
+      href: apidocs/Phoenix.PaczAPI.IExternalFile.md
+      items:
+      - name: Properties
+      - name: Path
+        href: apidocs/Phoenix.PaczAPI.IExternalFile.Path.md
+    - name: IExternalMetadata
+      href: apidocs/Phoenix.PaczAPI.IExternalMetadata.md
+      items:
+      - name: Properties
+      - name: IsReadOnly
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.IsReadOnly.md
+      - name: Metadata
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.Metadata.md
+      - name: Name
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.Name.md
+      - name: ReadOnlyReason
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.ReadOnlyReason.md
+      - name: SourceUri
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.SourceUri.md
+      - name: Methods
+      - name: GetMetadataValue
+        href: apidocs/Phoenix.PaczAPI.IExternalMetadata.GetMetadataValue.md
+    - name: IExtractedPacz
+      href: apidocs/Phoenix.PaczAPI.IExtractedPacz.md
+      items:
+      - name: Properties
+      - name: Config
+        href: apidocs/Phoenix.PaczAPI.IExtractedPacz.Config.md
+    - name: IInstanceFile
+      href: apidocs/Phoenix.PaczAPI.IInstanceFile.md
+      items:
+      - name: Properties
+      - name: PlugInIntegral
+        href: apidocs/Phoenix.PaczAPI.IInstanceFile.PlugInIntegral.md
+      - name: RelativePath
+        href: apidocs/Phoenix.PaczAPI.IInstanceFile.RelativePath.md
+    - name: IPacz
+      href: apidocs/Phoenix.PaczAPI.IPacz.md
+      items:
+      - name: Properties
+      - name: Config
+        href: apidocs/Phoenix.PaczAPI.IPacz.Config.md
+      - name: IsSourceExtracted
+        href: apidocs/Phoenix.PaczAPI.IPacz.IsSourceExtracted.md
+      - name: SourceUri
+        href: apidocs/Phoenix.PaczAPI.IPacz.SourceUri.md
+      - name: Methods
+      - name: ExtractToTempFolderAsync
+        href: apidocs/Phoenix.PaczAPI.IPacz.ExtractToTempFolderAsync.md
+      - name: OpenAlreadyExtractedFolder
+        href: apidocs/Phoenix.PaczAPI.IPacz.OpenAlreadyExtractedFolder.md
+    - name: IPaczClient
+      href: apidocs/Phoenix.PaczAPI.IPaczClient.md
+      items:
+      - name: Methods
+      - name: CreateNewPaczFileAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczClient.CreateNewPaczFileAsync.md
+      - name: OpenExtractedPaczFileAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczClient.OpenExtractedPaczFileAsync.md
+      - name: OpenPaczFileAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczClient.OpenPaczFileAsync.md
+    - name: IPaczWriter
+      href: apidocs/Phoenix.PaczAPI.IPaczWriter.md
+      items:
+      - name: Methods
+      - name: AsReadOnly
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.AsReadOnly.md
+      - name: ReReadConfigFromExtractionFolder
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.ReReadConfigFromExtractionFolder.md
+      - name: SaveAsLocalFilesAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.SaveAsLocalFilesAsync.md
+      - name: SaveAsLocalPaczAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.SaveAsLocalPaczAsync.md
+      - name: SaveToSourceAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.SaveToSourceAsync.md
+      - name: UpdateSourceAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.UpdateSourceAsync.md
+      - name: WriteConfigToExtractionFolderAsync
+        href: apidocs/Phoenix.PaczAPI.IPaczWriter.WriteConfigToExtractionFolderAsync.md
+    - name: IReadOnlyComponentConfig
+      href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.md
+      items:
+      - name: Properties
+      - name: ASComponent
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.ASComponent.md
+      - name: Author
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Author.md
+      - name: Compatibilities
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Compatibilities.md
+      - name: Description
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Description.md
+      - name: ExternalFiles
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.ExternalFiles.md
+      - name: HelpUrl
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.HelpUrl.md
+      - name: Icon
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Icon.md
+      - name: Inputs
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Inputs.md
+      - name: InstanceFiles
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.InstanceFiles.md
+      - name: Outputs
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Outputs.md
+      - name: PlugInId
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.PlugInId.md
+      - name: Properties
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Properties.md
+      - name: RequiredFeatures
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.RequiredFeatures.md
+      - name: RunFolderPreference
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.RunFolderPreference.md
+      - name: Version
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.Version.md
+      - name: Methods
+      - name: ToJson
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyComponentConfig.ToJson.md
+    - name: IReadOnlyExtractedPacz
+      href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.md
+      items:
+      - name: Properties
+      - name: Config
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.Config.md
+      - name: ExternalMetadata
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.ExternalMetadata.md
+      - name: ExtractionFolder
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.ExtractionFolder.md
+      - name: PaczSource
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.PaczSource.md
+      - name: Methods
+      - name: ExportAsLocalFilesAsync
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.ExportAsLocalFilesAsync.md
+      - name: ExportAsLocalPaczAsync
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.ExportAsLocalPaczAsync.md
+      - name: KeepFolderOnDispose
+        href: apidocs/Phoenix.PaczAPI.IReadOnlyExtractedPacz.KeepFolderOnDispose.md
+    - name: IRuntimeVariable
+      href: apidocs/Phoenix.PaczAPI.IRuntimeVariable.md
+      items:
+      - name: Properties
+      - name: CustomMetadata
+        href: apidocs/Phoenix.PaczAPI.IRuntimeVariable.CustomMetadata.md
+      - name: DefaultValue
+        href: apidocs/Phoenix.PaczAPI.IRuntimeVariable.DefaultValue.md
+      - name: Metadata
+        href: apidocs/Phoenix.PaczAPI.IRuntimeVariable.Metadata.md
+      - name: Name
+        href: apidocs/Phoenix.PaczAPI.IRuntimeVariable.Name.md
+    - name: IUpdatableSet<T>
+      href: apidocs/Phoenix.PaczAPI.IUpdatableSet-1.md
+    - name: Enums
+    - name: RunFolderPreference
+      href: apidocs/Phoenix.PaczAPI.RunFolderPreference.md
+  - name: Phoenix.PlugIns
+    href: apidocs/Phoenix.PlugIns.md
+    items:
+    - name: Classes
+    - name: PlugInDescriptionAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInDescriptionAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInDescriptionAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInDescriptionAttribute.-ctor.md
+      - name: Properties
+      - name: Description
+        href: apidocs/Phoenix.PlugIns.PlugInDescriptionAttribute.Description.md
+    - name: PlugInDisplayNameAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInDisplayNameAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInDisplayNameAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInDisplayNameAttribute.-ctor.md
+      - name: Properties
+      - name: DisplayName
+        href: apidocs/Phoenix.PlugIns.PlugInDisplayNameAttribute.DisplayName.md
+      - name: Locale
+        href: apidocs/Phoenix.PlugIns.PlugInDisplayNameAttribute.Locale.md
+    - name: PlugInHelpUrlAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInHelpUrlAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInHelpUrlAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInHelpUrlAttribute.-ctor.md
+      - name: Properties
+      - name: HelpUrl
+        href: apidocs/Phoenix.PlugIns.PlugInHelpUrlAttribute.HelpUrl.md
+    - name: PlugInIconAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInIconAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInIconAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInIconAttribute.-ctor.md
+      - name: Properties
+      - name: IconPath
+        href: apidocs/Phoenix.PlugIns.PlugInIconAttribute.IconPath.md
+    - name: PlugInInfo
+      href: apidocs/Phoenix.PlugIns.PlugInInfo.md
+      items:
+      - name: Constructors
+      - name: PlugInInfo
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.-ctor.md
+      - name: Fields
+      - name: METADATA_FILENAME
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.METADATA_FILENAME.md
+      - name: Properties
+      - name: Author
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Author.md
+      - name: CurrentDisplayName
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.CurrentDisplayName.md
+      - name: Description
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Description.md
+      - name: DisplayName
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.DisplayName.md
+      - name: HelpUrl
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.HelpUrl.md
+      - name: Icon
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Icon.md
+      - name: Id
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Id.md
+      - name: ImplClass
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.ImplClass.md
+      - name: ImplFile
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.ImplFile.md
+      - name: ImplFramework
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.ImplFramework.md
+      - name: Options
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Options.md
+      - name: SupportedTypes
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.SupportedTypes.md
+      - name: Version
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Version.md
+      - name: Methods
+      - name: GetMetadataForAssembly
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.GetMetadataForAssembly.md
+      - name: GetPlugInType
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.GetPlugInType.md
+      - name: Implements<T>
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Implements.md
+      - name: Instantiate<T>
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.Instantiate.md
+      - name: ReadJson
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.ReadJson.md
+      - name: ReadJsonStreamAsync
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.ReadJsonStreamAsync.md
+      - name: WriteJson
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.WriteJson.md
+      - name: WriteMetadataForDLLs
+        href: apidocs/Phoenix.PlugIns.PlugInInfo.WriteMetadataForDLLs.md
+    - name: PlugInInterfaceNameAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInInterfaceNameAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInInterfaceNameAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInInterfaceNameAttribute.-ctor.md
+      - name: Properties
+      - name: Id
+        href: apidocs/Phoenix.PlugIns.PlugInInterfaceNameAttribute.Id.md
+      - name: Methods
+      - name: GetNameOrDefault
+        href: apidocs/Phoenix.PlugIns.PlugInInterfaceNameAttribute.GetNameOrDefault.md
+    - name: PlugInManagerFactory
+      href: apidocs/Phoenix.PlugIns.PlugInManagerFactory.md
+      items:
+      - name: Methods
+      - name: ConfigureServiceCollection
+        href: apidocs/Phoenix.PlugIns.PlugInManagerFactory.ConfigureServiceCollection.md
+      - name: ConfigureWithDefaultRepositories
+        href: apidocs/Phoenix.PlugIns.PlugInManagerFactory.ConfigureWithDefaultRepositories.md
+    - name: PlugInMetadataFromAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInMetadataFromAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInMetadataFromAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInMetadataFromAttribute.-ctor.md
+      - name: Properties
+      - name: ReadFrom
+        href: apidocs/Phoenix.PlugIns.PlugInMetadataFromAttribute.ReadFrom.md
+    - name: PlugInOptionAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInOptionAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInOptionAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInOptionAttribute.-ctor.md
+      - name: Properties
+      - name: Option
+        href: apidocs/Phoenix.PlugIns.PlugInOptionAttribute.Option.md
+      - name: Value
+        href: apidocs/Phoenix.PlugIns.PlugInOptionAttribute.Value.md
+    - name: PlugInTypesAttribute
+      href: apidocs/Phoenix.PlugIns.PlugInTypesAttribute.md
+      items:
+      - name: Constructors
+      - name: PlugInTypesAttribute
+        href: apidocs/Phoenix.PlugIns.PlugInTypesAttribute.-ctor.md
+      - name: Properties
+      - name: SupportedTypes
+        href: apidocs/Phoenix.PlugIns.PlugInTypesAttribute.SupportedTypes.md
+    - name: Interfaces
+    - name: IPlugInInstance
+      href: apidocs/Phoenix.PlugIns.IPlugInInstance.md
+      items:
+      - name: Properties
+      - name: Icon
+        href: apidocs/Phoenix.PlugIns.IPlugInInstance.Icon.md
+      - name: Metadata
+        href: apidocs/Phoenix.PlugIns.IPlugInInstance.Metadata.md
+      - name: Methods
+      - name: GetLocalFolder
+        href: apidocs/Phoenix.PlugIns.IPlugInInstance.GetLocalFolder.md
+      - name: GetPlugInTypeAsync
+        href: apidocs/Phoenix.PlugIns.IPlugInInstance.GetPlugInTypeAsync.md
+      - name: InstantiateAsync<T>
+        href: apidocs/Phoenix.PlugIns.IPlugInInstance.InstantiateAsync.md
+    - name: IPlugInManager
+      href: apidocs/Phoenix.PlugIns.IPlugInManager.md
+      items:
+      - name: Properties
+      - name: Count
+        href: apidocs/Phoenix.PlugIns.IPlugInManager.Count.md
+      - name: Methods
+      - name: GetPlugInFor<T>
+        href: apidocs/Phoenix.PlugIns.IPlugInManager.GetPlugInFor.md
+      - name: GetViewFor<T>
+        href: apidocs/Phoenix.PlugIns.IPlugInManager.GetViewFor.md
+      - name: InstantiateAsync<T>
+        href: apidocs/Phoenix.PlugIns.IPlugInManager.InstantiateAsync.md
+      - name: ReReadAsync
+        href: apidocs/Phoenix.PlugIns.IPlugInManager.ReReadAsync.md
+    - name: IPlugInRepository
+      href: apidocs/Phoenix.PlugIns.IPlugInRepository.md
+      items:
+      - name: Methods
+      - name: GetChildrenAsync
+        href: apidocs/Phoenix.PlugIns.IPlugInRepository.GetChildrenAsync.md
+      - name: GetPlugInsAsync
+        href: apidocs/Phoenix.PlugIns.IPlugInRepository.GetPlugInsAsync.md
+    - name: Enums
+    - name: Framework
+      href: apidocs/Phoenix.PlugIns.Framework.md
+  - name: Phoenix.PlugIns.Repositories
+    href: apidocs/Phoenix.PlugIns.Repositories.md
+    items:
+    - name: Classes
+    - name: CombiningRepository
+      href: apidocs/Phoenix.PlugIns.Repositories.CombiningRepository.md
+      items:
+      - name: Constructors
+      - name: CombiningRepository
+        href: apidocs/Phoenix.PlugIns.Repositories.CombiningRepository.-ctor.md
+      - name: Methods
+      - name: Dispose
+        href: apidocs/Phoenix.PlugIns.Repositories.CombiningRepository.Dispose.md
+      - name: GetChildrenAsync
+        href: apidocs/Phoenix.PlugIns.Repositories.CombiningRepository.GetChildrenAsync.md
+      - name: GetPlugInsAsync
+        href: apidocs/Phoenix.PlugIns.Repositories.CombiningRepository.GetPlugInsAsync.md
+    - name: DirectoryRepository
+      href: apidocs/Phoenix.PlugIns.Repositories.DirectoryRepository.md
+      items:
+      - name: Constructors
+      - name: DirectoryRepository
+        href: apidocs/Phoenix.PlugIns.Repositories.DirectoryRepository.-ctor.md
+      - name: Methods
+      - name: Dispose
+        href: apidocs/Phoenix.PlugIns.Repositories.DirectoryRepository.Dispose.md
+      - name: GetChildrenAsync
+        href: apidocs/Phoenix.PlugIns.Repositories.DirectoryRepository.GetChildrenAsync.md
+      - name: GetPlugInsAsync
+        href: apidocs/Phoenix.PlugIns.Repositories.DirectoryRepository.GetPlugInsAsync.md
 - name: Changelog
   href: changelog.md


### PR DESCRIPTION
## Summary

- Add new ModelCenter Component Plugin SDK documentation set under `2026R1/ModelCenter_ComponentPlugin_SDK-26-r1/`
- Includes introduction, getting started guide, threading guide, FAQ, glossary, examples (BasicPaczPlugin and FMUv2Import), APIs page, changelog, and full .NET API reference
- Flatten nested `apidocs/toc.yml` into the main `toc.yml` (nested TOC references are not supported)
- Apply sentence case to all titles across TOC, headings, and docfx.json metadata

## Test plan

- [ ] Verify the doc set renders correctly on the developer portal
- [ ] Confirm TOC navigation works end-to-end including the .NET API reference section
- [ ] Verify all internal cross-links resolve correctly