### PR TITLE
docs(dpf-framework): document field scoping setter semantics and live coordinate references in release folders

### DIFF
--- a/2026R1/dpf-framework-26-r1/core-concepts/data-containers.md
+++ b/2026R1/dpf-framework-26-r1/core-concepts/data-containers.md
@@ -4,6 +4,8 @@
 
 The field is the main simulation data container. In numerical simulations, results data are defined by values associated to entities (scoping), and these entities are a subset of a model (support). In DPF, field data is always associated to its scoping and support, making the field a self-describing piece of data. A field is also defined by its dimensionnality, unit, location... A field can for example, describe a displacement vector or norm, stresses and strains tensors, stresses and strains equivalent, min max over time of any result... It can be defined on a complete model or just on certain entities of the model thanks to its scoping. The data is stored as a vector of double values and each elementary entity has a number of components (thanks to the dimensionality, a displacement will have 3 components, a symmetrical stress matrix 6...)
 
+> **Note:** Assigning a new scoping to an existing field updates only the metadata index - it does **not** filter or resize the underlying data array. To extract data for a spatial subset, use the `rescope` operator or call `field.deep_copy()` before modifying the scoping.
+
 ## Scoping
 
 The scoping is entities ids representing a subset of the model's support. Typically, scoping can represent node ids, element ids, time steps, frequencies, joints... Its location indicates what kind of entity the scoping is referring to. Scopings are used to identify the entities where a field is scoped or to choose (through an input pin) a subset on which an operator should compute its result.
@@ -27,6 +29,8 @@ The fields container is a container of fields, used mainly in transient, harmoni
 ## Meshed Region
 
 The meshed region is dpf's entity describing a mesh. Node and element scopings, element types, connectivity (list of node indices composing each element) and node coordinates are the fundamental entities composing the meshed region. It can also have materials, named selections...
