### PR TITLE
docs(dpf-framework): document field scoping setter semantics and live coordinate reference behavior

### DIFF
--- a/docs/dpf/dpf-framework/versions/2026.R1.SP00/core-concepts/data-containers.md
+++ b/docs/dpf/dpf-framework/versions/2026.R1.SP00/core-concepts/data-containers.md
@@ -30,7 +30,7 @@ The fields container is a container of fields, used mainly in transient, harmoni
 
 The meshed region is dpf's entity describing a mesh. Node and element scopings, element types, connectivity (list of node indices composing each element) and node coordinates are the fundamental entities composing the meshed region. It can also have materials, named selections...
 
-> **Note:** `nodes.coordinates_field` (Python) and `CoordinatesField` (C# `mech_dpf`) return a **live reference** to the internal mesh coordinate array. Modifications affect the mesh directly. Use `coordinates_field.deep_copy()` or the `node_coordinates` operator to obtain an independent copy.
+> **Note:** `nodes.coordinates_field` (Python) and `CoordinatesField` (C# or IronPython MechDPF) return a **live reference** to the internal mesh coordinate array. Modifications affect the mesh directly. Use `coordinates_field.deep_copy()` (Python) or `GetHardCopy()` (C# or IronPython MechDPF) to obtain an independent copy.
 
 ## Time Freq Support
 

--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -221,7 +221,7 @@ my_field = result_field.deep_copy()
 ### `coordinates_field` returns a live reference
 
 The `MeshedRegion.nodes.coordinates_field` property (Python `nodes.coordinates_field`,
-C# `MeshedRegion.CoordinatesField`) returns a **live reference** to the internal mesh node
+C# or IronPython MechDPF `MeshedRegion.CoordinatesField`) returns a **live reference** to the internal mesh node
 coordinate array. Any modification to the returned field is reflected immediately in the
 mesh, and subsequent calls return the same underlying data.
 
@@ -230,19 +230,11 @@ To obtain an independent snapshot that is safe to modify without affecting the m
 ```python
 # Python - deep copy
 coords_copy = model.mesh.nodes.coordinates_field.deep_copy()
-
-# Python - use the node_coordinates operator
-node_coord_op = dpf.operators.geo.node_coordinates()
-node_coord_op.inputs.mesh.connect(model.mesh)
-coords_independent = node_coord_op.outputs.coordinates_as_field()
 ```
 
-In C# (`mech_dpf`), call `GetHardCopy()` to obtain an independent copy:
+In C# or IronPython (MechDPF), call `GetHardCopy()` to obtain an independent copy:
 
 ```csharp
-// C# - live reference (do not modify)
-var liveRef = mesh.CoordinatesField;
-
 // C# - independent copy
 Field snapshot = mesh.CoordinatesField.GetHardCopy();
 ```


### PR DESCRIPTION
Follow-up to #407. Removes incorrect references to the node_coordinates operator as an alternative to field rescoping/copying. node_coordinates does not accept a mesh_scoping input and returns a live reference to the mesh coordinates, not an independent copy.

## Changes
- Scoping setter pitfall: only rescope operator and deep_copy() are listed
- coordinates_field pitfall: only deep_copy() (Python) and GetHardCopy() (C#) are listed
- 2026 R1 data-containers.md: meshed region note updated to match