### PR TITLE
Rename Custom Optimization Algorithm to SDK and apply doc guidelines

### DIFF
--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/api/index_api.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/api/index_api.md
@@ -1,4 +1,4 @@
-# API Reference
+# API reference
 
-This section provides detailed API documentation for the ModelCenter Algorithm Developer Tools.
+This section provides detailed API documentation for the ModelCenter Custom Optimization Algorithm SDK.
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/changelog.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/changelog.md
@@ -1,4 +1,7 @@
 # Changelog
 
 ## 2026 R1
-- added doc to developer page
+
+### Added
+
+- Published documentation to the Ansys Developer portal

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm.md
@@ -1,15 +1,12 @@
-# How to create an Algorithm
+# Create an algorithm
 
 1. Create an algorithm project using your desired programming language:
-   - [Creating a .NET Algorithm Project](create_algorithm/create_algo_net.md) (C#, VB.NET, C++/CLI)
-   - [Creating a Java Algorithm Project](create_algorithm/create_algo_java.md)
-1. [Implement Description Properties](create_algorithm/create_algo_description.md)
-1. [Implement Capability Properties](create_algorithm/create_algo_capability.md)
-1. [Implement Setup Methods and Properties](create_algorithm/create_algo_setup.md)
-1. [Implement Algorithm Execution](create_algorithm/create_algo_execution.md)
-1. [Implement Results Properties](create_algorithm/create_algo_results.md)
-1. [Installing Algorithm](create_algorithm/create_algo_install.md)
-
-
-
+   - [Create a .NET algorithm project](create_algorithm/create_algo_net.md) (C#, VB.NET, C++/CLI)
+   - [Create a Java algorithm project](create_algorithm/create_algo_java.md)
+1. [Implement description properties](create_algorithm/create_algo_description.md)
+1. [Implement capability properties](create_algorithm/create_algo_capability.md)
+1. [Implement setup methods and properties](create_algorithm/create_algo_setup.md)
+1. [Implement algorithm execution](create_algorithm/create_algo_execution.md)
+1. [Implement results properties](create_algorithm/create_algo_results.md)
+1. [Install the algorithm](create_algorithm/create_algo_install.md)
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_capability.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_capability.md
@@ -1,4 +1,4 @@
-# How to Implement Capability Properties
+# Implement capability properties
 
 The algorithm capability properties are used by the Algorithm Selection Wizard to help the user select algorithms appropriate for their problem definition.
 
@@ -17,5 +17,3 @@ The algorithm capability properties are used by the Algorithm Selection Wizard t
 - [`SupportsNonSmoothResponses`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#SupportsNonSmoothResponses) - whether the algorithm supports non-smooth responses (objectives and constraints). The property is of the [FuzzyBoolean](../api/Namespaces/NamespaceList/Phoenix/optimization.md#FuzzyBoolean) enum type. The algorithm can specify that it does or does not support non-smooth responses, or that it can handle non-smooth responses, but not very well.
 
 - [`SupportsSolveFor`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#SupportsSolveFor) - whether the algorithm supports solving an objective for a specific value. The property is of the [FuzzyBoolean](../api/Namespaces/NamespaceList/Phoenix/optimization.md#FuzzyBoolean) enum type. The algorithm can specify that it does or does not support discrete variables, or that it can handle solving for a value, but not very well. If the algorithm does not support solving for a value, the infrastructure will create an objective to minimize the difference between the objective and the solve for value.
-
-

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_description.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_description.md
@@ -1,4 +1,4 @@
-# Implement Description Properties
+# Implement description properties
 
 The description properties are read-only properties that provide information about the algorithm to the infrastructure.
 
@@ -23,10 +23,6 @@ The description properties are read-only properties that provide information abo
 - [`Version`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#version) - This is the version information provided to Optimization Tool infrastructure.
 
 It is recommended that `Description`, `HelpFilePath`, `HelpURL`, and `Keywords` be specified using the `UIStrings` resource so that they can be translated. The license feature should not be translatable.
-
-
-
-
 
 
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_execution.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_execution.md
@@ -1,4 +1,4 @@
-# Implement Algorithm Execution
+# Implement algorithm execution
 
 The Optimization Tool calls the [`Run()`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#run) method to start the execution of the algorithm.
 
@@ -8,11 +8,9 @@ When the algorithm requires a model evaluation from ModelCenter, it should call 
 
 For single objective problems, the algorithm should call [`UpdateBestDesign(Object[])`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithmHost.md#updatebestdesign) as the optimization progresses so that the designs can be plotted in the convergence history. For multiobjective problems, the Pareto front of designs should be reported back to the Optimization Tool using the `UpdateBestDesigns` method.
 
-### See Also
+### See also
 
 - [`IAlgorithmHost`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithmHost.md)
 - [`SetStatusMessage(String)`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithmHost.md#setstatusmessage)
 - [`SetStatusMessage(String, MessageType)`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithmHost.md#setstatusmessage)
-
-
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_index.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_index.md
@@ -1,8 +1,8 @@
-# Create an Algorithm Index
+# Create an algorithm index
 
 This article outlines the lifecycle of an algorithm from its creation to its final disposal.
 
-## Algorithm Lifecycle
+## Algorithm lifecycle
 
 1. [Algorithm created](../create_algorithm.md)
 2. [IAlgorithmHost](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithmHost.md) set (see [SetHost(IAlgorithmHost)](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#SetHost))

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_install.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_install.md
@@ -1,4 +1,4 @@
-# Install the Algorithm
+# Install the algorithm
 
 Once the algorithm has been successfully compiled, the algorithm files must be moved where the Optimization Tool can find them.
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_java.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_java.md
@@ -1,8 +1,8 @@
-# How to create a Java Algorithm
+# Create a Java algorithm project
 
 The following instructions are for creating a Java algorithm using the NetBeans IDE. NetBeans can be downloaded for free from [netbeans.org](http://netbeans.org/downloads/).
 
-## Creating a new Algorithm project using NetBeans
+## Create a new algorithm project using NetBeans
 
 1. Create a new project for the Java algorithm by selecting **File > New Project** from the **NetBeans** menu.
 
@@ -70,7 +70,7 @@ The following instructions are for creating a Java algorithm using the NetBeans 
 
 The base class for the Java algorithm has now been implemented. The rest of the guide is based on .NET, but the major differences for Java are that properties use **get *[property name]()*** and methods start with lowercase letters. Java algorithms install to the same location as the .NET algorithms, and the build file can be modified to move the algorithm to the correct location using the ant copy task.
 
-### Add Manifest File for Algorithm
+### Add manifest file for algorithm
 
 A manifest file must be added to tell the Optimization Tool which JAR files should be searched for implementations of [`IAlgorithm`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md). To add the manifest:
 
@@ -82,7 +82,7 @@ A manifest file must be added to tell the Optimization Tool which JAR files shou
 
 4. The file should be created in the project's base directory. Open the manifest file and enter the name of the JAR file output by the algorithm project. A single manifest file can specify multiple files that contain [`IAlgorithm`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md) implementations, but only one file name should be specified per line.
 
-### Adding Algorithm Copy to the Java Algorithm Build Process
+### Add algorithm copy to the Java algorithm build process
 
 The algorithm can be moved to a location where the Optimization Tool can locate it automatically by adding the following code to the algorithm's *build.xml*.
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_net.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_net.md
@@ -1,4 +1,4 @@
-# How to create a .Net Algorithm Project
+# Create a .NET algorithm project
 
 All that is required of an algorithm by the Optimization Tool is that it implements the [`IAlgorithm`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md) interface. Algorithm templates have been included for C#, Visual Basic, and C++ to further simplify the process.
 
@@ -32,7 +32,7 @@ public class Algorithm : IAlgorithm
 
 New GUIDs can be generated using **Create GUID** from the **Tools** menu.
 
-## Adding Algorithm Move to Pre-Build Event
+## Add algorithm move to pre-build event
 
 1. Select *[algorithm project name] Properties* from the **Project** menu to open that algorithm's project properties.
 
@@ -51,7 +51,7 @@ New GUIDs can be generated using **Create GUID** from the **Tools** menu.
 
 3. The next time the Optimization Tool plug-in is invoked, the algorithm will be available for use.
 
-## Add Manifest File for Algorithm
+## Add manifest file for algorithm
 
 A manifest file must be added to tell the Optimization Tool which `.dll` files should be searched for implementations of [`IAlgorithm`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md). To add the manifest:
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_results.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_results.md
@@ -1,4 +1,4 @@
-# Implement Results Properties
+# Implement results properties
 
 Algorithms have two properties with which they can report back their results to the Optimization Tool.
 
@@ -9,7 +9,4 @@ Algorithms have two properties with which they can report back their results to 
 Both of these properties can be accessed during the run, so they should be threadsafe. At a minimum, the DetailsReport should be updated during the run so that the user can examine the details of the algorithm progress while the algorithm is still running.
 
 **NOTE:** The report can either be a simple string, or it can be in HTML format. If HTML format is used, then the starting and ending `<html>` tags must be defined.
-
-
-
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_setup.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_setup.md
@@ -1,8 +1,8 @@
-# Implement Setup Methods 
+# Implement setup methods and properties
 
 Algorithms have five methods and one property that the Optimization Tool uses to pass the problem definition to the algorithm.
 
-## Implement the Setup Methods
+## Implement the setup methods
 
 When the algorithm is being prepared to run the setup methods are called in the following order:
 
@@ -18,7 +18,7 @@ When the algorithm is being prepared to run the setup methods are called in the 
 
    **NOTE:** checkpoints have not yet been implemented into the infrastructure, but the interfaces for it have been defined in preparation.
 
-## Implement Options
+## Implement options
 
 - [`Options`](../api/Namespaces/NamespaceList/Phoenix/Optimization/IAlgorithm.md#Options) - an object that contains all of the options available for the algorithm. Is used to pass the options to the infrastructure for display and to return the options to the algorithm for use.
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_tests.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_algorithm/create_algo_tests.md
@@ -1,8 +1,8 @@
-# Create Algorithm Tests
+# Create algorithm tests
 
 A suite of unit tests for the algorithm are included with the Developer Tools. Implementing and running the tests help ensure that the algorithm will work properly within the Optimization Tool.
 
-## Added NUnit Tests
+## Add NUnit tests
 
 The algorithm tests require NUnit to run. NUnit can be downloaded for free from [nunit.org](http://www.nunit.org/download). 
 
@@ -16,9 +16,7 @@ The algorithm tests require NUnit to run. NUnit can be downloaded for free from 
    - [`createAlgorithm()`](../api/Namespaces/NamespaceList/Phoenix/Optimization/AlgorithmTests/AlgorithmTestFixture.md#createAlgorithm) - Method to instantiate the algorithm to be tested.
    - [`AlgorithmInstallationPath`](../api/Namespaces/NamespaceList/Phoenix/Optimization/AlgorithmTests/AlgorithmTestFixture.md#property.AlgorithmInstallationPath) - Method used by the test to locate the algorithm to be tested.
 
-### See Also
+### See also
 
 - [AlgorithmTestFixture](../api/Namespaces/NamespaceList/Phoenix/Optimization/AlgorithmTests/AlgorithmTestFixture.md)
-
-
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_evaluator.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/create_evaluator.md
@@ -1,8 +1,8 @@
-# How to create an Evaluator
+# Create an evaluator
 
 The Algorithm Developer Tools includes a suite of test problems to test the performance of algorithms. Some of these test problems are academic in nature and others are more real world (some require ModelCenter and other tools such as ABACUS, LS-DYNA, etc.). Additional test problems can be added by implementing the interface and placing the resulting DLL in the correct location.
 
-## Added New Evaluator Functions
+## Add new evaluator functions
 
 Evaluator functions are run using the Algorithm Problem Test Suite which is included with the Algorithm Developer Tools.
 
@@ -46,5 +46,4 @@ Evaluator functions are run using the Algorithm Problem Test Suite which is incl
    - In a subdirectory of Optimization Tool's algorithms directory. Typically, "C:\Program Files\Phoenix Integration\Optimization Tool\evaluators". **NOTE:** This is the location for algorithms that are installed with the Optimization Tool, but users may not have write access to this location because of user security privileges.
 
    Copy the evaluator DLL (and any files it requires) to the new directory.
-
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/docfx.json
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/docfx.json
@@ -1,8 +1,8 @@
 {
   "build": {
     "globalMetadata": {
-      "title": "ModelCenter Custom Optimization Algorithm - Developer's Guide 2026 R1",
-      "summary": "The ModelCenter algorithm developer SDK enables users to create custom optimization algorithms for use in ModelCenter products.",
+      "title": "ModelCenter Custom Optimization Algorithm SDK 2026 R1",
+      "summary": "The ModelCenter Custom Optimization Algorithm SDK enables you to create custom optimization algorithms for use in ModelCenter products.",
       "version": "2026 R1",
       "product": "ModelCenter",
       "programming language": "java",

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/how_test_suite.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/how_test_suite.md
@@ -1,8 +1,8 @@
-# How to use the Problem Test Suite
+# Use the problem test suite
 
 The problem test suite included with the Algorithm Developer Tools allows developers to run their algorithms against a variety of academic and real-world test problems and compare the performance of their algorithm against the performance of the algorithms included with ModelCenter. New evaluators can be added to the test suite by implementing the `IEvaluator` interface.
 
-## PHXProblemTestSuite *[options] [file]*
+## PHXProblemTestSuite [options] [file]
 
 With no options, all algorithms are run against all evaluators using their default options.
 
@@ -59,6 +59,4 @@ The ***user.xml*** file has three top-level elements. The basic format is as fol
   - `GUID` - GUID of the algorithm
   - `Use` - specifies whether or not the evaluator should be run in this configuration (Default: true)
   - `Options` - The XML serialization of the algorithm options
-
-
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/index.md
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/index.md
@@ -1,8 +1,6 @@
 # Introduction
 
-The ModelCenter algorithm developer SDK enables users to create custom optimization algorithms for use in ModelCenter products.
+The ModelCenter Custom Optimization Algorithm SDK enables you to create custom optimization algorithms for use in ModelCenter products.
 
-For an overview of the algorithm lifecycle, see [Create an Algorithm Index](create_algorithm/create_algo_index.md).
-
-
+For an overview of the algorithm lifecycle, see [Create an algorithm index](create_algorithm/create_algo_index.md).
 

--- a/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/toc.yml
+++ b/2026R1/ModelCenter_Algo_Developers_Guide-26-r1/toc.yml
@@ -1,31 +1,31 @@
 - name: Introduction
   href: index.md
-- name: Create an Algorithm
+- name: Create an algorithm
   href: create_algorithm.md
   items:
-  - name: Create an Algorithm Index
+  - name: Create an algorithm index
     href: create_algorithm/create_algo_index.md
-  - name: Create a .NET Algorithm Project
+  - name: Create a .NET algorithm project
     href: create_algorithm/create_algo_net.md
-  - name: Create a Java Algorithm Project
+  - name: Create a Java algorithm project
     href: create_algorithm/create_algo_java.md
-  - name: Implement Description Properties
+  - name: Implement description properties
     href: create_algorithm/create_algo_description.md
-  - name: Implement Capability Properties
+  - name: Implement capability properties
     href: create_algorithm/create_algo_capability.md
-  - name: Implement Setup Methods and Properties
+  - name: Implement setup methods and properties
     href: create_algorithm/create_algo_setup.md
-  - name: Implement Algorithm Execution
+  - name: Implement algorithm execution
     href: create_algorithm/create_algo_execution.md
-  - name: Implement Results Properties
+  - name: Implement results properties
     href: create_algorithm/create_algo_results.md
-  - name: Installing the Algorithm
+  - name: Install the algorithm
     href: create_algorithm/create_algo_install.md
-- name: How to Create an Evaluator
+- name: Create an evaluator
   href: create_evaluator.md
-- name: How to Use the Problem Test Suite
+- name: Use the problem test suite
   href: how_test_suite.md
-- name: API 
+- name: API reference
   href: api/index_api.md
   items:
   - name: Namespaces


### PR DESCRIPTION
## Summary

- Renamed title from "ModelCenter Custom Optimization Algorithm - Developer's Guide" to "ModelCenter Custom Optimization Algorithm SDK" for consistency with the Dev portal naming convention (summary and intro already referenced it as an SDK)
- Applied sentence case to all headings across toc.yml and 15 content .md files per Ansys API documentation guidelines
- Cleaned up changelog format (categorized entries), removed trailing blank lines, and updated API reference description to match the new SDK title

## Test plan

- [ ] Verify the doc set renders correctly on the developer portal
- [ ] Confirm TOC navigation works end-to-end
- [ ] Verify all internal cross-links resolve correctly
