### PR TITLE
docs(field): document ElementalNodal layout and element-type properties

### DIFF
--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -115,17 +115,20 @@ for a fields container). It interpolates corner-node values onto the mid-side no
 producing a field whose elementary data sizes match the full corner + mid-node
 layout.
 
-#### Homogeneous sub-fields per shape
+#### Homogeneous sub-fields per element type
 
 When downstream code needs to process the data array as a regular block - for
 example reshaping it as `(n_entities, rows_per_entity * components)` - the
 variable-size layout of a mixed-element ElementalNodal field becomes an obstacle.
-The recommended strategy is to **split by shape**: use the
+The recommended strategy is to **split by element type**: use the
 [`split_on_property_type`](../operator-specifications/scoping/split_on_property_type.md)
-operator with the `elshape` property to produce one scoping per shape class
+operator with the `eltype` property to produce one scoping per element type
 (triangles, quads, tets, hexes, ...). Re-evaluating (or rescoping) the result for
-each scoping yields homogeneous-size sub-fields, one per shape, that can each be
-processed as a regular block without per-element bookkeeping.
+each scoping yields homogeneous-size sub-fields, one per element type, that can
+each be processed as a regular block without per-element bookkeeping. Splitting
+on the coarser `elshape` property (solid, shell, beam, point) is not sufficient
+on its own: a single shape class can still mix element types with different node
+counts (for example `tet4` and `hex8` are both solids).
 
 ### Unit
 

--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -44,7 +44,7 @@ The size of elementary data depends on the field's location:
 
 ### ElementalNodal fields and element-type properties
 
-For `Elemental` and `ElementalNodal` fields, the size of each elementary data block
+For `ElementalNodal` fields, the size of each elementary data block
 depends on the **element type** of the entity it describes. Mixed-element meshes
 therefore produce **variable-size** ElementalNodal fields: each element contributes
 `n_nodes_per_element × n_components × n_layers` consecutive values, with no padding

