### PR TITLE
Granta MI: Fix taxonomy and broken toc link

### DIFF
--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2024.R1.SP00/docfx.json
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2024.R1.SP00/docfx.json
@@ -4,7 +4,7 @@
         "title": "Granta MI Scripting Toolkit 3.3",
         "summary": "",
         "version": "3.3",
-        "product": "Granta",
+        "product": "Granta MI",
         "programming language": "Python",
         "product collection": "Materials",
         "physics": "Materials Data"

--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2024.R2.SP00/docfx.json
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2024.R2.SP00/docfx.json
@@ -4,7 +4,7 @@
         "title": "Granta MI Scripting Toolkit 4.0",
         "summary": "",
         "version": "4.0",
-        "product": "Granta",
+        "product": "Granta MI",
         "programming language": "Python",
         "product collection": "Materials",
         "physics": "Materials Data"

--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2025.R1.SP00/docfx.json
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2025.R1.SP00/docfx.json
@@ -4,7 +4,7 @@
         "title": "Granta MI Scripting Toolkit 4.1",
         "summary": "",
         "version": "4.1",
-        "product": "Granta",
+        "product": "Granta MI",
         "programming language": "Python",
         "product collection": "Materials",
         "physics": "Materials Data"

--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2025.R2.SP00/docfx.json
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2025.R2.SP00/docfx.json
@@ -4,7 +4,7 @@
         "title": "Granta MI Scripting Toolkit 4.2",
         "summary": "Granta MI Scripting Toolkit documentation",
         "version": "4.2",
-        "product": "Granta",
+        "product": "Granta MI",
         "programming language": "Python",
         "physics": "Connect"
       }

--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/docfx.json
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/docfx.json
@@ -4,7 +4,7 @@
         "title": "Granta MI Scripting Toolkit 5.0",
         "summary": "Granta MI Scripting Toolkit documentation",
         "version": "5.0",
-        "product": "Granta",
+        "product": "Granta MI",
         "programming language": "Python",
         "physics": "Connect"
       }

--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/toc.yml
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/toc.yml
@@ -47,7 +47,7 @@
     - name: Point and range data
       href: samples/streamlined/07_Edit_Point_Range_Data.md
     - name: Date, integer and logical data
-      href: samples/streamlined/08_Edit_Data_Integer_and_Logical_Data.md
+      href: samples/streamlined/08_Edit_Date_Integer_and_Logical_Data.md
     - name: Files, pictures, and hyperlinks
       href: samples/streamlined/09_Edit_Files_Pictures_and_Hyperlinks.md
     - name: Float functional data


### PR DESCRIPTION
Fix two suggestions from the AI review.

A third suggestion relates more to the structure of the docs, in terms of having a single H1 heading on all pages. This will require more changes in the source documentation definitions to resolve, but I will add it to our backlog for fixing by 27 R1.

Tagging @EstherProsperi for information.