### PR TITLE
27R1 Step 1a - Add osl-fmop-solver-api 2027.R1.SP00 baseline

### DIFF
--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/_f_m_o_p_solver_8c.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/_f_m_o_p_solver_8c.md
@@ -1,0 +1,519 @@
+# File FMOPSolver.c
+
+
+**Location**: `doc/FMOPSolver.c`
+
+
+## Includes
+
+* <stdlib.h>
+* <stdio.h>
+* <string.h>
+* include/sos_capi_script.h
+* include/fmop_solver.h
+
+
+```mermaid
+graph LR
+1["doc/FMOPSolver.c"]
+click 1 "_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c"
+1 --> 2
+1 --> 3
+1 --> 4
+1 --> 5
+1 --> 6
+
+6["include/fmop_solver.h"]
+
+5["include/sos_capi_script.h"]
+
+3["stdio.h"]
+
+2["stdlib.h"]
+
+4["string.h"]
+
+```
+
+
+## Macros
+
+<a id="_f_m_o_p_solver_8c_1ae7c3138bceee1d3e419dadbea1c80fa5"></a>
+### Macro REF_NUM_PARAMS
+
+![][public]
+
+
+```cpp
+#define REF_NUM_PARAMS 6
+```
+
+## Functions
+
+<a id="_f_m_o_p_solver_8c_1af3ed9c200de85b53c94cd18764b246a2"></a>
+### Function main
+
+![][public]
+
+
+```cpp
+int main(int argc, char *const argv[])
+```
+
+
+FMOPSolver interface example using the sos_demo database provided with your oSP3D installation.
+
+**copyright**\
+2026, Ansys Austria GmbH
+
+## Example
+```cpp
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "include/sos_capi_script.h"
+#include "include/fmop_solver.h"
+
+int main ( int argc, char* const argv[] )
+{
+    FMOP_initializeLibrary();
+
+    // - - - - - - - - - - - -
+    // S T A R T: USER INPUT
+    // - - - - - - - - - - - -
+
+    int num_errors = 0;
+
+    char user_lic_path[10000];
+    strcpy(user_lic_path, argv[0]);
+#ifdef MINGW
+    char delimit = '\\';
+#else
+    char delimit = '/';
+#endif
+    char * last_pos = strrchr( argv[0], delimit ); // pointer to last / or \ in string (after that there is the name of the exe)
+    if (last_pos != NULL)
+    {
+        int count = 0;
+        char * counter = argv[0];
+        while (counter != last_pos)
+        {
+            ++counter;
+            ++count;
+        }
+        strncpy(user_lic_path, argv[0], count);
+        user_lic_path[count] = '\0'; // manual 0-termination required!
+        printf("count: %d\n", count);
+    }
+
+    printf("Search for license in dir %s\n", user_lic_path);
+    printf("argv: %s\n", argv[0]);
+
+    char* db_path = NULL;
+    const char* fmop_ident = "pstrain";
+
+    //
+    // \brief FMOP reference number of active parameters
+    //
+    #define REF_NUM_PARAMS 6
+    const double param_values [ REF_NUM_PARAMS ] = { 43341.092, 134.12064, 0.093418892, 0.042747076, 2.7525392e-09, 58.798039 };
+
+    // - - - - - - - - - - - -
+    // E N D: USER INPUT
+    // - - - - - - - - - - - -
+
+    // Define some further internal global variables
+
+    fmop_license_t feature = fmop_mesh_all;
+    fmop_db_handle_t database = NULL;
+    fmop_handle_t fmop = NULL;
+    char* public_dir = getenv ( "SOS_PUBLIC_DIR" );
+
+    if ( db_path == NULL &&
+         public_dir != NULL )
+    {
+        printf ( "INFO  | Using sos_demo database from public documents dir.\n" );
+
+
+        const char* db_rel_path = "/examples/sos_demo.sdb";
+        db_path = malloc ( strlen (public_dir) + strlen (db_rel_path) + 1 );
+        strcpy ( db_path, public_dir );
+        strcat ( db_path, db_rel_path );
+    }
+
+    {
+        printf ( "INFO  | Acquire licenses\n" );
+
+        if ( argv[0] && FMOP_appendLicenseSearchPath ( user_lic_path ) )
+//        if ( user_lic_path && FMOP_appendLicenseSearchPath ( user_lic_path ) )
+            fprintf ( stderr, "ERROR | Appending an additional license search path. "
+                              "The library reports:\n%s\n", FMOP_getLastErrorString () );
+
+        if ( FMOP_acquireLicenses ( feature ) )
+        {
+            fprintf ( stderr, "FATAL | Acquiring licenses. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+            return FMOP_getLastErrno ();
+        }
+    }
+
+    fmop_script_handle_t engine = FMOP_globalScriptEngine();
+    if (engine == NULL)
+    {
+        fprintf ( stderr, "FATAL | Cannot get a hendle to Lua interpeter. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+
+    /*
+     We will execute the following code:
+     A = tmath.Matrix({{1,2},{3,4}})
+     B = tmath.Matrix({{1,0},{0,1}})
+     s = 2.0
+     c = "Hello"
+     c2 = c .. " world!"
+     C = A*s+B
+     y = C[{0,0}]
+     -- print(C)
+     -- print(c2)
+     -- print(C[{0,0}])
+     -- print(y)
+    */
+
+    printf ( "INFO  | Start script\n" );
+    if (FMOP_script_execute(engine,"print(\"Start script\");\n"))
+    {
+        fprintf ( stderr, "FATAL | Cannot execute string. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+
+    double A_data[] = {1,3,2,4};
+    double B_data[] = {1,0,0,1};
+    printf ( "INFO  | Create matrix A\n" );
+    if (FMOP_script_createMatrix(engine,"A",2,2,A_data))
+    {
+        fprintf ( stderr, "FATAL | Cannot create matrix A. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+    printf ( "INFO  | Create matrix B\n" );
+    if (FMOP_script_createMatrix(engine,"B",2,2,B_data))
+    {
+        fprintf ( stderr, "FATAL | Cannot create matrix B. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+    printf ( "INFO  | Create number s\n" );
+    if (FMOP_script_createNumber(engine,"s",2.0))
+    {
+        fprintf ( stderr, "FATAL | Cannot create number s. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+    printf ( "INFO  | Create string c\n" );
+    if (FMOP_script_createString(engine,"c","Hello"))
+    {
+        fprintf ( stderr, "FATAL | Cannot create string c. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+    printf ( "INFO  | Execute some script\n" );
+    char script[] = "c2 = c .. \" world!\";\n C = A*s+B;\n y = C[{0,0}]; \n";
+    if (FMOP_script_execute(engine,script))
+    {
+        fprintf ( stderr, "FATAL | Cannot execute string. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+    printf ( "INFO  | Get matrix C\n" );
+    int C_rows = 0;
+    int C_cols = 0;
+    const double * C_data = NULL;
+    if (FMOP_script_getMatrix(engine,"C",&C_rows,&C_cols,&C_data))
+    {
+        fprintf ( stderr, "FATAL | Cannot get matrix C. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+
+    printf ( "INFO  | Get number y\n" );
+    double y_data = 0;
+    if (FMOP_script_getNumber(engine,"y",&y_data))
+    {
+        fprintf ( stderr, "FATAL | Cannot get number y. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+
+    printf ( "INFO  | Get string c2\n" );
+    const char * c2_data = NULL;
+    if (FMOP_script_getString(engine,"c2",&c2_data))
+    {
+        fprintf ( stderr, "FATAL | Cannot get string c2. The library reports:\n%s\n",
+                  FMOP_getLastErrorString () );
+        return FMOP_getLastErrno ();
+    }
+
+    if (!FMOP_script_identExists(engine,"y"))
+    {
+        fprintf ( stderr, "ERROR | The ident y does not exist." );
+        ++num_errors;
+    }
+
+    {
+        printf ( "INFO  | Load the oSP3D demo database\n" );
+
+//        if ( FMOP_loadDbFile ( & database, db_path ) )
+        if ( FMOP_loadDbFileWMesh ( & database, db_path ) )
+        {
+            fprintf ( stderr, "FATAL | Loading the oSP3D demo database. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+            return FMOP_getLastErrno ();
+        }
+    }
+
+    {
+        printf ( "INFO  | Query FMOP idents and load the '%s' element data FMOP\n", fmop_ident );
+
+        char** fmop_idents = NULL;
+        size_t num_idents = 0;
+
+        if ( FMOP_getModelIdents ( database, fmop_node_data, & fmop_idents, & num_idents ) )
+            fprintf ( stderr, "ERROR | Querying available node data FMOP model idents. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+
+        // Delete and reset fmop_idents before passing it into the next call
+        FMOP_releaseIdents ( & fmop_idents, & num_idents );
+
+        if ( FMOP_getModelIdents ( database, fmop_element_data, & fmop_idents, & num_idents ) )
+        {
+            fprintf ( stderr, "FATAL | Querying available element data FMOP model idents. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+            return FMOP_getLastErrno ();
+        }
+
+        // Delete and reset fmop_idents before passing it into the next call
+        FMOP_releaseIdents ( & fmop_idents, & num_idents );
+
+        if ( FMOP_getModelIdentsDim ( database, fmop_element_data, & num_idents ) )
+            fprintf ( stderr, "ERROR | Querying dimension of available element data FMOP model idents. The library "
+                      "reports:\n%s\n", FMOP_getLastErrorString () );
+
+        const char * ident = NULL;
+        size_t i;
+        for ( i = 0; i < num_idents; ++i )
+        {
+            ident = FMOP_getModelIdent ( database, fmop_element_data, i );
+            if ( FMOP_getLastErrno() )
+                fprintf ( stderr, "ERROR | Querying the %zd. of available element data FMOP model idents. The library "
+                          "reports:\n%s\n", i, FMOP_getLastErrorString () );
+            fprintf ( stdout, "DEBUG |   fmop_ident [%zd] : %s\n", i, ident );
+        }
+
+        if ( FMOP_getModel ( database, fmop_element_data, fmop_ident, & fmop ) )
+        {
+            fprintf ( stderr, "FATAL | Getting the '%s' FMOP model. The library reports:\n%s\n",
+                      fmop_ident, FMOP_getLastErrorString () );
+            return FMOP_getLastErrno ();
+        }
+    }
+
+    {
+        printf ( "INFO  | Query properties of '%s' FMOP\n", fmop_ident );
+
+        {
+            printf ( "INFO  | Get parameter idents\n" );
+
+            char** param_idents = NULL;
+            size_t num_idents = 0;
+
+            if ( FMOP_getModelParamIdents ( fmop, & param_idents, & num_idents ) )
+                fprintf ( stderr, "ERROR | Querying parameter idents. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+
+            if ( FMOP_getModelParamIdentsDim ( fmop, & num_idents ) )
+                fprintf ( stderr, "ERROR | Querying dimension of parameter idents. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+
+            const char* param_ident = NULL;
+            size_t i;
+            for ( i = 0; i < num_idents; ++i )
+            {
+                param_ident = FMOP_getModelParamIdent ( fmop, i );
+                if ( FMOP_getLastErrno() )
+                    fprintf ( stderr, "ERROR | Querying the %zd. parameter ident. The library reports:\n%s\n",
+                              i, FMOP_getLastErrorString () );
+                fprintf ( stdout, "DEBUG |   param_ident [%zd] : %s\n", i, param_ident );
+            }
+        }
+
+        {
+            fprintf(stdout,  "INFO | Test mesh connectivity\n" );
+            unsigned int i=0;
+
+            unsigned int num_elements_at;
+            if (FMOP_getNumElementsAtNode ( fmop, 100, & num_elements_at ) )
+            {
+                fprintf ( stderr, "FATAL | Error querying connectivity. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+                return FMOP_getLastErrno ();
+            }
+            unsigned int * elements_at = NULL;
+            elements_at = malloc( sizeof(unsigned int)*(num_elements_at+1));
+            if (FMOP_getElementsAtNode ( fmop, 100, elements_at ) )
+            {
+                fprintf ( stderr, "FATAL | Error querying connectivity. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+                return FMOP_getLastErrno ();
+            }
+            for (i=0; i<num_elements_at; ++i)
+                fprintf ( stdout, "element #i %d: %d\n", i, elements_at[i]);
+            unsigned test_elem = elements_at[0];
+            free(elements_at);
+
+            unsigned int num_nodes_at;
+            if (FMOP_getNumNodesAtElement( fmop, test_elem, & num_nodes_at ) )
+            {
+                fprintf ( stderr, "FATAL | Error querying connectivity. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+                return FMOP_getLastErrno ();
+            }
+            unsigned int * nodes_at = NULL;
+            nodes_at = malloc( sizeof(unsigned int)*(num_nodes_at+1));
+            if (FMOP_getElementsAtNode ( fmop, test_elem, nodes_at ) )
+            {
+                fprintf ( stderr, "FATAL | Error querying connectivity. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+                return FMOP_getLastErrno ();
+            }
+            for (i= 0; i<num_nodes_at; ++i)
+                fprintf ( stdout, "node #i %d: %d\n", i, nodes_at[i]);
+            free(nodes_at);
+
+            const char * element_ident = FMOP_getElementTypeIdent(fmop, test_elem);
+            if (element_ident == NULL)
+            {
+                fprintf ( stderr, "FATAL | Error querying connectivity. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+                return FMOP_getLastErrno ();
+            }
+            fprintf(stdout, "Element ident of element #%d: %s\n", test_elem, element_ident );
+
+        }
+
+
+        {
+            printf ( "INFO  | Query active scalar input parameter boundaries defined by the applied DOE\n" );
+
+            double bounds [ REF_NUM_PARAMS ];
+            if ( FMOP_getParamLowerBounds ( fmop, bounds ) )
+                fprintf ( stderr, "ERROR | Querying lower boundary values of active scalar input parameters. "
+                                  "The library reports:\n%s\n", FMOP_getLastErrorString () );
+
+            if ( FMOP_getParamUpperBounds ( fmop, bounds ) )
+                fprintf ( stderr, "ERROR | Querying upper boundary values of active scalar input parameters. "
+                                  "The library reports:\n%s\n", FMOP_getLastErrorString () );
+
+            size_t i;
+            for ( i = 0; i < REF_NUM_PARAMS; ++i )
+                printf ( "INFO  | %02lu : %G\n", i, bounds [i] );
+        }
+
+        {
+            printf ( "INFO  | Query FCoP values of active scalar input parameters\n" );
+
+            double fcop = 0.;
+            if ( FMOP_getModelTotalAvgFCoP ( fmop, & fcop ) )
+                fprintf ( stderr, "ERROR | Querying the total average FCoP value. The library reports:\n%s\n",
+                          FMOP_getLastErrorString () );
+
+            double fcops [ REF_NUM_PARAMS ];
+            if ( FMOP_getModelAvgFCoP ( fmop, fcops ) )
+                fprintf ( stderr, "ERROR | Querying average FCoP values per active scalar input parameter. The library "
+                                  "reports:\n%s\n", FMOP_getLastErrorString () );
+        }
+    }
+
+    {
+        printf ( "INFO  | Approximate field\n" );
+
+        size_t num_mesh_items = 0;
+        if ( FMOP_getModelDim ( fmop, & num_mesh_items ) )
+        {
+            fprintf ( stderr, "FATAL | Querying number of mesh idents. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+            return FMOP_getLastErrno ();
+        }
+
+        printf ( "INFO  |   Number of mesh items : %lu\n", num_mesh_items );
+
+        unsigned int * part_ids = NULL;
+        unsigned int item_ids [ num_mesh_items ];
+
+        if ( FMOP_getDataPointIndices ( fmop, part_ids, item_ids ) )
+            fprintf ( stderr, "ERROR |   Querying data point indices. The library reports:\n%s\n", FMOP_getLastErrorString () );
+
+        double x_coors [ num_mesh_items ];
+
+        if ( FMOP_getDataPointCoors ( fmop, 0, x_coors ) )
+            fprintf ( stderr, "ERROR |   Querying data point x-coordinates. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+
+        double coors [ 3 * num_mesh_items ];
+
+        if ( FMOP_getDataPointCoors ( fmop, 3, coors ) )
+            fprintf ( stderr, "ERROR |   Querying data point coordinates. The library reports:\n%s\n",
+                      FMOP_getLastErrorString () );
+
+        double approx_field [ num_mesh_items ];
+
+        if ( FMOP_approxField ( fmop, param_values, approx_field ) )
+            fprintf ( stderr, "ERROR | Approximating the field for a given set of scalar input parameters. The library "
+                      "reports:\n%s\n", FMOP_getLastErrorString () );
+
+    }
+
+    {
+        printf ( "INFO  | Change log level\n" );
+        FMOP_setLogLevel (4) //4: log all messages
+    }
+
+    {
+        printf ( "INFO  | Release data and licenses\n" );
+
+        if ( FMOP_releaseModel ( & fmop ) )
+            fprintf ( stderr, "ERROR | Releasing FMOP model. The library reports:\n%s\n", FMOP_getLastErrorString () );
+        if ( FMOP_releaseDb ( & database ) )
+            fprintf ( stderr, "ERROR | Releasing database. The library reports:\n%s\n", FMOP_getLastErrorString () );
+        if ( FMOP_releaseLicenses () )
+            fprintf ( stderr, "ERROR | Releasing licenses. The library reports:\n%s\n", FMOP_getLastErrorString () );
+    }
+
+    {
+        printf ( "INFO  | Miscellaneous\n" );
+
+        const char* version_string = FMOP_getVersionString();
+        if ( version_string == NULL )
+            fprintf ( stderr, "ERROR | Error querying version string.\n" );
+        else
+            printf ( "INFO  | %s\n", version_string );
+    }
+
+    {
+        printf ( "INFO | Unload library\n");
+
+        FMOP_unloadLibrary();
+    }
+
+    return num_errors;
+}
+
+// (c) 2019, Ansys Austria GmbH (proprietary license)
+```
+
+
+[C++]: https://img.shields.io/badge/language-C%2B%2B-blue (C++)
+[public]: https://img.shields.io/badge/-public-brightgreen (public)

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/_f_m_o_p_solver_8h.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/_f_m_o_p_solver_8h.md
@@ -1,0 +1,44 @@
+# File FMOPSolver.h
+
+
+**Location**: `FMOPSolver.h`
+
+
+## Includes
+
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h)
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h)
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h)
+
+
+```mermaid
+graph LR
+1["FMOPSolver.h"]
+click 1 "_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h"
+1 --> 2
+1 --> 3
+1 --> 4
+
+2["fmop_solver.h"]
+click 2 "fmop_solver.md#fmop__solver_8h"
+2 --> 3
+
+3["sos_capi_common.h"]
+click 3 "sos__capi__common_8h.md#sos__capi__common_8h"
+
+4["sos_capi_script.h"]
+click 4 "sos__capi__script_8h.md#sos__capi__script_8h"
+4 --> 3
+
+```
+
+
+## Source
+
+
+```cpp
+#include "fmop_solver.h"  
+#include "sos_capi_common.h"  
+#include "sos_capi_script.h"
+
+```

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/changelog.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/changelog.md
@@ -1,0 +1,13 @@
+# Changelog
+
+## 2027 R1
+
+No documentation changes for this release.
+
+## 2026 R1
+
+Released 2025-11-01.
+
+### Added
+
+- Initial publication of FMOPSolver API on the Ansys Developer portal.

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/deprecated.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/deprecated.md
@@ -1,0 +1,17 @@
+# Deprecated list
+
+
+
+<b>Member [FMOP_appendLicenseSearchPath](sos__capi__common_8h.md#sos__capi__common_8h_1a7086f4db3e639526b2b7fe9ce9392a24)  (const char *abs_path)</b>:
+
+<a id="deprecated_1_deprecated000001"></a>
+Since 2022 R2. Will be removed in 2023 R1
+
+<!--
+**TODO**:
+
+* `location  {"type":"element","name":"location","attributes":{"file":"deprecated"},"children":[]}`
+-->
+
+[C++]: https://img.shields.io/badge/language-C%2B%2B-blue (C++)
+[public]: https://img.shields.io/badge/-public-brightgreen (public)

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/docfx.json
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/docfx.json
@@ -1,0 +1,12 @@
+{
+    "build": {
+        "globalMetadata": {
+            "title": "optiSLang FMOPSolver API 2027 R1",
+            "summary": "C API reference for the optiSLang FMOP solver, 2027 R1.",
+            "version": "2027 R1",
+            "product": "optiSLang",
+            "programming language": "C++",
+            "physics": "Connect"
+        }
+    }
+}

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/file_contents.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/file_contents.md
@@ -1,0 +1,7 @@
+# Files
+
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h)
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h): C-API for utility functions (load/unload library, license management, error handling)
+* [FMOPSolver.c](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c)
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h): C-API to run oSP3D scripts and exchange basic data.
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h): C-API to evaluate a Field Meta model of Optimal Prognosis (FMOP)

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/file_index.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/file_index.md
@@ -1,0 +1,12 @@
+# Index of Files
+
+## F
+
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h): C-API to evaluate a Field Meta model of Optimal Prognosis (FMOP)
+* [FMOPSolver.c](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c)
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h)
+
+## S
+
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h): C-API for utility functions (load/unload library, license management, error handling)
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h): C-API to run oSP3D scripts and exchange basic data.

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/fmop_solver.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/fmop_solver.md
@@ -1,0 +1,1744 @@
+# File fmop_solver.h
+
+**Location**: `fmop_solver.h`
+
+* This API follows the _Basic_ exception safety _rule_. If any of the operations fail, the original data, e.g. the fmop_handle*_t, might have been overwritten, but there should be no resource leak.
+
+* Return values are typically of type [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec). To get a human readalbe interpretation forward this value to [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) or call [FMOP_getLastErrorString()](sos__capi__common_8h.md#sos__capi__common_8h_1aa79c50f0e38654fc5bf42e052b229748). More information can be found in the Error Handling section
+
+* Log messages from the oSP3D kernel are all bufferd in an internal variable. Unless otherwise stated in a function description, this internal variable gets reset(!) right at the beginning of each function call. Therefore, the user is forced into fetching all log messages of interest before proceeding.
+
+
+
+> **Warning** \
+Concurrent library calls are NOT supported
+
+
+> **Warning** \
+Unless otherwise stated, every function call overwrites any log message of any previous function call
+
+## Includes
+
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h)
+
+
+```mermaid
+graph LR
+1["fmop_solver.h"]
+click 1 "fmop_solver.md#fmop__solver_8h"
+1 --> 2
+
+2["sos_capi_common.h"]
+click 2 "sos__capi__common_8h.md#sos__capi__common_8h"
+
+```
+
+
+## Included by
+
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h)
+
+
+```mermaid
+graph RL
+2["FMOPSolver.h"]
+click 2 "_f_m_o_p_solver_8h.md#source"
+
+1["fmop_solver.h"]
+click 1 "fmop_solver.md#fmop__solver_8h"
+2 --> 1
+
+```
+
+
+## Create / Initialize Data Objects
+
+API handling data object life time
+
+<a id="fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc"></a>
+### Function FMOP_getModel
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModel(fmop_db_handle_t database, fmop_dataobject_types data_type, const char *const fmop_ident, fmop_handle_t *fmop)
+```
+
+
+Loads a [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object from the database given.
+
+**Parameters**:
+
+* **database**: The already initialized database handle
+* **data_type**: The data type in question
+* **fmop_ident**: The FMOP ident to be loaded from the database given
+* **fmop**: On input _*fmop_ must point to NULL. Returns an initialized fmop handle to the requested _fmop_ident_ on output. Pointer ownership is up to the caller after return. Call FMOP_releaseModel ([fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) *) at the end of lifetime.
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_ident argument is a NULL pointer
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the _fmop_ argument does not hold a NULL pointer on input
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to load a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_model_missing](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becaedda7a6dbd4f5dd3eedecca9ec7dc1e9) if the handle initialization fails
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that FMOP_initialize() returned fmop_model_success
+
+
+**Returns**:
+
+A success indicator. Call FMOP_getErrnoString to get a human readable representation
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) **database**
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) **data_type**
+* const char *const **fmop_ident**
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) * **fmop**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a0ad6b75479bad22c19004ccf3078f235"></a>
+### Function FMOP_loadDbBuf
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_loadDbBuf(fmop_db_handle_t *database, const char *buffer, size_t length)
+```
+
+
+Initializes a [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) object from a previously saved optiSLang Postprocessing 3D (oSP3D) database array.
+
+> **Warning** \
+Draft only. CURRENTLY NOT IMPLEMENTED. Returns fmop_not_implemented
+
+
+**Parameters**:
+
+* **database**: On input _*database_ must point to NULL. Returns an initialized handle to the loaded database on ouptut. The database of the returned handle has been set to the buffer content given. Pointer ownership is up to the caller after return. Call FMOP_releaseDb ([fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) *) at the end of lifetime.
+* **buffer**: A character array
+* **length**: The length of the character array
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database argument does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the buffer or length argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to load a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if the database handle has been initialized successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation.
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) * **database**
+* const char * **buffer**
+* size_t **length**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1ab77fe12cab675bb1d50232deacf23a34"></a>
+### Function FMOP_loadDbBufWMesh
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_loadDbBufWMesh(fmop_db_handle_t *database, const char *buffer, size_t length)
+```
+
+
+Initializes a [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) object from a previously saved optiSLang Postprocessing 3D (oSP3D) database array This function also builds up all internal data structures needed to represent FEM meshes. Hence it may need more CPU time and RAM.
+
+> **Warning** \
+Draft only. CURRENTLY NOT IMPLEMENTED. Returns fmop_not_implemented
+
+
+**Parameters**:
+
+* **database**: On input _*database_ must point to NULL. Returns an initialized handle to the loaded database on ouptut. The database of the returned handle has been set to the buffer content given. Pointer ownership is up to the caller after return. Call FMOP_releaseDb ([fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) *) at the end of lifetime.
+* **buffer**: A character array
+* **length**: The length of the character array
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database argument does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the buffer or length argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to load a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if the database handle has been initialized successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation.
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) * **database**
+* const char * **buffer**
+* size_t **length**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1adf36057836bc12095f01665fa068ba4c"></a>
+### Function FMOP_loadDbFile
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_loadDbFile(fmop_db_handle_t *database, const char *path)
+```
+
+
+Initializes a [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) object from a previously saved optiSLang Postprocessing 3D (oSP3D) database.
+
+**Parameters**:
+
+* **database**: On input _*database_ must point to NULL. Returns an initialized handle to the loaded database on ouptut. The database of the returned handle has been set to the content of the file path given. Pointer ownership is up to the caller after return. Call FMOP_releaseDb ([fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) *) at the end of lifetime.
+* **path**: The path to the oSP3D database file as a NULL terminated character array
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database argument does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the path argument doesn't point to an existing file
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to load a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if the [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) has been initialized successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation.
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) * **database**
+* const char * **path**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1ab3f6b6b4a84878f3c774a12a2b4cf958"></a>
+### Function FMOP_loadDbFileWMesh
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_loadDbFileWMesh(fmop_db_handle_t *database, const char *path)
+```
+
+
+Initializes a [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) object from a previously saved optiSLang Postprocessing 3D (oSP3D) database This function also builds up all internal data structures needed to represent FEM meshes. Hence it may need more CPU time and RAM.
+
+**Parameters**:
+
+* **database**: On input _*database_ must point to NULL. Returns an initialized handle to the loaded database on ouptut. The database of the returned handle has been set to the content of the file path given. Pointer ownership is up to the caller after return. Call FMOP_releaseDb ([fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) *) at the end of lifetime.
+* **path**: The path to the oSP3D database file as a NULL terminated character array
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database argument does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the path argument doesn't point to an existing file
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to load a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if the [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) has been initialized successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation.
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) * **database**
+* const char * **path**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1af36d28d4c5c718284a0f4236f2740e06"></a>
+### Function FMOP_releaseDb
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_releaseDb(fmop_db_handle_t *database)
+```
+
+
+Releases a [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) object and dedicated memory.
+
+**Parameters**:
+
+* **database**: The [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) to be released. Set to NULLptr on return.
+
+
+**Returns**:
+
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Parameters**:
+
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) * **database**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a37bdee678571cd855ac0bb10675b1d8c"></a>
+### Function FMOP_releaseIdents
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_releaseIdents(char ***const idents, const size_t *num_idents)
+```
+
+
+An auxiliary function to releases an array of char arrays and dedicated memory.
+
+**Parameters**:
+
+* **idents**: A pointer to an array of char arrays. Set to NULLptr on return.
+* **num_idents**: An already initialized scalar data object. Contains the number of idents in the char** array [] given
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the array argument is a NULL pointer or if *array points to NULL
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_idents argument is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Parameters**:
+
+* char ***const **idents**
+* const size_t * **num_idents**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a3ad01c460ed6e409b79e258a523d0bf9"></a>
+### Function FMOP_releaseModel
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_releaseModel(fmop_handle_t *fmop)
+```
+
+
+Releases a [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) object and dedicated memory.
+
+**Parameters**:
+
+* **fmop**: The [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) to be released. Set to NULLptr on return.
+
+
+**Returns**:
+
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) * **fmop**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+## Query properties
+
+API to query idents and properties of a "Field Meta Model of Optimal Prognosis" (FMOP)
+
+<a id="fmop__solver_8h_1a878106f886ca5f1ce112e6c5e238d80e"></a>
+### Function FMOP_getDataDim
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getDataDim(const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t *num_mesh_items)
+```
+
+
+Returns the size of the FCoP vector, aka the number of mesh items.
+
+**Parameters**:
+
+* **database**: A successfully initialized [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) data object
+* **data_type**: The data type to be queried (node, element, scalar)
+* **num_mesh_items**: An already initialized scalar data object. Contains the size of the data vectors for the givvemn data type on return
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_mesh_items pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that FMOP_initialize() returned fmop_model_success
+
+
+
+**Parameters**:
+
+* const [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) **database**
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) **data_type**
+* size_t * **num_mesh_items**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a535bee00c4d200d31fdf4118e49c1f05"></a>
+### Function FMOP_getDataPointCoors
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getDataPointCoors(fmop_handle_t fmop, char axis, double *coors)
+```
+
+
+Returns the cartesian data point coordinates for each data point.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **axis**: Controls coordinate output. The following integers are accepted:
+* 0... asks for x-coordinates only
+
+* 1... asks for y-coordinates only
+
+* 2... asks for z-coordinates only
+
+* 3... asks for x-, y- and z-coordinates
+* **coors**: An already initialized array of size `formula {"type":"element","name":"formula","attributes":{"id":"0"},"children":[{"type":"text","text":"$ ( 1 + \\lfloor \\frac{\\mathit{axis}}{3} \\rfloor ) * \\mathit{num_mesh_items} $"}]}`. Call [FMOP_getModelDim()](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65) to get _num_mesh_items_. On output contains the following coordinate values:
+* finite element nodes for an FMOP of type [fmop_node_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75aaf0fb275c161febc56c4f10e62987049)
+
+* finite elements using their center coordinate in space for an FMOP of type [fmop_element_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a1ec31fe31f3b8a9fd9dd902b014499ef)
+
+* an FMOP of type [fmop_scalar_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a16a14aa0d55901638e165fb3a39b3870) invokes an [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) error Follows the scheme: `formula {"type":"element","name":"formula","attributes":{"id":"1"},"children":[{"type":"text","text":"$ \\mathit{coors} \\lbrack k+ \\mathit{axis} \\bmod 3 \\rbrack $"}]}` with <br/>
+ k...internal mesh item ident, e.g. internal signal position, internal element number <br/>
+ Call [FMOP_getDataPointIndices()](fmop_solver.md#fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31) to map internal to external numbering scheme
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the axis parameter is out-of-bounds, or the coors pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+> **Warning** \
+Calling this function for FMOP models of type [fmop_element_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a1ec31fe31f3b8a9fd9dd902b014499ef) multiplies resource consumption!
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* char **axis**
+* double * **coors**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31"></a>
+### Function FMOP_getDataPointIndices
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getDataPointIndices(fmop_handle_t fmop, unsigned int *part_ids, unsigned int *item_ids)
+```
+
+
+Maps internal node/element numbering to the external scheme consisting of part and item ID.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **part_ids**: Either an already initialized array of size num_mesh_items as returned by [FMOP_getModelDim()](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65), or a NULL pointer. Note, most of the meshes consists of a single part only, e.g. signals. If the argument is initialized, it contains the external part IDs on output. A NULL pointer otherwise<br/>
+ 
+```cpp
+external( internal[k] ) = PART_ID [k], item_id [k] 
+```
+ k...mesh item, e.g. signal position, element number
+* **item_ids**: An already initialized array of size num_mesh_items as returned by [FMOP_getModelDim()](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65). On output contains the external node/element ID <br/>
+ 
+```cpp
+external( internal[k] ) = part_id [k], ITEM_ID [k] 
+```
+ k...mesh item, e.g. signal position, element number
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int * **part_ids**
+* unsigned int * **item_ids**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a8ca72d6a865df21ce5a5180475c71cda"></a>
+### Function FMOP_getElementsAtNode
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getElementsAtNode(fmop_handle_t fmop, unsigned int node_idx, unsigned int *elements)
+```
+
+
+Identifies the elements connected to a given node.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **node_idx**: the node index (0.. numNodes). This node index refers to the index in the FMOP data vectors.
+* **elements**: An already initialized array of size as returned by [FMOP_getNumElementsAtNode()](fmop_solver.md#fmop__solver_8h_1a4413f3e2bc5f893b9030631aceb03c54). On output contains the internal element ID that are connected to the given node.
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **node_idx**
+* unsigned int * **elements**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a3eea3398149b5f0f6177ccc4a649ab79"></a>
+### Function FMOP_getElementTypeIdent
+
+![][public]
+
+
+```cpp
+const char * FMOP_getElementTypeIdent(fmop_handle_t fmop, unsigned int element_idx)
+```
+
+
+Identifies the element type ident of a given element.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **element_idx**: the element index (0.. numElements). This element index refers to the index in the FMOP data vectors.
+
+
+**Returns**:
+
+On success the element type identifier at array position num_ident from the database given, othewise an empty string.
+
+
+> Calling this function changes the error number to:
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the param_ident pointer does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the value of num_param given is greater than, or equal to the size of the param_idents char* array []
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise. Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **element_idx**
+
+**Return type**: const char *
+
+<a id="fmop__solver_8h_1a185c515c2fe8b0528ccb5f95f543a3be"></a>
+### Function FMOP_getModelAvgFCoP
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelAvgFCoP(const fmop_handle_t fmop, double *fcops)
+```
+
+
+Returns the Field Coefficients of Prognosis per active scalar input parameter.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **fcops**: An already initialized array of size num_params as returned by FMOP_getModelNumParams() On output contains the average Field Coefficient of Prognosis per active scalar input parameter Follows the scheme: fcops[i] (i..i'th active scalar input parameter).
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the fcops pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* double * **fcops**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65"></a>
+### Function FMOP_getModelDim
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelDim(const fmop_handle_t fmop, size_t *num_mesh_items)
+```
+
+
+Returns the size of the FCoP vector, aka the number of mesh items.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **num_mesh_items**: An already initialized scalar data object. Contains the size of the FCoP vector on return
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_mesh_items pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* size_t * **num_mesh_items**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a9b6e5c7baeb1353a17f5efde188d0d8f"></a>
+### Function FMOP_getModelIdent
+
+![][public]
+
+
+```cpp
+const char * FMOP_getModelIdent(const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t num_ident)
+```
+
+
+Returns the n-th known FMOP identifier from the [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) given.
+
+**Parameters**:
+
+* **database**: A successfully initialized [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) data object
+* **data_type**: The data type in question
+* **num_ident**: Defines the position in the fmop_idents char* array []. Notice that the first element has a position of 0
+
+
+**Returns**:
+
+On succes the FMOP identifier at array position num_ident from the database given, otherwise an empty string. The returned string will be overwritten by this function at the next call and will be destroyed on program termination
+
+
+> Calling this function changes the error number to:
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the fmop_idents pointer does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the value of num_ident given is greater than, or equal to the size of the fmop_idents char* array []
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise. Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) **database**
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) **data_type**
+* size_t **num_ident**
+
+**Return type**: const char *
+
+<a id="fmop__solver_8h_1a22d6e807dc869fa28442d26e29ddbc27"></a>
+### Function FMOP_getModelIdents
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelIdents(const fmop_db_handle_t database, fmop_dataobject_types data_type, char ***const fmop_idents, size_t *num_idents)
+```
+
+
+Returns all known FMOP identifier from the [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) given.
+
+**Parameters**:
+
+* **database**: A successfully initialized [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) data object
+* **data_type**: The data type in question
+* **fmop_idents**: On input _*fmop_idents_ must point to NULL. On return contains all known FMOP identifier from the database given. Pointer ownership is up to the caller after return. Call [FMOP_releaseIdents()](fmop_solver.md#fmop__solver_8h_1a37bdee678571cd855ac0bb10675b1d8c) at the end of life
+* **num_idents**: An already initialized scalar data object. Contains the number of FMOP idents, aka the size of the fmop_idents char* array []
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the fmop_idents pointer does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_idents pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+> Many languages offers the possiblity to call functions from an external C-library, e.g. Java, python and Matlab. If you are running in some limitations due to our tripple pointer requirement, please use the wrapper functions [FMOP_getModelIdentsDim()](fmop_solver.md#fmop__solver_8h_1a600dca69efae1f2eafc63f9f6a0067fc) followed by [FMOP_getModelIdent()](fmop_solver.md#fmop__solver_8h_1a9b6e5c7baeb1353a17f5efde188d0d8f) to query known idents one by one
+
+
+
+**Parameters**:
+
+* const [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) **database**
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) **data_type**
+* char ***const **fmop_idents**
+* size_t * **num_idents**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a600dca69efae1f2eafc63f9f6a0067fc"></a>
+### Function FMOP_getModelIdentsDim
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelIdentsDim(const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t *num_idents)
+```
+
+
+Returns the total number of known FMOP identifiers from the [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) given.
+
+**Parameters**:
+
+* **database**: A successfully initialized [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) data object
+* **data_type**: The data type in question
+* **num_idents**: An already initialized scalar data object. Contains the number of FMOP idents, aka the size of the fmop_idents char* array []
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_idents pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) **database**
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) **data_type**
+* size_t * **num_idents**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1ae2ab3659b0419a9ab56ba3d7722708fb"></a>
+### Function FMOP_getModelParamIdent
+
+![][public]
+
+
+```cpp
+const char * FMOP_getModelParamIdent(const fmop_handle_t fmop, size_t num_param)
+```
+
+
+Returns the n-th active parameter identifier from the fmop handle given.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **num_param**: Defines the position in the fmop_idents char* array []. Notice that the first element has a position of 0
+
+
+**Returns**:
+
+On success the parameter identifier at array position num_ident from the database given, othewise an empty string. The returned string will be overwritten by this function at the next call and will be destroyed on program termination
+
+
+> Calling this function changes the error number to:
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the database or fmop_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the param_ident pointer does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the value of num_param given is greater than, or equal to the size of the param_idents char* array []
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise. Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* size_t **num_param**
+
+**Return type**: const char *
+
+<a id="fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f"></a>
+### Function FMOP_getModelParamIdents
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelParamIdents(const fmop_handle_t fmop, char ***const param_idents, size_t *num_params)
+```
+
+
+Returns all active scalar inputer parameters for the fmop handle given.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **param_idents**: Requires a NULL pointer on input. On return contains all active scalar input parameters used in the fmop handle given. Pointer ownership is up to the caller after return. Call [FMOP_releaseIdents()](fmop_solver.md#fmop__solver_8h_1a37bdee678571cd855ac0bb10675b1d8c) at the end of life
+* **num_params**: An already initialized scalar data object. Contains the number of active scalar input parameters used in the fmop handle given, aka the size of the param_idents char* array []
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop or param_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the param_idents pointer does not hold a NULL pointer on input
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_params pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+> Many languages offers the possiblity to call functions from an external C-library, e.g. Java, python and Matlab. If you are running in some limitations due to our tripple pointer requirement, please use the wrapper functions [FMOP_getModelParamIdentsDim()](fmop_solver.md#fmop__solver_8h_1adabef430a391d15eb077fe30e134f368) followed by [FMOP_getModelParamIdent()](fmop_solver.md#fmop__solver_8h_1ae2ab3659b0419a9ab56ba3d7722708fb) to query known idents one by one
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* char ***const **param_idents**
+* size_t * **num_params**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1adabef430a391d15eb077fe30e134f368"></a>
+### Function FMOP_getModelParamIdentsDim
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelParamIdentsDim(const fmop_handle_t fmop, size_t *num_params)
+```
+
+
+Returns the total number of active parameter identifiers from the fmop handle given.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **num_params**: An already initialized scalar data object. Contains the number of active scalar input parameters used in the fmop handle given, aka the size of the param_idents char* array []
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop or param_idents arguments is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the num_params pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* size_t * **num_params**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a1ff6f33cf199015b78c5837e40d90f42"></a>
+### Function FMOP_getModelTotalAvgFCoP
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getModelTotalAvgFCoP(const fmop_handle_t fmop, double *fcop)
+```
+
+
+Returns the total average Field Coefficient of Prognosis for the fmop handle given.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **fcop**: An already initialized scalar data object on input. On output contains the total average Field Coefficient of Prognosis
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the fcop pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* double * **fcop**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a03080c2458b8c03eb85ce9eb97926711"></a>
+### Function FMOP_getNodesAtElement
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getNodesAtElement(fmop_handle_t fmop, unsigned int element_idx, unsigned int *nodes)
+```
+
+
+Identifies the nodes connected to a given element.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **element_idx**: the element index (0.. numElements). This element index refers to the index in the FMOP data vectors.
+* **nodes**: An already initialized array of size as returned by [FMOP_getNumNodesAtElement()](fmop_solver.md#fmop__solver_8h_1a031be0f125c4fbeb450f03bb960e207d). On output contains the internal node ID that are connected to the given element.
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **element_idx**
+* unsigned int * **nodes**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a4413f3e2bc5f893b9030631aceb03c54"></a>
+### Function FMOP_getNumElementsAtNode
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getNumElementsAtNode(fmop_handle_t fmop, unsigned int node_idx, unsigned int *num_elements)
+```
+
+
+Identifies the elements connected to a given node.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **node_idx**: the node index (0.. numNodes). This node index refers to the index in the FMOP data vectors.
+* **num_elements**: a pointer to an unsigned integer number. On output it will contain the number of connected elements.
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **node_idx**
+* unsigned int * **num_elements**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a031be0f125c4fbeb450f03bb960e207d"></a>
+### Function FMOP_getNumNodesAtElement
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getNumNodesAtElement(fmop_handle_t fmop, unsigned int element_idx, unsigned int *num_nodes)
+```
+
+
+Identifies the nodes connected to a given element.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **element_idx**: the element index (0.. numElements). This element index refers to the index in the FMOP data vectors.
+* **num_nodes**: a pointer to an unsigned integer number. On output it will contain the number of connected nodes.
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **element_idx**
+* unsigned int * **num_nodes**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1abaed2ac2af6a304f8356e51b9cb98442"></a>
+### Function FMOP_getParamLowerBounds
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getParamLowerBounds(const fmop_handle_t fmop, double *lower_bounds)
+```
+
+
+Returns lower bound values of input parameters used to train the FMOP, aka the lower bound values of Design of Experiment input parameters.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **lower_bounds**: An already initialized array of size num_params as returned by [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) On output contains the vector of lower bound values of all active scalar input parameters used to train the FMOP, e.g. lower_bounds[j] (j..index of the active scalar input parameter).
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the lower_bounds pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* double * **lower_bounds**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a301cfcf26e28ec7ba4b2c730facb679c"></a>
+### Function FMOP_getParamUpperBounds
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_getParamUpperBounds(const fmop_handle_t fmop, double *upper_bounds)
+```
+
+
+Returns upper bound values of input parameters used to train the FMOP, aka the upper bound values of Design of Experiment input parameters.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **upper_bounds**: An already initialized array of size num_params as returned by [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) On output contains the vector of upper bound values of all active scalar input parameters used to train the FMOP, e.g. upper_bounds[j] (j..index of the active scalar input parameter).
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the upper_bounds pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise.
+
+
+**Returns**:
+
+Call FMOP_getErrnoString to get a human readable representation
+
+
+> Assumes that [FMOP_getModel()](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) returned fmop_success
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* double * **upper_bounds**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a1ff1451cc5f1c6cefa7a67c6a906d653"></a>
+### Function FMOP_isNodePartOfBoundary
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_isNodePartOfBoundary(fmop_handle_t fmop, unsigned int node_idx, unsigned int *is_part_of_boundary)
+```
+
+
+Identifies if the given node is on the surface.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **node_idx**: the node index (0.. numNodes). This node index refers to the index in the FMOP data vectors.
+* **is_part_of_boundary**: a pointer to an unsigned integer number. On output it will contain
+* 1 if the node is on the boundary
+
+* 0 if the node is not on the boundary
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop argument is a NULL pointer
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the item_id pointer is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Parameters**:
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* unsigned int **node_idx**
+* unsigned int * **is_part_of_boundary**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+## Operations
+
+API used to evalute a Field Meta Model of Optimal Prognosis (FMOP)
+
+<a id="fmop__solver_8h_1a1bd5d62d9c5ba6d327b0368a8b4e2e31"></a>
+### Function FMOP_approxField
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_approxField(const fmop_handle_t fmop, const double *param_values, double *field)
+```
+
+
+Approximates a field response based on a vector of given active scalar input parameters.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **param_values**: Vector of a single sample of all active scalar input parameters. Size and parameter order are defined by the return values of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f)<br/>
+ param_values [j]... the index j matches the parameter input name position returned in the param_idents argument of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) <br/>
+ sizeof ( param_values ) ... must match the num_params argument of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) The values must not be located outside the initial sampling bounds.
+* **field**: An already initialized array of size num_mesh_items as returned by [FMOP_getModelDim()](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65) On output contains the approximated field response. <br/>
+ Follows the scheme: `formula {"type":"element","name":"formula","attributes":{"id":"2"},"children":[{"type":"text","text":"$ field[k] $"}]}` <br/>
+ k...internal mesh item ident, e.g. internal signal position, internal element number <br/>
+ Call [FMOP_getDataPointIndices()](fmop_solver.md#fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31) to map internal to external numbering scheme
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop handle is not allocated.
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the param_values or field array argument is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation. For detailed log messages call FMOP_getLastError() which outputs internal log messages.
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* const double * **param_values**
+* double * **field**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="fmop__solver_8h_1a4380a704857be093fc6444aa5b8fdadc"></a>
+### Function FMOP_approxFieldExtrapolate
+
+![][public]
+
+
+```cpp
+fmop_error_t FMOP_approxFieldExtrapolate(const fmop_handle_t fmop, const double *param_values, double *field)
+```
+
+
+Approximates a field response based on a vector of given active scalar input parameters.
+
+**Parameters**:
+
+* **fmop**: A successfully initialized [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) data object
+* **param_values**: Vector of a single sample of all active scalar input parameters. Size and parameter order are defined by the return values of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f)<br/>
+ param_values [j]... the index j matches the parameter input name position returned in the param_idents argument of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) <br/>
+ sizeof ( param_values ) ... must match the num_params argument of [FMOP_getModelParamIdents()](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) The values may be located outside the initial sampling bounds.
+* **field**: An already initialized array of size num_mesh_items as returned by [FMOP_getModelDim()](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65) On output contains the approximated field response. <br/>
+ Follows the scheme: `formula {"type":"element","name":"formula","attributes":{"id":"2"},"children":[{"type":"text","text":"$ field[k] $"}]}` <br/>
+ k...internal mesh item ident, e.g. internal signal position, internal element number <br/>
+ Call [FMOP_getDataPointIndices()](fmop_solver.md#fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31) to map internal to external numbering scheme
+
+
+**Returns**:
+
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the fmop handle is not allocated.
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurs, e.g. no license has been acquired so far or one tries to release a 3D mesh but acquired a oSP3D license for 1D meshes, e.g. signals, only
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the param_values or field array argument is a NULL pointer
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any other failure get invoked
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) elsewise
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation. For detailed log messages call FMOP_getLastError() which outputs internal log messages.
+
+
+
+**Parameters**:
+
+* const [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) **fmop**
+* const double * **param_values**
+* double * **field**
+
+**Return type**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+## Typedefs
+
+<a id="fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572"></a>
+### Typedef fmop_db_handle_t
+
+![][public]
+
+**Definition**: `fmop_solver.h` (line 42)
+
+
+```cpp
+typedef void* fmop_db_handle_t
+```
+
+
+Contains all the data being required to post-process any FMOP.
+
+> Since we had some unresolved troubles in Matlab using the forward declaration 
+```cpp
+typedef struct FMOP_Database* fmop_db_handle_t; 
+```
+ we now prefer to write for the public definition 'void*' only
+
+
+
+**Return type**: void *
+
+<a id="fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef"></a>
+### Typedef fmop_handle_t
+
+![][public]
+
+**Definition**: `fmop_solver.h` (line 53)
+
+
+```cpp
+typedef void* fmop_handle_t
+```
+
+
+Contains one specific single or cross correlated FMOP.
+
+> Since we had some unresolved troubles in Matlab using the forward declaration 
+```cpp
+typedef struct FMOP* fmop_handle_t; 
+```
+ we now prefer to write for the public defintion 'void*' only
+
+
+
+**Return type**: void *
+
+## Source
+
+
+```cpp
+
+#ifndef DYNARDO_FMOP_H
+    #define DYNARDO_FMOP_H
+
+#include "sos_capi_common.h"
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef DYNARDO_FMOP_DLL_EXPORTS
+    typedef struct FMOP_Database* fmop_db_handle_t;
+#else
+    typedef void* fmop_db_handle_t;
+#endif
+#ifdef DYNARDO_FMOP_DLL_EXPORTS
+    typedef struct FMOP* fmop_handle_t;
+#else
+    typedef void* fmop_handle_t;
+#endif
+
+
+
+/*********************************************/
+
+fmop_error_t FMOP_loadDbFile ( fmop_db_handle_t * database, const char* path );
+
+fmop_error_t FMOP_loadDbFileWMesh ( fmop_db_handle_t * database, const char* path );
+
+#ifndef DOXYGEN_IGNORE
+fmop_error_t FMOP_loadDbBuf
+    ( fmop_db_handle_t * database, const char* buffer,  size_t length );
+fmop_error_t FMOP_loadDbBufWMesh
+    ( fmop_db_handle_t * database, const char* buffer, size_t length );
+#endif
+fmop_error_t FMOP_getModel ( fmop_db_handle_t database, fmop_dataobject_types data_type,
+                                              const char * const fmop_ident, fmop_handle_t * fmop );
+fmop_error_t FMOP_releaseModel ( fmop_handle_t * fmop );
+fmop_error_t FMOP_releaseDb ( fmop_db_handle_t * database );
+fmop_error_t FMOP_releaseIdents ( char *** const idents, const size_t * num_idents );
+
+
+/*********************************************/
+
+fmop_error_t FMOP_getModelIdents
+    ( const fmop_db_handle_t database, fmop_dataobject_types data_type, char *** const fmop_idents, size_t * num_idents );
+fmop_error_t FMOP_getModelIdentsDim
+    ( const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t * num_idents );
+const char * FMOP_getModelIdent
+    ( const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t num_ident );
+fmop_error_t FMOP_getModelParamIdents
+    ( const fmop_handle_t fmop, char *** const param_idents, size_t * num_params );
+fmop_error_t FMOP_getModelParamIdentsDim ( const fmop_handle_t fmop, size_t * num_params );
+const char * FMOP_getModelParamIdent ( const fmop_handle_t fmop, size_t num_param );
+fmop_error_t FMOP_getParamLowerBounds ( const fmop_handle_t fmop, double * lower_bounds );
+fmop_error_t FMOP_getParamUpperBounds ( const fmop_handle_t fmop, double * upper_bounds );
+fmop_error_t FMOP_getModelTotalAvgFCoP ( const fmop_handle_t fmop, double * fcop );
+fmop_error_t FMOP_getModelAvgFCoP ( const fmop_handle_t fmop, double * fcops );
+fmop_error_t FMOP_getModelDim ( const fmop_handle_t fmop, size_t * num_mesh_items );
+fmop_error_t FMOP_getDataDim ( const fmop_db_handle_t database, fmop_dataobject_types data_type, size_t * num_mesh_items );
+fmop_error_t FMOP_getDataPointIndices ( fmop_handle_t fmop, unsigned int * part_ids, unsigned int * item_ids );
+fmop_error_t FMOP_getDataPointCoors (fmop_handle_t fmop, char axis, double * coors );
+
+
+fmop_error_t FMOP_getNumElementsAtNode ( fmop_handle_t fmop, unsigned int node_idx, unsigned int * num_elements );
+fmop_error_t FMOP_getElementsAtNode ( fmop_handle_t fmop, unsigned int node_idx, unsigned int * elements );
+fmop_error_t FMOP_isNodePartOfBoundary (fmop_handle_t fmop, unsigned int node_idx, unsigned int * is_part_of_boundary);
+fmop_error_t FMOP_getNumNodesAtElement ( fmop_handle_t fmop, unsigned int element_idx, unsigned int * num_nodes );
+fmop_error_t FMOP_getNodesAtElement ( fmop_handle_t fmop, unsigned int element_idx, unsigned int * nodes );
+const char * FMOP_getElementTypeIdent ( fmop_handle_t fmop, unsigned int element_idx );
+
+/*********************************************/
+
+fmop_error_t FMOP_approxField
+    ( const fmop_handle_t fmop, const double * param_values, double * field );
+
+fmop_error_t FMOP_approxFieldExtrapolate
+    ( const fmop_handle_t fmop, const double * param_values, double * field );
+
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DYNARDO_FMOP_H
+```
+
+**copyright**
+
+Copyright © 2026 Synopsys, Inc. and ANSYS, Inc. All rights reserved.

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/global_contents.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/global_contents.md
@@ -1,0 +1,84 @@
+# Contents
+
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h) File
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h) File
+  * [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) Enumeration type
+  * [fmop_node_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75aaf0fb275c161febc56c4f10e62987049) Enumerator
+  * [fmop_element_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a1ec31fe31f3b8a9fd9dd902b014499ef) Enumerator
+  * [fmop_scalar_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a16a14aa0d55901638e165fb3a39b3870) Enumerator
+  * [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec) Enumeration type
+  * [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) Enumerator
+  * [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) Enumerator
+  * [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) Enumerator
+  * [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) Enumerator
+  * [fmop_model_missing](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becaedda7a6dbd4f5dd3eedecca9ec7dc1e9) Enumerator
+  * [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) Enumerator
+  * [fmop_script_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becab6e0160bb71d6930176d907409618f4d) Enumerator
+  * [fmop_script_no_object](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca749f1c6edf13b1303018d7a3632dc316) Enumerator
+  * [fmop_script_wrong_type](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca32eddc7d860101cdbb8e1571c726ee91) Enumerator
+  * [fmop_not_implemented](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca7fc167a096db0f31209791e0053de2ec) Enumerator
+  * [fmop_const_max](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41b2d8995eb66857227a50e49e8f6016) Enumerator
+  * [fmop_license_t](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422e) Enumeration type
+  * [fmop_mesh_signal](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea5b9372ca962a29cf37faac2948897143) Enumerator
+  * [fmop_mesh_all](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea71a41e6fb1935010b6ed34037f7dae8c) Enumerator
+  * [FMOP_acquireLicense](sos__capi__common_8h.md#sos__capi__common_8h_1a1cdd0d44e0ea8172b1f7f1095395da89) Function
+  * [FMOP_appendLicenseSearchPath](sos__capi__common_8h.md#sos__capi__common_8h_1a7086f4db3e639526b2b7fe9ce9392a24) Function
+  * [FMOP_licenseLocked](sos__capi__common_8h.md#sos__capi__common_8h_1a462a99c932a9b5704aae42a15826e4c3) Function
+  * [FMOP_releaseLicense](sos__capi__common_8h.md#sos__capi__common_8h_1a62d038d686a8183e10f52131697bce6c) Function
+  * [FMOP_getErrnoString](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) Function
+  * [FMOP_getLastErrno](sos__capi__common_8h.md#sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186) Function
+  * [FMOP_getLastErrnoString](sos__capi__common_8h.md#sos__capi__common_8h_1a6d55525bac5ec09f8194536705dfce7c) Function
+  * [FMOP_getLastErrorString](sos__capi__common_8h.md#sos__capi__common_8h_1aa79c50f0e38654fc5bf42e052b229748) Function
+  * [FMOP_getLastLogString](sos__capi__common_8h.md#sos__capi__common_8h_1a1fd89d5a52a09e446992e60a30636118) Function
+  * [FMOP_setLogLevel](sos__capi__common_8h.md#sos__capi__common_8h_1ac13c87c4e4d30a83f4d041a908d0a1e7) Function
+  * [FMOP_getVersionString](sos__capi__common_8h.md#sos__capi__common_8h_1a14d4d11f425cfcd2f7149798ad4d9274) Function
+  * [FMOP_initializeLibrary](sos__capi__common_8h.md#sos__capi__common_8h_1a9c8f0f808d3f27c57a3a57d5f9cf4834) Function
+  * [FMOP_unloadLibrary](sos__capi__common_8h.md#sos__capi__common_8h_1ae0af273cc642061f90933b4af2a958ad) Function
+* [FMOPSolver.c](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c) File
+  * [REF_NUM_PARAMS](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c_1ae7c3138bceee1d3e419dadbea1c80fa5) Macro
+  * [main](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c_1af3ed9c200de85b53c94cd18764b246a2) Function
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h) File
+  * [FMOP_globalScriptEngine](sos__capi__script_8h.md#sos__capi__script_8h_1ace6f8c522f626dddbf5fc12d4d1d7a11) Function
+  * [FMOP_script_createMatrix](sos__capi__script_8h.md#sos__capi__script_8h_1a86518674fc7aa5571d44f5d8544879f0) Function
+  * [FMOP_script_createNumber](sos__capi__script_8h.md#sos__capi__script_8h_1acd830885fbde66f6d3133d7f1e943796) Function
+  * [FMOP_script_createString](sos__capi__script_8h.md#sos__capi__script_8h_1a31383b3c0eb3e408c74430b1cd610183) Function
+  * [FMOP_script_execute](sos__capi__script_8h.md#sos__capi__script_8h_1a585497e6891f11a032944d26f3b0d9c0) Function
+  * [FMOP_script_getMatrix](sos__capi__script_8h.md#sos__capi__script_8h_1afe7c32369056cdee19411d3924538d5d) Function
+  * [FMOP_script_getNumber](sos__capi__script_8h.md#sos__capi__script_8h_1a6b01058d679a651d52882f928caa14e7) Function
+  * [FMOP_script_getString](sos__capi__script_8h.md#sos__capi__script_8h_1ac1304b306d77e15fcfd1e99603bbff62) Function
+  * [FMOP_script_identExists](sos__capi__script_8h.md#sos__capi__script_8h_1adaf34349f4a16e537f5fe8a5ceb52856) Function
+  * [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) Typedef
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h) File
+  * [FMOP_getModel](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) Function
+  * [FMOP_loadDbBuf](fmop_solver.md#fmop__solver_8h_1a0ad6b75479bad22c19004ccf3078f235) Function
+  * [FMOP_loadDbBufWMesh](fmop_solver.md#fmop__solver_8h_1ab77fe12cab675bb1d50232deacf23a34) Function
+  * [FMOP_loadDbFile](fmop_solver.md#fmop__solver_8h_1adf36057836bc12095f01665fa068ba4c) Function
+  * [FMOP_loadDbFileWMesh](fmop_solver.md#fmop__solver_8h_1ab3f6b6b4a84878f3c774a12a2b4cf958) Function
+  * [FMOP_releaseDb](fmop_solver.md#fmop__solver_8h_1af36d28d4c5c718284a0f4236f2740e06) Function
+  * [FMOP_releaseIdents](fmop_solver.md#fmop__solver_8h_1a37bdee678571cd855ac0bb10675b1d8c) Function
+  * [FMOP_releaseModel](fmop_solver.md#fmop__solver_8h_1a3ad01c460ed6e409b79e258a523d0bf9) Function
+  * [FMOP_getDataDim](fmop_solver.md#fmop__solver_8h_1a878106f886ca5f1ce112e6c5e238d80e) Function
+  * [FMOP_getDataPointCoors](fmop_solver.md#fmop__solver_8h_1a535bee00c4d200d31fdf4118e49c1f05) Function
+  * [FMOP_getDataPointIndices](fmop_solver.md#fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31) Function
+  * [FMOP_getElementsAtNode](fmop_solver.md#fmop__solver_8h_1a8ca72d6a865df21ce5a5180475c71cda) Function
+  * [FMOP_getElementTypeIdent](fmop_solver.md#fmop__solver_8h_1a3eea3398149b5f0f6177ccc4a649ab79) Function
+  * [FMOP_getModelAvgFCoP](fmop_solver.md#fmop__solver_8h_1a185c515c2fe8b0528ccb5f95f543a3be) Function
+  * [FMOP_getModelDim](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65) Function
+  * [FMOP_getModelIdent](fmop_solver.md#fmop__solver_8h_1a9b6e5c7baeb1353a17f5efde188d0d8f) Function
+  * [FMOP_getModelIdents](fmop_solver.md#fmop__solver_8h_1a22d6e807dc869fa28442d26e29ddbc27) Function
+  * [FMOP_getModelIdentsDim](fmop_solver.md#fmop__solver_8h_1a600dca69efae1f2eafc63f9f6a0067fc) Function
+  * [FMOP_getModelParamIdent](fmop_solver.md#fmop__solver_8h_1ae2ab3659b0419a9ab56ba3d7722708fb) Function
+  * [FMOP_getModelParamIdents](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) Function
+  * [FMOP_getModelParamIdentsDim](fmop_solver.md#fmop__solver_8h_1adabef430a391d15eb077fe30e134f368) Function
+  * [FMOP_getModelTotalAvgFCoP](fmop_solver.md#fmop__solver_8h_1a1ff6f33cf199015b78c5837e40d90f42) Function
+  * [FMOP_getNodesAtElement](fmop_solver.md#fmop__solver_8h_1a03080c2458b8c03eb85ce9eb97926711) Function
+  * [FMOP_getNumElementsAtNode](fmop_solver.md#fmop__solver_8h_1a4413f3e2bc5f893b9030631aceb03c54) Function
+  * [FMOP_getNumNodesAtElement](fmop_solver.md#fmop__solver_8h_1a031be0f125c4fbeb450f03bb960e207d) Function
+  * [FMOP_getParamLowerBounds](fmop_solver.md#fmop__solver_8h_1abaed2ac2af6a304f8356e51b9cb98442) Function
+  * [FMOP_getParamUpperBounds](fmop_solver.md#fmop__solver_8h_1a301cfcf26e28ec7ba4b2c730facb679c) Function
+  * [FMOP_isNodePartOfBoundary](fmop_solver.md#fmop__solver_8h_1a1ff1451cc5f1c6cefa7a67c6a906d653) Function
+  * [FMOP_approxField](fmop_solver.md#fmop__solver_8h_1a1bd5d62d9c5ba6d327b0368a8b4e2e31) Function
+  * [FMOP_approxFieldExtrapolate](fmop_solver.md#fmop__solver_8h_1a4380a704857be093fc6444aa5b8fdadc) Function
+  * [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) Typedef
+  * [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) Typedef
+* [Deprecated List](deprecated.md#deprecated) Page

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/global_index.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/global_index.md
@@ -1,0 +1,98 @@
+# Index
+
+## D
+
+* [Deprecated List](deprecated.md#deprecated) Page
+
+## F
+
+* [FMOP_acquireLicense](sos__capi__common_8h.md#sos__capi__common_8h_1a1cdd0d44e0ea8172b1f7f1095395da89) Function
+* [FMOP_appendLicenseSearchPath](sos__capi__common_8h.md#sos__capi__common_8h_1a7086f4db3e639526b2b7fe9ce9392a24) Function
+* [FMOP_approxField](fmop_solver.md#fmop__solver_8h_1a1bd5d62d9c5ba6d327b0368a8b4e2e31) Function
+* [FMOP_approxFieldExtrapolate](fmop_solver.md#fmop__solver_8h_1a4380a704857be093fc6444aa5b8fdadc) Function
+* [fmop_const_max](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41b2d8995eb66857227a50e49e8f6016) Enumerator
+* [fmop_dataobject_types](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75) Enumeration type
+* [fmop_db_handle_t](fmop_solver.md#fmop__solver_8h_1a4f3b1f4672b1b913e04f95def14d3572) Typedef
+* [fmop_element_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a1ec31fe31f3b8a9fd9dd902b014499ef) Enumerator
+* [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec) Enumeration type
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) Enumerator
+* [FMOP_getDataDim](fmop_solver.md#fmop__solver_8h_1a878106f886ca5f1ce112e6c5e238d80e) Function
+* [FMOP_getDataPointCoors](fmop_solver.md#fmop__solver_8h_1a535bee00c4d200d31fdf4118e49c1f05) Function
+* [FMOP_getDataPointIndices](fmop_solver.md#fmop__solver_8h_1add2527ad2ad1bf1df141e5fa5b4c2e31) Function
+* [FMOP_getElementsAtNode](fmop_solver.md#fmop__solver_8h_1a8ca72d6a865df21ce5a5180475c71cda) Function
+* [FMOP_getElementTypeIdent](fmop_solver.md#fmop__solver_8h_1a3eea3398149b5f0f6177ccc4a649ab79) Function
+* [FMOP_getErrnoString](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) Function
+* [FMOP_getLastErrno](sos__capi__common_8h.md#sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186) Function
+* [FMOP_getLastErrnoString](sos__capi__common_8h.md#sos__capi__common_8h_1a6d55525bac5ec09f8194536705dfce7c) Function
+* [FMOP_getLastErrorString](sos__capi__common_8h.md#sos__capi__common_8h_1aa79c50f0e38654fc5bf42e052b229748) Function
+* [FMOP_getLastLogString](sos__capi__common_8h.md#sos__capi__common_8h_1a1fd89d5a52a09e446992e60a30636118) Function
+* [FMOP_getModel](fmop_solver.md#fmop__solver_8h_1aae65fdf242dba6c37b9de818be7c9dcc) Function
+* [FMOP_getModelAvgFCoP](fmop_solver.md#fmop__solver_8h_1a185c515c2fe8b0528ccb5f95f543a3be) Function
+* [FMOP_getModelDim](fmop_solver.md#fmop__solver_8h_1a24e43563d67cc64bffb7bccddbaada65) Function
+* [FMOP_getModelIdent](fmop_solver.md#fmop__solver_8h_1a9b6e5c7baeb1353a17f5efde188d0d8f) Function
+* [FMOP_getModelIdents](fmop_solver.md#fmop__solver_8h_1a22d6e807dc869fa28442d26e29ddbc27) Function
+* [FMOP_getModelIdentsDim](fmop_solver.md#fmop__solver_8h_1a600dca69efae1f2eafc63f9f6a0067fc) Function
+* [FMOP_getModelParamIdent](fmop_solver.md#fmop__solver_8h_1ae2ab3659b0419a9ab56ba3d7722708fb) Function
+* [FMOP_getModelParamIdents](fmop_solver.md#fmop__solver_8h_1a485827623b3d01cf3157c0a16559908f) Function
+* [FMOP_getModelParamIdentsDim](fmop_solver.md#fmop__solver_8h_1adabef430a391d15eb077fe30e134f368) Function
+* [FMOP_getModelTotalAvgFCoP](fmop_solver.md#fmop__solver_8h_1a1ff6f33cf199015b78c5837e40d90f42) Function
+* [FMOP_getNodesAtElement](fmop_solver.md#fmop__solver_8h_1a03080c2458b8c03eb85ce9eb97926711) Function
+* [FMOP_getNumElementsAtNode](fmop_solver.md#fmop__solver_8h_1a4413f3e2bc5f893b9030631aceb03c54) Function
+* [FMOP_getNumNodesAtElement](fmop_solver.md#fmop__solver_8h_1a031be0f125c4fbeb450f03bb960e207d) Function
+* [FMOP_getParamLowerBounds](fmop_solver.md#fmop__solver_8h_1abaed2ac2af6a304f8356e51b9cb98442) Function
+* [FMOP_getParamUpperBounds](fmop_solver.md#fmop__solver_8h_1a301cfcf26e28ec7ba4b2c730facb679c) Function
+* [FMOP_getVersionString](sos__capi__common_8h.md#sos__capi__common_8h_1a14d4d11f425cfcd2f7149798ad4d9274) Function
+* [FMOP_globalScriptEngine](sos__capi__script_8h.md#sos__capi__script_8h_1ace6f8c522f626dddbf5fc12d4d1d7a11) Function
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) Typedef
+* [FMOP_initializeLibrary](sos__capi__common_8h.md#sos__capi__common_8h_1a9c8f0f808d3f27c57a3a57d5f9cf4834) Function
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) Enumerator
+* [FMOP_isNodePartOfBoundary](fmop_solver.md#fmop__solver_8h_1a1ff1451cc5f1c6cefa7a67c6a906d653) Function
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) Enumerator
+* [fmop_license_t](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422e) Enumeration type
+* [FMOP_licenseLocked](sos__capi__common_8h.md#sos__capi__common_8h_1a462a99c932a9b5704aae42a15826e4c3) Function
+* [FMOP_loadDbBuf](fmop_solver.md#fmop__solver_8h_1a0ad6b75479bad22c19004ccf3078f235) Function
+* [FMOP_loadDbBufWMesh](fmop_solver.md#fmop__solver_8h_1ab77fe12cab675bb1d50232deacf23a34) Function
+* [FMOP_loadDbFile](fmop_solver.md#fmop__solver_8h_1adf36057836bc12095f01665fa068ba4c) Function
+* [FMOP_loadDbFileWMesh](fmop_solver.md#fmop__solver_8h_1ab3f6b6b4a84878f3c774a12a2b4cf958) Function
+* [fmop_mesh_all](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea71a41e6fb1935010b6ed34037f7dae8c) Enumerator
+* [fmop_mesh_signal](sos__capi__common_8h.md#sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea5b9372ca962a29cf37faac2948897143) Enumerator
+* [fmop_model_missing](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becaedda7a6dbd4f5dd3eedecca9ec7dc1e9) Enumerator
+* [fmop_node_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75aaf0fb275c161febc56c4f10e62987049) Enumerator
+* [fmop_not_implemented](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca7fc167a096db0f31209791e0053de2ec) Enumerator
+* [FMOP_releaseDb](fmop_solver.md#fmop__solver_8h_1af36d28d4c5c718284a0f4236f2740e06) Function
+* [FMOP_releaseIdents](fmop_solver.md#fmop__solver_8h_1a37bdee678571cd855ac0bb10675b1d8c) Function
+* [FMOP_releaseLicense](sos__capi__common_8h.md#sos__capi__common_8h_1a62d038d686a8183e10f52131697bce6c) Function
+* [FMOP_releaseModel](fmop_solver.md#fmop__solver_8h_1a3ad01c460ed6e409b79e258a523d0bf9) Function
+* [fmop_scalar_data](sos__capi__common_8h.md#sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a16a14aa0d55901638e165fb3a39b3870) Enumerator
+* [FMOP_script_createMatrix](sos__capi__script_8h.md#sos__capi__script_8h_1a86518674fc7aa5571d44f5d8544879f0) Function
+* [FMOP_script_createNumber](sos__capi__script_8h.md#sos__capi__script_8h_1acd830885fbde66f6d3133d7f1e943796) Function
+* [FMOP_script_createString](sos__capi__script_8h.md#sos__capi__script_8h_1a31383b3c0eb3e408c74430b1cd610183) Function
+* [fmop_script_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becab6e0160bb71d6930176d907409618f4d) Enumerator
+* [FMOP_script_execute](sos__capi__script_8h.md#sos__capi__script_8h_1a585497e6891f11a032944d26f3b0d9c0) Function
+* [FMOP_script_getMatrix](sos__capi__script_8h.md#sos__capi__script_8h_1afe7c32369056cdee19411d3924538d5d) Function
+* [FMOP_script_getNumber](sos__capi__script_8h.md#sos__capi__script_8h_1a6b01058d679a651d52882f928caa14e7) Function
+* [FMOP_script_getString](sos__capi__script_8h.md#sos__capi__script_8h_1ac1304b306d77e15fcfd1e99603bbff62) Function
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) Typedef
+* [FMOP_script_identExists](sos__capi__script_8h.md#sos__capi__script_8h_1adaf34349f4a16e537f5fe8a5ceb52856) Function
+* [fmop_script_no_object](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca749f1c6edf13b1303018d7a3632dc316) Enumerator
+* [fmop_script_wrong_type](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca32eddc7d860101cdbb8e1571c726ee91) Enumerator
+* [FMOP_setLogLevel](sos__capi__common_8h.md#sos__capi__common_8h_1ac13c87c4e4d30a83f4d041a908d0a1e7) Function
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) Enumerator
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h) File
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) Enumerator
+* [FMOP_unloadLibrary](sos__capi__common_8h.md#sos__capi__common_8h_1ae0af273cc642061f90933b4af2a958ad) Function
+* [FMOPSolver.c](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c) File
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h) File
+
+## M
+
+* [main](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c_1af3ed9c200de85b53c94cd18764b246a2) Function
+
+## R
+
+* [REF_NUM_PARAMS](_f_m_o_p_solver_8c.md#_f_m_o_p_solver_8c_1ae7c3138bceee1d3e419dadbea1c80fa5) Macro
+
+## S
+
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h) File
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h) File

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/index.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/index.md
@@ -1,0 +1,5 @@
+# Introduction
+
+This C‑API to evaluate a Field Metamodel of Optimal Prognosis (FMOP) provides tools to load and work with a previously generated FMOP database. A FMOP predicts spatially distributed field responses—such as stress, displacement, or temperature— as a function of scalar input parameters. It captures the most influential input parameters per mesh location and assembles them into an efficient model that can be evaluated quickly.
+
+With this API, you can load a previously generated FMOP database, inspect its structure (input parameters, mesh topology, Field Coefficients of Prognosis), and approximate field responses for arbitrary input parameter combinations at a fraction of the cost of a full simulation.

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/sos__capi__common_8h.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/sos__capi__common_8h.md
@@ -1,0 +1,791 @@
+# File sos_capi_common.h
+
+![][C++]
+
+**Location**: `sos_capi_common.h`
+
+C-API for utility functions (load/unload library, license management, error handling)
+
+**copyright**\
+Ansys Austria GmbH
+
+## Included by
+
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h)
+* [fmop_solver.h](fmop_solver.md#fmop__solver_8h)
+* [sos_capi_script.h](sos__capi__script_8h.md#sos__capi__script_8h)
+
+
+```mermaid
+graph RL
+2["FMOPSolver.h"]
+click 2 "_f_m_o_p_solver_8h.md#source"
+
+3["fmop_solver.h"]
+click 3 "fmop_solver.md#fmop__solver_8h"
+2 --> 3
+
+1["sos_capi_common.h"]
+click 1 "sos__capi__common_8h.md#sos__capi__common_8h"
+2 --> 1
+3 --> 1
+4 --> 1
+
+4["sos_capi_script.h"]
+click 4 "sos__capi__script_8h.md#sos__capi__script_8h"
+2 --> 4
+
+```
+
+
+## Public type definitions
+
+Pubic type definitions used within this API
+
+<a id="sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75"></a>
+### Enumeration type fmop_dataobject_types
+
+![][public]
+
+**Definition**: `sos_capi_common.h` (line 111)
+
+
+```cpp
+enum fmop_dataobject_types {
+  fmop_node_data = 0,
+  fmop_element_data = 1,
+  fmop_scalar_data = 3
+}
+```
+
+
+Data type definitions.
+
+
+
+
+
+<a id="sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75aaf0fb275c161febc56c4f10e62987049"></a>
+#### Enumerator fmop_node_data
+
+node data (one scalar per node)
+
+
+
+<a id="sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a1ec31fe31f3b8a9fd9dd902b014499ef"></a>
+#### Enumerator fmop_element_data
+
+element data (one scalar per element)
+
+
+
+<a id="sos__capi__common_8h_1a69eb42c1b3b49f22b9e73c6c9869cb75a16a14aa0d55901638e165fb3a39b3870"></a>
+#### Enumerator fmop_scalar_data
+
+scalar data (vector of size 1)
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec"></a>
+### Enumeration type fmop_error_t
+
+![][public]
+
+**Definition**: `sos_capi_common.h` (line 79)
+
+
+```cpp
+enum fmop_error_t {
+  fmop_success = 0,
+  fmop_invalid_handle = 1,
+  fmop_exception_occurred = 2,
+  fmop_settings_error = 3,
+  fmop_model_missing = 4,
+  fmop_license_error = 5,
+  fmop_script_error = 6,
+  fmop_script_no_object = 7,
+  fmop_script_wrong_type = 8,
+  fmop_not_implemented = 16382,
+  fmop_const_max = 16383
+}
+```
+
+
+Error code definitions.
+
+
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55"></a>
+#### Enumerator fmop_success
+
+Function execution returned successfully.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf"></a>
+#### Enumerator fmop_invalid_handle
+
+The function got an unexpected NULL pointer.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198"></a>
+#### Enumerator fmop_exception_occurred
+
+An internal error occurred. Request log messages.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd"></a>
+#### Enumerator fmop_settings_error
+
+Input argument(s) is invalid or missing.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becaedda7a6dbd4f5dd3eedecca9ec7dc1e9"></a>
+#### Enumerator fmop_model_missing
+
+The requested model identifier is not known.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe"></a>
+#### Enumerator fmop_license_error
+
+No valid license available.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becab6e0160bb71d6930176d907409618f4d"></a>
+#### Enumerator fmop_script_error
+
+An error appeare while executing Lua script.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca749f1c6edf13b1303018d7a3632dc316"></a>
+#### Enumerator fmop_script_no_object
+
+Object with ident not found in script engine.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca32eddc7d860101cdbb8e1571c726ee91"></a>
+#### Enumerator fmop_script_wrong_type
+
+Object with ident has wrong type.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca7fc167a096db0f31209791e0053de2ec"></a>
+#### Enumerator fmop_not_implemented
+
+This function is yet not implemented or has been removed.
+
+
+
+<a id="sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41b2d8995eb66857227a50e49e8f6016"></a>
+#### Enumerator fmop_const_max
+
+2^14-1 non-modifiable for each API version
+
+
+
+<a id="sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422e"></a>
+### Enumeration type fmop_license_t
+
+![][public]
+
+**Definition**: `sos_capi_common.h` (line 100)
+
+
+```cpp
+enum fmop_license_t {
+  fmop_mesh_signal = 10,
+  fmop_mesh_all = 30
+}
+```
+
+
+FMOP mesh features which need to be unlocked by a valid license.
+
+
+
+
+
+<a id="sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea5b9372ca962a29cf37faac2948897143"></a>
+#### Enumerator fmop_mesh_signal
+
+Unlocks signal meshes.
+
+
+
+<a id="sos__capi__common_8h_1afe21e382a604ef55cba4d683d706422ea71a41e6fb1935010b6ed34037f7dae8c"></a>
+#### Enumerator fmop_mesh_all
+
+Unlocks all mesh features.
+
+
+
+## License handling
+
+API handling licenes requests
+
+<a id="sos__capi__common_8h_1a1cdd0d44e0ea8172b1f7f1095395da89"></a>
+### Function FMOP_acquireLicense
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_acquireLicense()
+```
+
+
+Acquires an optiSLang enterprise license.
+
+**Returns**:
+
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if a license has already been acquired successfully
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if any error occures while checking out the requested feature(s)
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if a license has been acquired successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__common_8h_1a7086f4db3e639526b2b7fe9ce9392a24"></a>
+### Function FMOP_appendLicenseSearchPath
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_appendLicenseSearchPath(const char *abs_path)
+```
+
+
+Appends another license search path to the default ones.
+
+**Deprecated**:
+
+Since 2022 R2. Will be removed in 2023 R1
+
+
+
+
+
+
+By default the following license search paths will be checked in the order given:
+* @localhost
+
+* the current working directory
+
+* the path pointed to by the environment variable 'LM_LICENSE_FILE'
+
+* the path pointed to by the environment variable 'DYNARDO_LICENSE_FILE'
+
+
+
+
+
+
+
+
+**Parameters**:
+
+* **abs_path**: An absolute file system path, e.g. '/opt/DYNARDO/licensing', 'D:\Licenses', ...
+
+
+**Returns**:
+
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if the path given does not exist
+
+* [fmop_exception_occurred](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becadac3d9086cdab852d265dc924070c198) if the path given invoces any other filesystem error
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) if the path has been appended successfully
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Parameters**:
+
+* const char * **abs_path**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__common_8h_1a462a99c932a9b5704aae42a15826e4c3"></a>
+### Function FMOP_licenseLocked
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API bool FMOP_licenseLocked()
+```
+
+
+Check whether any license feature was acquired.
+
+**Returns**:
+
+True if any license feature is locked, false otherwise
+
+
+
+**Return type**: DYNARDO_FMOP_API bool
+
+<a id="sos__capi__common_8h_1a62d038d686a8183e10f52131697bce6c"></a>
+### Function FMOP_releaseLicense
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_releaseLicense()
+```
+
+
+Release the acquired license.
+
+Note, that no previously acquired license is released if not all loaded Database and FMOP objects are already released
+
+
+
+
+
+
+**Returns**:
+
+
+* [fmop_settings_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca4040927e4d05d13e93b9f2c7373ca0cd) if any Database or FMOP object is not already released
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) in all other cases
+
+
+**Returns**:
+
+Call [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) to get a human readable representation
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+## Error Handling
+
+API to access and interpret recent data object error messages
+
+<a id="sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110"></a>
+### Function FMOP_getErrnoString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API const char * FMOP_getErrnoString(fmop_error_t error_num)
+```
+
+
+Returns a string description for the error number given.
+
+**Parameters**:
+
+* **error_num**: The error number
+
+
+**Returns**:
+
+A human readable string description for the error number given.The returned string will be overwritten by this function at the next call and will be destroyed on program termination
+
+
+?> Calling this function will neither manipulate the internal log message stack nor the errno state of the last library call
+
+
+?> DON'T USE ERRNO as agrument identifier as this seems to be defined as a macro identifier Refer to [http://www.cplusplus.com/reference/cerrno/errno/](http://www.cplusplus.com/reference/cerrno/errno/) for details
+
+
+
+**Parameters**:
+
+* [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec) **error_num**
+
+**Return type**: DYNARDO_FMOP_API const char *
+
+<a id="sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186"></a>
+### Function FMOP_getLastErrno
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_getLastErrno()
+```
+
+
+Returns the error number which has been set at the last library call.
+
+**Returns**:
+
+The error number which has been set at the last library call
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__common_8h_1a6d55525bac5ec09f8194536705dfce7c"></a>
+### Function FMOP_getLastErrnoString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API const char * FMOP_getLastErrnoString()
+```
+
+
+Returns a pointer to a string that describes the error code which has been set at the last library call.
+
+**Returns**:
+
+A human readable string description for the error code that has been set at the last library call. The returned string will be overwritten by this function at the next call and will be destroyed on program termination
+
+
+?> Calling this function will neither manipulate the internal log message stack nor the errno state of the last library call
+
+
+
+**Return type**: DYNARDO_FMOP_API const char *
+
+<a id="sos__capi__common_8h_1aa79c50f0e38654fc5bf42e052b229748"></a>
+### Function FMOP_getLastErrorString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API const char * FMOP_getLastErrorString()
+```
+
+
+Returns internal log messages of level warning and above.
+
+This log level is immutable. [FMOP_setLogLevel()](sos__capi__common_8h.md#sos__capi__common_8h_1ac13c87c4e4d30a83f4d041a908d0a1e7) can not modify it. If the internal logger is empty, the value of [FMOP_getLastErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a6d55525bac5ec09f8194536705dfce7c) will be returned
+
+
+
+
+
+
+**Returns**:
+
+Returns all internal, formatted log messages of log level warning and above if either a warning or an error message occured during the last library call. Otherwise the return value of [FMOP_getLastErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a6d55525bac5ec09f8194536705dfce7c) will be returned. The returned string will be overwritten by this function at its next call and will be destroyed on program termination
+
+
+?> Calling this function will neither manipulate the internal log message stack nor the errno state of the last library call
+
+
+
+**Return type**: DYNARDO_FMOP_API const char *
+
+<a id="sos__capi__common_8h_1a1fd89d5a52a09e446992e60a30636118"></a>
+### Function FMOP_getLastLogString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API const char * FMOP_getLastLogString()
+```
+
+
+Returns internal log messages of log levels defined by FMOP_setLogLevel. Serves as debug logger.
+
+Initially all log levels are deactivated and no log messages will be buffered. Call FMOP_setLogLevel ( >0 ) to activate the logger and FMOP_setLogLevel (0) to deactivate it again.
+
+
+
+
+
+
+**Returns**:
+
+Returns all internal, formatted log messages of the last library call. The returned string will be overwritten by this function at the next call and will be destroyed on program termination
+
+
+?> Calling this function will not manipulate the internal log message stack. Though the errno number will be set and can be queried calling [FMOP_getLastErrno()](sos__capi__common_8h.md#sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186)
+
+
+
+**Return type**: DYNARDO_FMOP_API const char *
+
+<a id="sos__capi__common_8h_1ac13c87c4e4d30a83f4d041a908d0a1e7"></a>
+### Function FMOP_setLogLevel
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API int FMOP_setLogLevel(int log_level)
+```
+
+
+Defines the new log level filter. Valid for all subsequent library calls until a new log level gets set.
+
+**Parameters**:
+
+* **log_level**: Defines the new log level filter for messages returned by FMOP_getLastLog. Accepts the following integer values only:
+* 0 ... filter all log levels
+
+* 1 ... return only log messages of log level ERROR
+
+* 2 ... return only log messages of log level WARNING and below
+
+* 3 ... return only log messages of log level INFO and below
+
+* 4 ... return only log messages of log level DEBUG and below
+
+* 5 ... return all log messages, i.e. ERROR, WARNING INFO, DEBUG, TRACE. The log level TRACE is not existing in maintenance, i.e. in customer builds.
+
+
+**Returns**:
+
+The former log level or -1 if the log_level is unknown
+
+
+?> Calling this function will not manipulate the internal log message stack. Though the errno number will be set and can be queried calling [FMOP_getLastErrno()](sos__capi__common_8h.md#sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186)
+
+
+
+**Parameters**:
+
+* int **log_level**
+
+**Return type**: DYNARDO_FMOP_API int
+
+## Miscellaneous
+
+<a id="sos__capi__common_8h_1a14d4d11f425cfcd2f7149798ad4d9274"></a>
+### Function FMOP_getVersionString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API const char * FMOP_getVersionString()
+```
+
+
+Returns a version string.
+
+**Returns**:
+
+A const pointer to a character array holding the version string. Ownership is handled internally.
+
+
+?> Calling this function will not manipulate the internal log message stack. Though the errno number will be set and can be queried calling [FMOP_getLastErrno()](sos__capi__common_8h.md#sos__capi__common_8h_1ac78d83f9f73afd90854e1d07657fc186)
+
+
+
+**Return type**: DYNARDO_FMOP_API const char *
+
+## FMOP library handling
+
+<a id="sos__capi__common_8h_1a9c8f0f808d3f27c57a3a57d5f9cf4834"></a>
+### Function FMOP_initializeLibrary
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_initializeLibrary()
+```
+
+
+Initialize the FMOP library Allocates memory for the global script engine. Call [FMOP_unloadLibrary()](sos__capi__common_8h.md#sos__capi__common_8h_1ae0af273cc642061f90933b4af2a958ad) to release it. A warning is logged if the library was initialized already.
+
+?> This method must be called once, before requesting the global script engine with [FMOP_globalScriptEngine()](sos__capi__script_8h.md#sos__capi__script_8h_1ace6f8c522f626dddbf5fc12d4d1d7a11);
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__common_8h_1ae0af273cc642061f90933b4af2a958ad"></a>
+### Function FMOP_unloadLibrary
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_unloadLibrary()
+```
+
+
+Unload the FMOP library Clears the FMOP library from memory. A warning is logged if the library was unloaded already.
+
+
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+## Source
+
+
+```cpp
+
+#ifndef DYNARDO_SOS_CAPI_COMMON_H
+    #define DYNARDO_SOS_CAPI_COMMON_H
+
+
+// Generic helper definitions for shared library support
+//#if (defined _WIN32 || defined __CYGWIN__) && (not defined MINGW)
+#if defined _WIN32 || defined __CYGWIN__
+  #define DYNARDO_HELPER_DLL_IMPORT __declspec(dllimport)
+  #define DYNARDO_HELPER_DLL_EXPORT __declspec(dllexport)
+  #define DYNARDO_HELPER_DLL_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define DYNARDO_HELPER_DLL_IMPORT __attribute__ ((visibility ("default")))
+    #define DYNARDO_HELPER_DLL_EXPORT __attribute__ ((visibility ("default")))
+    #define DYNARDO_HELPER_DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define DYNARDO_HELPER_DLL_IMPORT
+    #define DYNARDO_HELPER_DLL_EXPORT
+    #define DYNARDO_HELPER_DLL_LOCAL
+  #endif
+#endif
+
+// Now we use the generic helper definitions above to define DYNARDO_FMOP_API and DYNARDO_FMOP_LOCAL.
+// DYNARDO_FMOP_API is used for the public API symbols. It either DLL imports or DLL exports (or does nothing
+// for static build)
+// DYNARDO_FMOP_LOCAL is used for non-api symbols.
+
+#ifdef DYNARDO_DLL // defined if the library is compiled as a DLL
+  #ifdef DYNARDO_FMOP_DLL_EXPORTS // defined if we are building the DYNARDO DLL (instead of using it)
+    #define DYNARDO_FMOP_API DYNARDO_HELPER_DLL_EXPORT
+  #else
+    #define DYNARDO_FMOP_API DYNARDO_HELPER_DLL_IMPORT
+  #endif // DYNARDO_FMOP_DLL_EXPORTS
+  #define DYNARDO_FMOP_LOCAL DYNARDO_HELPER_DLL_LOCAL
+#else // DYNARDO_DLL is not defined: this means we compile a static lib.
+  #define DYNARDO_FMOP_API
+  #define DYNARDO_FMOP_LOCAL
+#endif // DYNARDO_DLL
+
+#ifndef __cplusplus
+    #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+        #include <stdbool.h>
+    #elif !defined(false) && !defined(true)
+        typedef int bool;
+        #define false 0
+        #define true 1
+    #endif
+    #include <stddef.h>
+#else
+    #include <cstddef>
+#endif
+
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+
+/*********************************************/
+
+typedef enum
+{
+    fmop_success = 0,               
+    fmop_invalid_handle = 1,        
+    fmop_exception_occurred = 2,     
+    fmop_settings_error = 3,        
+    fmop_model_missing = 4,         
+    fmop_license_error = 5,         
+    fmop_script_error = 6,          
+    fmop_script_no_object = 7,      
+    fmop_script_wrong_type = 8,     
+
+    fmop_not_implemented = 16382,   
+
+    fmop_const_max = 16383          
+
+} fmop_error_t;
+
+typedef enum
+{
+    // Mesh related features
+    // Predefined feature combinations
+    fmop_mesh_signal    = 10, 
+    fmop_mesh_all       = 30  
+} fmop_license_t;
+
+typedef enum
+{
+    fmop_node_data    = 0,  
+    fmop_element_data = 1,  
+    fmop_scalar_data  = 3   
+} fmop_dataobject_types;
+
+
+
+/*********************************************/
+
+DYNARDO_FMOP_API fmop_error_t FMOP_appendLicenseSearchPath ( const char * abs_path );
+DYNARDO_FMOP_API fmop_error_t FMOP_acquireLicense ( );
+DYNARDO_FMOP_API bool FMOP_licenseLocked ();
+DYNARDO_FMOP_API fmop_error_t FMOP_releaseLicense ();
+
+
+
+/*********************************************/
+
+DYNARDO_FMOP_API const char* FMOP_getLastErrorString ();
+DYNARDO_FMOP_API fmop_error_t FMOP_getLastErrno ();
+DYNARDO_FMOP_API const char* FMOP_getLastErrnoString ();
+
+DYNARDO_FMOP_API const char* FMOP_getLastLogString ();
+DYNARDO_FMOP_API int FMOP_setLogLevel ( int log_level );
+
+DYNARDO_FMOP_API const char* FMOP_getErrnoString ( fmop_error_t error_num );
+
+
+/*********************************************/
+
+DYNARDO_FMOP_API const char* FMOP_getVersionString ();
+
+
+/*********************************************/
+
+DYNARDO_FMOP_API fmop_error_t FMOP_initializeLibrary();
+DYNARDO_FMOP_API fmop_error_t FMOP_unloadLibrary();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DYNARDO_SOS_CAPI_COMMON_H
+
+// (c) 2017, Ansys Austria GmbH (proprietary license)
+```
+
+
+[C++]: https://img.shields.io/badge/language-C%2B%2B-blue (C++)
+[public]: https://img.shields.io/badge/-public-brightgreen (public)

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/sos__capi__script_8h.md
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/sos__capi__script_8h.md
@@ -1,0 +1,528 @@
+# File sos_capi_script.h
+
+![][C++]
+
+**Location**: `sos_capi_script.h`
+
+C-API to run oSP3D scripts and exchange basic data.
+
+**copyright**\
+Ansys Austria GmbH
+
+
+
+
+
+
+
+
+* This API follows the _Basic_ exception safety _rule_. If any of the operations fail, the original data, e.g. the fmop_handle*_t, might have been overwritten, but there should be no resource leak.
+
+* Return values are typically of type [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec). To get a human readalbe interpretation forward this value to [FMOP_getErrnoString()](sos__capi__common_8h.md#sos__capi__common_8h_1a4dcdde79d3a37a80540e3a7f5b486110) or call [FMOP_getLastErrorString()](sos__capi__common_8h.md#sos__capi__common_8h_1aa79c50f0e38654fc5bf42e052b229748). More information can be found in the Error Handling section
+
+* Log messages from the oSP3D kernel are all bufferd in an internal variable. Unless otherwise stated in a function description, this internal variable gets reset(!) right at the beginning of each function call. Therefore, the user is forced into fetching all log messages of interest before proceeding.
+
+
+
+
+
+
+
+
+!> **Warning** \
+Concurrent library calls are NOT supported
+
+
+!> **Warning** \
+Unless stated otherwise, function calls overwrite log messages of any previous function call
+
+## Includes
+
+* [sos_capi_common.h](sos__capi__common_8h.md#sos__capi__common_8h)
+
+
+```mermaid
+graph LR
+2["sos_capi_common.h"]
+click 2 "sos__capi__common_8h.md#sos__capi__common_8h"
+
+1["sos_capi_script.h"]
+click 1 "sos__capi__script_8h.md#sos__capi__script_8h"
+1 --> 2
+
+```
+
+
+## Included by
+
+* [FMOPSolver.h](_f_m_o_p_solver_8h.md#_f_m_o_p_solver_8h)
+
+
+```mermaid
+graph RL
+2["FMOPSolver.h"]
+click 2 "_f_m_o_p_solver_8h.md#source"
+
+1["sos_capi_script.h"]
+click 1 "sos__capi__script_8h.md#sos__capi__script_8h"
+2 --> 1
+
+```
+
+
+## Create / Initialize Data Objects
+
+API handling data object life time
+
+<a id="sos__capi__script_8h_1ace6f8c522f626dddbf5fc12d4d1d7a11"></a>
+### Function FMOP_globalScriptEngine
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_script_handle_t FMOP_globalScriptEngine()
+```
+
+
+Get the handle to the global script engine from the initialized library. The routine checks if the Lua interpreter is available. If no, it returns 0. If yes, it returns the handle to the Lua interpreter. There is only a single instance available. Repeated calls of this functions always return the same handle.
+
+**Returns**:
+
+
+* [fmop_handle_t](fmop_solver.md#fmop__solver_8h_1aed65d1ae14f8c298a702ad5b828a70ef) if the FMOP library was previously initialized with [FMOP_initializeLibrary()](sos__capi__common_8h.md#sos__capi__common_8h_1a9c8f0f808d3f27c57a3a57d5f9cf4834)
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf) if the global script engine is unavailable
+
+
+
+**Return type**: DYNARDO_FMOP_API [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb)
+
+<a id="sos__capi__script_8h_1a86518674fc7aa5571d44f5d8544879f0"></a>
+### Function FMOP_script_createMatrix
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createMatrix(fmop_script_handle_t context, const char *const ident, int rows, int cols, const double *const data)
+```
+
+
+Creates a tmath.Matrix in Lua script context. This version may be more efficient than creating a matrix through a text based script - at least for large matrices.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the ident in Lua script of the matrix to be created
+* **rows**: the number of rows of the matrix to be created
+* **cols**: the number of columns of the matrix to be created
+* **data**: the data array of the matrix to be created. The dimension of the data array must be rows*cols. The matrix data is stored in a column-major format.
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful matrix creation
+
+* [fmop_script_no_object](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca749f1c6edf13b1303018d7a3632dc316) ident could not be accessed
+
+* [fmop_script_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becab6e0160bb71d6930176d907409618f4d) if an error occurred during LUA script execution
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has been acquired
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* int **rows**
+* int **cols**
+* const double *const **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1acd830885fbde66f6d3133d7f1e943796"></a>
+### Function FMOP_script_createNumber
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createNumber(fmop_script_handle_t context, const char *const ident, double data)
+```
+
+
+Creates a double precision floating point number variable in the Lua script context.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the number's variable name
+* **data**: the number's value
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful number creation
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf)
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has been acquired
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* double **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1a31383b3c0eb3e408c74430b1cd610183"></a>
+### Function FMOP_script_createString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createString(fmop_script_handle_t context, const char *const ident, const char *const data)
+```
+
+
+Create a string variable in the Lua script context.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the string's variable name
+* **data**: the string's text
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful string creation
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf)
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has been acquired
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* const char *const **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1a585497e6891f11a032944d26f3b0d9c0"></a>
+### Function FMOP_script_execute
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_execute(fmop_script_handle_t context, const char *const script)
+```
+
+
+Execute Lua script code. The script engine has the ability to parse and execute:
+
+* any oSP3D script code (check the command log in the oSP3D GUI and the scripting examples provided with your oSP3D installation, in the public documents folder on Windows)
+
+* any Lua code 
+**Parameters**:
+
+* **context**: handle to a script engine
+* **script**: the Lua script code to be executed
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful script execution
+
+* [fmop_script_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becab6e0160bb71d6930176d907409618f4d) if an error occurred during LUA script execution
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has beend acquired
+
+
+
+**See also**: [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **script**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1afe7c32369056cdee19411d3924538d5d"></a>
+### Function FMOP_script_getMatrix
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getMatrix(fmop_script_handle_t context, const char *const ident, int *rows, int *cols, const double **data)
+```
+
+
+Retrieves the binary data of a tmath.Matrix existing in the Lua script context The matrix must be saved in a Lua variable. The data can be retrieved in an efficient way by accessing only the data buffers in memory. Do not change the data from outside. Memory management remains with the Lua interpreter. Thus, the garbage collector may free the memory to which the output of this method refers to.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the ident of the tmath.Matrix variable in Lua.
+* **rows**: the number of rows
+* **cols**: the number of columns
+* **data**: *data will point to the matrix data array on output. The dimension of the data array must be rows*cols. The matrix data is stored in a column-major format.
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful matrix access
+
+* [fmop_script_no_object](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca749f1c6edf13b1303018d7a3632dc316) ident could not be accessed
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has been acquired
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* int * **rows**
+* int * **cols**
+* const double ** **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1a6b01058d679a651d52882f928caa14e7"></a>
+### Function FMOP_script_getNumber
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getNumber(fmop_script_handle_t context, const char *const ident, double *const data)
+```
+
+
+Retrieve the pointer to a number variable in the Lua script context. The number is is stored in double precision floating point format.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the number's variable name
+* **data**: contains the number's memory address on [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55). The caller retains ownership of the pointer.
+
+
+**Returns**:
+
+
+* [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55) on successful number access
+
+* [fmop_script_wrong_type](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca32eddc7d860101cdbb8e1571c726ee91)
+
+* [fmop_invalid_handle](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacef5c059b0dd649f97d5404db95c3ccf)
+
+* [fmop_license_error](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8becacf8dfe2eaba2eada73a26e487a04f8fe) if a license error occurred, e.g. no license has been acquired
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* double *const **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1ac1304b306d77e15fcfd1e99603bbff62"></a>
+### Function FMOP_script_getString
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getString(fmop_script_handle_t context, const char *const ident, const char **data)
+```
+
+
+Retrieve the char array pointer to a string variable in the Lua script context. The data can be retrieved in an efficient way by accessing only the data buffers in memory. Do not change the data from outside. Memory management remains with the Lua interpreter. Thus, the garbage collector may free the memory to which the output of this method refers to.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the string's variable name
+* **data**: contain's the string's text on [fmop_success](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8beca41a0a2e83b0ac20d414f4b015522ce55)
+
+
+**Returns**:
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+* const char ** **data**
+
+**Return type**: DYNARDO_FMOP_API [fmop_error_t](sos__capi__common_8h.md#sos__capi__common_8h_1a4847f3fa2943ffd694eb6cbe169a8bec)
+
+<a id="sos__capi__script_8h_1adaf34349f4a16e537f5fe8a5ceb52856"></a>
+### Function FMOP_script_identExists
+
+![][public]
+
+
+```cpp
+DYNARDO_FMOP_API bool FMOP_script_identExists(fmop_script_handle_t context, const char *const ident)
+```
+
+
+Check whether a variable exists in the Lua script context.
+
+**Parameters**:
+
+* **context**: handle to a script engine
+* **ident**: the variable's name
+
+
+**Returns**:
+
+
+* true: the ident exists
+
+* false: the ident does not exist
+
+
+
+**Parameters**:
+
+* [fmop_script_handle_t](sos__capi__script_8h.md#sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb) **context**
+* const char *const **ident**
+
+**Return type**: DYNARDO_FMOP_API bool
+
+## Typedefs
+
+<a id="sos__capi__script_8h_1aab8ff16aaa9cf05fccc70920f4b62bfb"></a>
+### Typedef fmop_script_handle_t
+
+![][public]
+
+**Definition**: `sos_capi_script.h` (line 44)
+
+
+```cpp
+typedef void* fmop_script_handle_t
+```
+
+
+Contains the data required to post-process any Field-MOP.
+
+
+
+
+
+**Return type**: void *
+
+## Source
+
+
+```cpp
+
+#ifndef DYNARDO_SOS_SCRIPT_H
+    #define DYNARDO_SOS_SCRIPT_H
+
+#include "sos_capi_common.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*********************************************/
+
+#ifdef DYNARDO_FMOP_DLL_EXPORTS
+    typedef class FMOP_ScriptInterpreter* fmop_script_handle_t;
+#else
+    typedef void* fmop_script_handle_t;
+#endif
+
+
+/*********************************************/
+
+
+/*
+ *
+#ifndef DOXYGEN_IGNORE
+DYNARDO_FMOP_API fmop_error_t FMOP_loadDbBuf
+    ( fmop_db_handle_t * database, const char* buffer, const size_t * length );
+
+// FMOP_saveDbBuf
+
+#endif
+
+
+*/
+
+
+
+DYNARDO_FMOP_API fmop_script_handle_t FMOP_globalScriptEngine();
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_execute(fmop_script_handle_t context,
+                                                  const char * const script);
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createMatrix(fmop_script_handle_t context,
+                                                       const char * const ident,
+                                                       int rows, int cols, const double * const data);
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getMatrix(fmop_script_handle_t context,
+                                                    const char * const ident,
+                                                    int * rows, int *cols, const double **data);
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createNumber(fmop_script_handle_t context,
+                                                       const char * const ident,
+                                                       double data);
+
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getNumber(fmop_script_handle_t context,
+                                                    const char * const ident,
+                                                    double * const data);
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_createString(fmop_script_handle_t context,
+                                                       const char * const ident,
+                                                       const char * const data);
+
+DYNARDO_FMOP_API fmop_error_t FMOP_script_getString(fmop_script_handle_t context,
+                                                    const char * const ident,
+                                                    const char **data);
+
+DYNARDO_FMOP_API bool FMOP_script_identExists(fmop_script_handle_t context, const char * const ident);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // DYNARDO_SOS_SCRIPT_H
+
+// (c) 2018, Ansys Austria GmbH (proprietary license)
+```
+
+
+[C++]: https://img.shields.io/badge/language-C%2B%2B-blue (C++)
+[public]: https://img.shields.io/badge/-public-brightgreen (public)

--- a/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/toc.yml
+++ b/docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/toc.yml
@@ -1,0 +1,16 @@
+- name: Introduction
+  href: index.md
+- name: Content
+  items:
+    - name: Global content
+      href: global_contents.md
+    - name: Files
+      href: file_contents.md
+- name: Index pages
+  items:
+    - name: Global index
+      href: global_index.md
+    - name: Files
+      href: file_index.md
+- name: Changelog
+  href: changelog.md


### PR DESCRIPTION
## Summary

- Step 1a baseline folder for 27R1: copy `2026.R1.SP03` → `2027.R1.SP00`
- Updated `docfx.json` metadata and `changelog.md` for 2027 R1
- Contributor-owned folder creation per Melanie Jul 10 sandbox workflow

## Files changed

14 files under `docs/optislang/osl-fmop-solver-api/versions/2027.R1.SP00/`

## Test plan

- [ ] PR targets `sandbox`
- [ ] After merge: spot-check package on https://developer-a.synopsys.com/