### PR TITLE
Update license file link to 2026R1

### DIFF
--- a/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/copyright.md
+++ b/docs/granta-mi/granta-mi-scripting-toolkit/versions/2026.R1.SP00/copyright.md
@@ -42,4 +42,4 @@ third-party software. If you are unable to access the Legal Notice, contact ANSY
 
 Published in the U.S.A.
 
-[View third-party licenses](https://innovationspace.ansys.com/wp-content/uploads/granta/2025R2/miscriptingtoolkit/)
+[View third-party licenses](https://innovationspace.ansys.com/wp-content/uploads/granta/2026R1/miscriptingtoolkit/)


### PR DESCRIPTION
The license file for the v5.0 release wasn't updated to the 2026R1 version. Fix the link.

@AnsMelanie Once this is merged, can it be updated in production?