### PR TITLE
Fix UTF-8 BOM in MCRE Java API toc.yml (PR 464 migration)

### DIFF
--- a/docs/modelcenter/modelcenter-remote-execution-java-api/versions/2026.R1.SP03/toc.yml
+++ b/docs/modelcenter/modelcenter-remote-execution-java-api/versions/2026.R1.SP03/toc.yml
@@ -1,4 +1,4 @@
-﻿- name: Introduction
+- name: Introduction
   href: index.md
 - name: Getting started
   href: started.md

--- a/docs/modelcenter/modelcenter-remote-execution-java-api/versions/2027.R1.SP00/toc.yml
+++ b/docs/modelcenter/modelcenter-remote-execution-java-api/versions/2027.R1.SP00/toc.yml
@@ -1,4 +1,4 @@
-﻿- name: Introduction
+- name: Introduction
   href: index.md
 - name: Getting started
   href: started.md


### PR DESCRIPTION
## Summary

- Remove UTF-8 byte-order mark from \	oc.yml\ in \2027.R1.SP00\ and source \2026.R1.SP03\ for modelcenter-remote-execution-java-api.
- Fixes sandbox migration failure reported on PR 464: invalid YML content in table of contents.
- BOM was introduced in commit a231c258c (Jun 15 getting-started edit) and copied into the 2027 baseline.

## Test plan

- [ ] Melanie merges PR to \sandbox\
- [ ] Document Migration job succeeds for \docs/modelcenter/modelcenter-remote-execution-java-api/versions/2027.R1.SP00\
- [ ] Spot-check package on https://developer-a.synopsys.com/
- [ ] Confirm TOC navigation works end-to-end

Made with [Cursor](https://cursor.com)