### PR TITLE
1477589 - Fix unclosed execute_custom code fence on oSL Python Node topics

### DIFF
--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/changelog.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/changelog.md
@@ -8,6 +8,7 @@
 - restored Integration Node API anchor links
 - corrected `reset_hid` incoming argument name and cross-reference
 - clarified load return-value list wording on Integration Node topic
+- fixed unclosed `execute_custom` code fence on Basic, Integration, and MOP Node topics (#1477589)
 
 ## 2025 R2 
 

--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_basic.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_basic.md
@@ -69,7 +69,7 @@ The execute_custom function can be triggered from the QML layer using the follow
 
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 

--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_integration.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_integration.md
@@ -95,7 +95,7 @@ The execute_custom function can be triggered from the QML layer using the follow
 
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 

--- a/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_mop.md
+++ b/docs/optislang/osl-interface-customization/versions/2026.R1.SP00/opti_api_python_nodes_mop.md
@@ -69,7 +69,7 @@ This function serves as flexible, general-purpose, signal and information channe
 The execute_custom function can be triggered from the QML layer using the following:
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 
 The function can be used for as many types of tasks as needed, and as often as needed. Various different QML user interface elements created by you can trigger `execute_custom`, and in the QML code you can put together any kind of cargo-containing JSON to pass over to the Python layer. At the same time, in the Python layer, inside `execute_custom` you can trigger any kind of work on the Python side. When a task is resolved, you can send the result of the Python work back to the QML layer in the same way. A dictionary is used for the communication back to the QML layer.


### PR DESCRIPTION
## Summary

- Fix malformed closing fence (\\\javascript → \\\) in \execute_custom\ code example on Basic, Integration, and MOP Node topics (\2026.R1.SP00\).
- The bad close left the remainder of each page rendering as one giant code/quoted block (Benjamin Bendig #1477589).
- Changelog entry added to trigger Document Migration republish.

## Test plan

- [ ] Verify \opti_api_python_nodes_integration.md#functions-to-implement\ renders prose below \execute_custom\ on developer.ansys.com after migration
- [ ] Spot-check Basic and MOP Node topics

Work item: #1477589

Made with [Cursor](https://cursor.com)