### PR TITLE
Trigger prod migration for oSL Interface Customization 2026 R1

### DIFF
--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/changelog.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/changelog.md
@@ -4,6 +4,10 @@
 - deprecated OSL_PROJECT_DIR; added OSL_PROJECT_WORKING_DIR and OSL_PROJECT_FILE_DIR
 - refreshed external documentation links (MOP Solver API, Ansys Product Help references, integration demo download)
 - synced Integration Node data exchange KWARGs with XML (`reference_file_path` added; `reference_file` deprecated)
+- updated `ScriptInterfaceVersion` description in configuration files topic
+- restored Integration Node API anchor links
+- corrected `reset_hid` incoming argument name and cross-reference
+- clarified load return-value list wording on Integration Node topic
 
 ## 2025 R2 
 


### PR DESCRIPTION
## Summary

- Add changelog entries for Jul 2026 Interface Customization updates (ScriptInterfaceVersion text, anchor links, reset_hid fix, load return-value wording).
- Triggers Document Migration to republish \2026.R1.SP00\ to production after Jul 7 merges (#449, #450) landed on \main\ but were not published (migration workflow shallow-checkout miss, fixed Jul 9).

## Test plan

- [ ] Melanie merges PR to \main\
- [ ] Document Migration workflow detects \docs/optislang/osl-interface-customization/versions/2026.R1.SP00\ and creates migration job
- [ ] Verify \ScriptInterfaceVersion\ text on developer.ansys.com config files topic

Made with [Cursor](https://cursor.com)