### PR TITLE
docs(dpf-framework): document Field scoping setter semantics and mesh coordinate live references

### DIFF
--- a/docs/dpf/dpf-framework/versions/2026.R1.SP00/core-concepts/data-containers.md
+++ b/docs/dpf/dpf-framework/versions/2026.R1.SP00/core-concepts/data-containers.md
@@ -4,6 +4,8 @@
 
 The field is the main simulation data container. In numerical simulations, results data are defined by values associated to entities (scoping), and these entities are a subset of a model (support). In DPF, field data is always associated to its scoping and support, making the field a self-describing piece of data. A field is also defined by its dimensionnality, unit, location... A field can for example, describe a displacement vector or norm, stresses and strains tensors, stresses and strains equivalent, min max over time of any result... It can be defined on a complete model or just on certain entities of the model thanks to its scoping. The data is stored as a vector of double values and each elementary entity has a number of components (thanks to the dimensionality, a displacement will have 3 components, a symmetrical stress matrix 6...)
 
+> **Note:** Assigning a new scoping to an existing field updates only the metadata index - it does **not** filter or resize the underlying data array. To extract data for a spatial subset, use the `rescope` operator or call `field.deep_copy()` before modifying the scoping.
+
 ## Scoping
 
 The scoping is entities ids representing a subset of the model's support. Typically, scoping can represent node ids, element ids, time steps, frequencies, joints... Its location indicates what kind of entity the scoping is referring to. Scopings are used to identify the entities where a field is scoped or to choose (through an input pin) a subset on which an operator should compute its result.
@@ -27,6 +29,8 @@ The fields container is a container of fields, used mainly in transient, harmoni
 ## Meshed Region
 
 The meshed region is dpf's entity describing a mesh. Node and element scopings, element types, connectivity (list of node indices composing each element) and node coordinates are the fundamental entities composing the meshed region. It can also have materials, named selections...
+
+> **Note:** `nodes.coordinates_field` (Python) and `CoordinatesField` (C# `mech_dpf`) return a **live reference** to the internal mesh coordinate array. Modifications affect the mesh directly. Use `coordinates_field.deep_copy()` or the `node_coordinates` operator to obtain an independent copy.
 
 ## Time Freq Support
 

--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -187,6 +187,66 @@ Key field properties for introspection:
 | `field_definition` | Aggregated metadata | [`field_definition`](./dpf-types.md#field-definition) |
 | `data` | Raw data array | `array of double` |
 
+## Common pitfalls
+
+### Replacing the scoping does not resize the data buffer
+
+Assigning a new scoping to a field updates only the metadata - it does **not** filter or
+resize the underlying data array. After reassignment, the scoping length and the data
+length may be inconsistent, which leads to silent incorrect results or errors when the
+field is consumed by a downstream operator.
+
+**Do not** use the scoping setter to extract a spatial subset. Instead:
+
+- Use the `rescope` operator to produce a correctly-sized field for a chosen subset.
+- Call `field.deep_copy()` to obtain an independent copy before modifying the scoping.
+
+```python
+import ansys.dpf.core as dpf
+
+model = dpf.Model("file.rst")
+result_field = model.results.displacement()[0]
+my_scoping = dpf.Scoping(ids=[1, 2, 3], location=dpf.locations.nodal)
+
+# Correct - use rescope to filter any field to a scoping
+rescope_op = dpf.operators.scoping.rescope()
+rescope_op.inputs.fields.connect(result_field)
+rescope_op.inputs.mesh_scoping.connect(my_scoping)
+filtered_field = rescope_op.outputs.fields_as_field()
+
+# Correct - deep-copy a field before modifying its scoping
+my_field = result_field.deep_copy()
+```
+
+### `coordinates_field` returns a live reference
+
+The `MeshedRegion.nodes.coordinates_field` property (Python `nodes.coordinates_field`,
+C# `MeshedRegion.CoordinatesField`) returns a **live reference** to the internal mesh node
+coordinate array. Any modification to the returned field is reflected immediately in the
+mesh, and subsequent calls return the same underlying data.
+
+To obtain an independent snapshot that is safe to modify without affecting the mesh:
+
+```python
+# Python - deep copy
+coords_copy = model.mesh.nodes.coordinates_field.deep_copy()
+
+# Python - use the node_coordinates operator
+node_coord_op = dpf.operators.geo.node_coordinates()
+node_coord_op.inputs.mesh.connect(model.mesh)
+coords_independent = node_coord_op.outputs.coordinates_as_field()
+```
+
+In C# (`mech_dpf`), call `GetHardCopy()` to obtain an independent copy:
+
+```csharp
+// C# - live reference (do not modify)
+var liveRef = mesh.CoordinatesField;
+
+// C# - independent copy
+Field snapshot = mesh.CoordinatesField.GetHardCopy();
+```
+
 ## Related types
 
 Fields are often used in combination with:


### PR DESCRIPTION
## Summary

Adds a new 'Common pitfalls' section to the DPF Framework Theory Guide (2027 R1) covering:
- The scoping setter is metadata-only and does not resize the data buffer
- coordinates_field / CoordinatesField returns a live reference to the mesh coordinate array
- How to obtain safe independent copies (deep_copy(), node_coordinates operator, Clone.ToVector in C#)

Also adds concise notes to the 2026 R1 data-containers reference page under Field and Meshed Region.