+
+> **Note:** `nodes.coordinates_field` (Python) and `CoordinatesField` (C# or IronPython MechDPF) return a **live reference** to the internal mesh coordinate array. Modifications affect the mesh directly. Use `coordinates_field.deep_copy()` (Python) or `GetHardCopy()` (C# or IronPython MechDPF) to obtain an independent copy.
 
 ## Time Freq Support
 

--- a/2026R1/dpf-framework-26-r1/core-concepts/field.md
+++ b/2026R1/dpf-framework-26-r1/core-concepts/field.md
@@ -264,6 +264,58 @@ Key field properties for introspection:
 | `field_definition` | Aggregated metadata | [`field_definition`](./dpf-types.md#field-definition) |
 | `data` | Raw data array | `array of double` |
 
+## Common pitfalls
+
+### Replacing the scoping does not resize the data buffer
+
+Assigning a new scoping to a field updates only the metadata - it does **not** filter or
+resize the underlying data array. After reassignment, the scoping length and the data
+length may be inconsistent, which leads to silent incorrect results or errors when the
+field is consumed by a downstream operator.
+
+**Do not** use the scoping setter to extract a spatial subset. Instead:
+
+- Use the `rescope` operator to produce a correctly-sized field for a chosen subset.
+- Call `field.deep_copy()` to obtain an independent copy before modifying the scoping.
+
+```python
+import ansys.dpf.core as dpf
+
+model = dpf.Model("file.rst")
+result_field = model.results.displacement()[0]
+my_scoping = dpf.Scoping(ids=[1, 2, 3], location=dpf.locations.nodal)
+
+# Correct - use rescope to filter any field to a scoping
+rescope_op = dpf.operators.scoping.rescope()
+rescope_op.inputs.fields.connect(result_field)
+rescope_op.inputs.mesh_scoping.connect(my_scoping)
+filtered_field = rescope_op.outputs.fields_as_field()
+
+# Correct - deep-copy a field before modifying its scoping
+my_field = result_field.deep_copy()
+```
+
+### `coordinates_field` returns a live reference
+
+The `MeshedRegion.nodes.coordinates_field` property (Python `nodes.coordinates_field`,
+C# or IronPython MechDPF `MeshedRegion.CoordinatesField`) returns a **live reference** to the internal mesh node
+coordinate array. Any modification to the returned field is reflected immediately in the
+mesh, and subsequent calls return the same underlying data.
+
+To obtain an independent snapshot that is safe to modify without affecting the mesh:
+
+```python
+# Python - deep copy
+coords_copy = model.mesh.nodes.coordinates_field.deep_copy()
+```
+
+In C# or IronPython (MechDPF), call `GetHardCopy()` to obtain an independent copy:
+
+```csharp
+// C# - independent copy
+Field snapshot = mesh.CoordinatesField.GetHardCopy();
+```
+
 ## Related types
 
 Fields are often used in combination with:

--- a/2027R1/dpf-framework-27-r1/core-concepts/data-containers.md
+++ b/2027R1/dpf-framework-27-r1/core-concepts/data-containers.md
@@ -4,6 +4,8 @@
 
 The field is the main simulation data container. In numerical simulations, results data are defined by values associated to entities (scoping), and these entities are a subset of a model (support). In DPF, field data is always associated to its scoping and support, making the field a self-describing piece of data. A field is also defined by its dimensionnality, unit, location... A field can for example, describe a displacement vector or norm, stresses and strains tensors, stresses and strains equivalent, min max over time of any result... It can be defined on a complete model or just on certain entities of the model thanks to its scoping. The data is stored as a vector of double values and each elementary entity has a number of components (thanks to the dimensionality, a displacement will have 3 components, a symmetrical stress matrix 6...)
 
+> **Note:** Assigning a new scoping to an existing field updates only the metadata index - it does **not** filter or resize the underlying data array. To extract data for a spatial subset, use the `rescope` operator or call `field.deep_copy()` before modifying the scoping.
+
 ## Scoping
 
 The scoping is entities ids representing a subset of the model's support. Typically, scoping can represent node ids, element ids, time steps, frequencies, joints... Its location indicates what kind of entity the scoping is referring to. Scopings are used to identify the entities where a field is scoped or to choose (through an input pin) a subset on which an operator should compute its result.
@@ -27,6 +29,8 @@ The fields container is a container of fields, used mainly in transient, harmoni
 ## Meshed Region
 
 The meshed region is dpf's entity describing a mesh. Node and element scopings, element types, connectivity (list of node indices composing each element) and node coordinates are the fundamental entities composing the meshed region. It can also have materials, named selections...
+
+> **Note:** `nodes.coordinates_field` (Python) and `CoordinatesField` (C# or IronPython MechDPF) return a **live reference** to the internal mesh coordinate array. Modifications affect the mesh directly. Use `coordinates_field.deep_copy()` (Python) or `GetHardCopy()` (C# or IronPython MechDPF) to obtain an independent copy.
 
 ## Time Freq Support
 

--- a/2027R1/dpf-framework-27-r1/core-concepts/field.md
+++ b/2027R1/dpf-framework-27-r1/core-concepts/field.md
@@ -187,6 +187,58 @@ Key field properties for introspection:
 | `field_definition` | Aggregated metadata | [`field_definition`](./dpf-types.md#field-definition) |
 | `data` | Raw data array | `array of double` |
 
+## Common pitfalls
+
+### Replacing the scoping does not resize the data buffer
+
+Assigning a new scoping to a field updates only the metadata - it does **not** filter or
+resize the underlying data array. After reassignment, the scoping length and the data
+length may be inconsistent, which leads to silent incorrect results or errors when the
+field is consumed by a downstream operator.
+
+**Do not** use the scoping setter to extract a spatial subset. Instead:
+
+- Use the `rescope` operator to produce a correctly-sized field for a chosen subset.
+- Call `field.deep_copy()` to obtain an independent copy before modifying the scoping.
+
+```python
+import ansys.dpf.core as dpf
+
+model = dpf.Model("file.rst")
+result_field = model.results.displacement()[0]
+my_scoping = dpf.Scoping(ids=[1, 2, 3], location=dpf.locations.nodal)
+
+# Correct - use rescope to filter any field to a scoping
+rescope_op = dpf.operators.scoping.rescope()
+rescope_op.inputs.fields.connect(result_field)
+rescope_op.inputs.mesh_scoping.connect(my_scoping)
+filtered_field = rescope_op.outputs.fields_as_field()
+
+# Correct - deep-copy a field before modifying its scoping
+my_field = result_field.deep_copy()
+```
+
+### `coordinates_field` returns a live reference
+
+The `MeshedRegion.nodes.coordinates_field` property (Python `nodes.coordinates_field`,
+C# or IronPython MechDPF `MeshedRegion.CoordinatesField`) returns a **live reference** to the internal mesh node
+coordinate array. Any modification to the returned field is reflected immediately in the
+mesh, and subsequent calls return the same underlying data.
+
+To obtain an independent snapshot that is safe to modify without affecting the mesh:
+
+```python
+# Python - deep copy
+coords_copy = model.mesh.nodes.coordinates_field.deep_copy()
+```
+
+In C# or IronPython (MechDPF), call `GetHardCopy()` to obtain an independent copy:
+
+```csharp
+// C# - independent copy
+Field snapshot = mesh.CoordinatesField.GetHardCopy();
+```
+
 ## Related types
 
 Fields are often used in combination with:


### PR DESCRIPTION
## Summary

Adds the same field scoping setter and live coordinate reference pitfall notes
that were introduced in the versioned `docs/` tree (PR #408) to the two release-folder
copies of the DPF framework guide.

## Changes

**2026 R1** (`2026R1/dpf-framework-26-r1/core-concepts/`):
- `data-containers.md`: added notes after the Field and Meshed Region sections
- `field.md`: added Common pitfalls section with code examples

**2027 R1** (`2027R1/dpf-framework-27-r1/core-concepts/`):
- `data-containers.md`: added notes after the Field and Meshed Region sections
- `field.md`: added Common pitfalls section with code examples

Pitfall notes cover:
1. **Scoping setter is metadata-only** - assigning a new scoping updates the index only; it does not filter or resize the data array. Use the `rescope` operator or `field.deep_copy()` instead.
2. **`coordinates_field` is a live reference** - returns a direct reference to the internal mesh coordinate array. Use `deep_copy()` (Python) or `GetHardCopy()` (C#/MechDPF) to obtain an independent copy.

Relates to TFS US 1459270.