--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -66,18 +66,28 @@ field. This information lives on the [`meshed_region`](./dpf-types.md#meshed-reg
 not on the field. Two element-type properties are central to interpreting the data
 layout:
 
-- **Dimensionality** (`0D`, `1D`, `2D`, `3D` -> point, beam, shell, solid). It
-  governs the geometric role of the element and which nodes carry physically
-  meaningful results.
-- **Second-order flag**. Second-order elements add **mid-side nodes** between the
-  corner nodes. When set, the element contributes additional nodal rows to an
-  ElementalNodal field for those mid-nodes (when the solver file stores values for
-  them).
+- **Shape** (`0D`, `1D`, `2D`, `3D` -> point, beam, shell, solid), exposed on the
+  meshed region as the `elshape` property. It governs the geometric role of the
+  element and which nodes carry physically meaningful results. (Note that
+  `dimensionality` in DPF is a distinct, field-level concept - scalar, vector,
+  tensor - and does not describe element geometry.)
+- **Order**. Second-order (quadratic) element types have **mid-side nodes** in
+  addition to their corner nodes. This is a topology fact of the element type
+  itself.
 
-Dimensionality and second-order are properties of the **element type itself**; they
-are not field-level concepts. The field's `location` only states *where* the data
-sits (`Nodal`, `Elemental`, `ElementalNodal`); it does not encode the element
-shape, order, or node count.
+Shape and order are properties of the **element type**; they are not field-level
+concepts. The field's `location` only states *where* the data sits (`Nodal`,
+`Elemental`, `ElementalNodal`); it does not encode the element shape, order, or
+node count.
+
+Whether an ElementalNodal field defined on a mesh with second-order elements
+actually contains rows for those mid-side nodes is a separate, **field-level**
+property. It is recorded as a boolean flag on the [field definition](#field-definition)
+(`has_midnode_data` in the C++ API). Two ElementalNodal fields can share the same
+support and still differ in how much data they store per second-order element: one
+may carry only corner-node rows, another the full corner + mid-node layout. See
+[Mid-node values and `extend_to_mid_nodes`](#mid-node-values-and-extend_to_mid_nodes)
+below for how to move between the two.
 
 #### Entity ID uniqueness across element types
 

--- a/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
+++ b/docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md
@@ -42,6 +42,81 @@ The size of elementary data depends on the field's location:
 - **Tensor**: 6 or 9 values per entity (e.g., stress: `[σx, σy, σz, τxy, τyz, τxz]`)
 - **ElementalNodal**: All nodal values for the element (e.g., 4-node element with 3 components: 12 values)
 
+### ElementalNodal fields and element-type properties
+
+For `Elemental` and `ElementalNodal` fields, the size of each elementary data block
+depends on the **element type** of the entity it describes. Mixed-element meshes
+therefore produce **variable-size** ElementalNodal fields: each element contributes
+`n_nodes_per_element × n_components × n_layers` consecutive values, with no padding
+between elements.
+
+To locate each entity's data block in the flat array without recomputing per-element
+sizes, every field exposes a **`data_pointer`** array: `data_pointer[i]` is the
+index in the flat `data` array where entity *i*'s elementary data begins. For
+fields where every entity has the same number of components (typical `Nodal`,
+`Elemental`, scalar or 3D-vector cases) the `data_pointer` is **empty** - the
+simple stride `index × elementary_data_size` is sufficient. For variable-size
+fields (mixed-element ElementalNodal, connectivity property fields) it is
+populated and is the canonical way to slice the `data` array per entity without
+walking element types upfront.
+
+The number of rows per element (`n_nodes_per_element` for ElementalNodal, `1` for
+Elemental) is derivable from the element type alone, independently of any specific
+field. This information lives on the [`meshed_region`](./dpf-types.md#meshed-region),
+not on the field. Two element-type properties are central to interpreting the data
+layout:
+
+- **Dimensionality** (`0D`, `1D`, `2D`, `3D` -> point, beam, shell, solid). It
+  governs the geometric role of the element and which nodes carry physically
+  meaningful results.
+- **Second-order flag**. Second-order elements add **mid-side nodes** between the
+  corner nodes. When set, the element contributes additional nodal rows to an
+  ElementalNodal field for those mid-nodes (when the solver file stores values for
+  them).
+
+Dimensionality and second-order are properties of the **element type itself**; they
+are not field-level concepts. The field's `location` only states *where* the data
+sits (`Nodal`, `Elemental`, `ElementalNodal`); it does not encode the element
+shape, order, or node count.
+
+#### Entity ID uniqueness across element types
+
+Element IDs used in the `scoping` of an `Elemental` or `ElementalNodal` field are
+**globally unique within the `MeshedRegion`**, across all element types. A given
+integer ID identifies exactly one element regardless of whether it is a tetrahedron,
+hexahedron, shell, beam, or point. The same uniqueness guarantee applies to node
+IDs in `Nodal` scopings. The scoping's ID list is therefore sufficient on its own to
+locate each entity in the mesh - no element-type lookup is needed to disambiguate
+IDs.
+
+#### Mid-node values and `extend_to_mid_nodes`
+
+When an ElementalNodal field is read from a solver file that produced results at
+both corner and mid-side nodes, the field already contains one row per node per
+element - corner and mid-node rows interleaved per element in the order declared by
+the element's connectivity.
+
+Solver files that only store corner-node values for second-order elements produce
+an ElementalNodal field with corner-node rows only. To obtain a field that also
+carries mid-node rows for downstream consumers that expect them, use the
+[`extend_to_mid_nodes`](../operator-specifications/averaging/extend_to_mid_nodes.md)
+operator (or [`extend_to_mid_nodes_fc`](../operator-specifications/averaging/extend_to_mid_nodes_fc.md)
+for a fields container). It interpolates corner-node values onto the mid-side nodes,
+producing a field whose elementary data sizes match the full corner + mid-node
+layout.
+
+#### Homogeneous sub-fields per shape
+
+When downstream code needs to process the data array as a regular block - for
+example reshaping it as `(n_entities, rows_per_entity * components)` - the
+variable-size layout of a mixed-element ElementalNodal field becomes an obstacle.
+The recommended strategy is to **split by shape**: use the
+[`split_on_property_type`](../operator-specifications/scoping/split_on_property_type.md)
+operator with the `elshape` property to produce one scoping per shape class
+(triangles, quads, tets, hexes, ...). Re-evaluating (or rescoping) the result for
+each scoping yields homogeneous-size sub-fields, one per shape, that can each be
+processed as a regular block without per-element bookkeeping.
+
 ### Unit
 
 The **unit** defines the measurement system for all values in the field. All data in a field shares the same unit.


### PR DESCRIPTION
﻿## Summary

Adds a new section "ElementalNodal fields and element-type properties" to the
DPF Theory Guide page on Fields, addressing common confusion about how
`Elemental` and `ElementalNodal` field data is laid out for mixed-element
meshes.

## Topics covered

- **Variable-size data layout**: each element in an ElementalNodal field
  contributes `n_nodes_per_element × n_components × n_layers` consecutive
  values with no padding; the per-element row count is derivable from the
  element type alone.
- **Element-type properties as `meshed_region` concerns**: dimensionality
  (`0D`/`1D`/`2D`/`3D` = point/beam/shell/solid) and the second-order flag
  belong to the element type, not to the field. The field's `location`
  records only where the data sits, not the element shape, order, or node
  count.
- **Entity ID uniqueness across element types**: element IDs in
  `Elemental`/`ElementalNodal` scopings are globally unique within a
  `MeshedRegion` regardless of element type; the scoping's ID list alone
  is enough to locate each entity.
- **Mid-node values and `extend_to_mid_nodes`**: when a solver file stores
  only corner-node values for second-order elements, the `extend_to_mid_nodes`
  (and `extend_to_mid_nodes_fc`) operator interpolates onto mid-side nodes so
  downstream consumers get the full corner + mid-node layout.
- **Homogeneous sub-fields per shape**: `split_on_property_type` with the
  `elshape` property is the recommended strategy to obtain homogeneous-size
  sub-fields suitable for uniform-block processing.

## Affected files

- `docs/dpf/dpf-framework/versions/2027.R1.SP00/core-concepts/field.md`

## Validation

- All relative links resolve to existing files in the same release tree.
- `#meshed-region` anchor confirmed in the matching `dpf-types.md`.
- 65 lines added, no deletions; surrounding sections untouched.
