### PR TITLE
1477693 - Clarify load return values in Integration Node API doc

### DIFF
--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_integration.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_integration.md
@@ -50,8 +50,8 @@ This function is called when opening the node’s edit dialog box. In this funct
 
 **Return Values**
 - List of two elements:
-    - [InputValueDefinition](#table-13-contents-of-inputvaluedefinition)
-    - [OutputValueDefinition](#table-14-contents-of-outputvaluedefinition)
+    - List of [InputValueDefinition](#table-13-contents-of-inputvaluedefinition)
+    - List of [OutputValueDefinition](#table-14-contents-of-outputvaluedefinition)
 
 ### execute
 This function is used to call your solver.


### PR DESCRIPTION
## Summary

- Clarify that the `load` function return-value list elements are each a list of `InputValueDefinition` and `OutputValueDefinition` objects.
- Updates wording under `### load` -> **Return Values** in the Integration Node API doc.

Fixes #1477693

## Test plan

- [ ] Verify the doc set renders correctly on the developer portal
- [ ] Confirm TOC navigation works end-to-end
- [ ] Verify internal cross-links to Table 13 and Table 14 resolve correctly