### PR TITLE
1477573/1477589/1477693 - Forward-port 26R1 oSL Interface Customization fixes to 2027.R1.SP00

### DIFF
--- a/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/changelog.md
+++ b/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/changelog.md
@@ -2,6 +2,11 @@
 
 ## 2027 R1
 - added `StdErrIndicatesError` to Integration-specific configuration settings
+- updated `ScriptInterfaceVersion` description in configuration files topic
+- restored Integration Node API anchor links
+- corrected `reset_hid` incoming argument name and cross-reference
+- clarified load return-value list wording on Integration Node topic
+- fixed unclosed `execute_custom` code fence on Basic, Integration, and MOP Node topics
 
 ## 2026 R1
 - deprecated OSL_PROJECT_DIR; added OSL_PROJECT_WORKING_DIR and OSL_PROJECT_FILE_DIR

--- a/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_basic.md
+++ b/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_basic.md
@@ -69,7 +69,7 @@ The execute_custom function can be triggered from the QML layer using the follow
 
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 

--- a/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_config_files.md
+++ b/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_config_files.md
@@ -8,7 +8,7 @@ The following name-value pairs can be contained in the file:
 |----------------------------|------------------|
 | Name                       | Specifies a distinct display name. |
 | Maturity                   | Specifies the level of development. Allowed values are `Beta`, `Stable`, and `Deprecated`. |
-| ScriptInterfaceVersion     | Specifies the version of the script interface. In the current optiSLang version, interface version 3 is the recommended choice for all node types. |
+| ScriptInterfaceVersion     | Specifies the version of the script interface and provides backwards compatibilty. Ensure this variable is set to the version of the current optiSLang release(i.e 2710). Defaults to a legacy version of the API. |
 | EnableParallel             | Allows parallel execution of multiple instances of the integration. Allowed values are `true` and `false`.<br>Related default property values can be `MaxParallel` for the number of processes to be started in parallel and `DelayBetweenExecutions` in `[ms]` for the time interval between process calls (see `DefaultPropertiesValues`). |
 | EnableMultiDesignMode      | Enables multiple designs being passed to script at once. Allowed values are `true` and `false`.<br>A related default property value can be `MultiDesignLaunchNum` for the number of designs sent to each process at once (see `DefaultPropertiesValues`). |
 | PythonPath                 | List of search directories. Separate different paths using `;` on Windows or `:` on Linux. |

--- a/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_integration.md
+++ b/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_integration.md
@@ -7,6 +7,8 @@ The following topics describe the framework for creating a Python-based integrat
 - [Essential and Additional Files](#essential-and-additional-files)
 - [Integration plugin demonstrators](#integration-plugin-demonstrators)
 
+<a id="basic-requirements"></a>
+
 ## Basic Requirements
 The following requirements must be met for optiSLang to detect, load, and execute a plugin you provide.
 
@@ -16,6 +18,8 @@ The following requirements must be met for optiSLang to detect, load, and execut
     - The default custom plugin folder belonging to the installation: `[installation path]/scripting/integrations`
     - An alternative customized integrations directory specified in the `SC_AlternativeCIDirectories` entry of the optiSLang configuration file.
     - An alternative customized integrations directory specified by the environment variable `OSL_ALT_CI_SEARCH_DIRS`
+
+<a id="functions-to-implement"></a>
 
 ## Functions to Implement
 You can add a plugin for extending optiSLang by providing a Python file following a special naming convention and by implementing a set of functions within it following special naming and signature conventions.
@@ -42,6 +46,8 @@ You do not need to declare anywhere explicitly the set of functions you are impl
 
 The following functions are available:
 
+<a id="load"></a>
+
 ### load
 This function is called when opening the node’s edit dialog box. In this function, define inputs (`InputValueDefinition`) and outputs (`OutputValueDefinition`) which are used in the node’s edit dialog box to register parameters and responses.
 
@@ -50,8 +56,10 @@ This function is called when opening the node’s edit dialog box. In this funct
 
 **Return Values**
 - List of two elements:
-    - [InputValueDefinition](#table-13-contents-of-inputvaluedefinition)
-    - [OutputValueDefinition](#table-14-contents-of-outputvaluedefinition)
+    - List of [InputValueDefinition](#table-13-contents-of-inputvaluedefinition)
+    - List of [OutputValueDefinition](#table-14-contents-of-outputvaluedefinition)
+
+<a id="execute"></a>
 
 ### execute
 This function is used to call your solver.
@@ -62,6 +70,8 @@ This function is used to call your solver.
 
 **Return Values**
 - List of [HidSpecificOutputDataIntegrations](#table-12-hidspecificoutputdataintegrations-attributes)
+
+<a id="default_settings"></a>
 
 ### default_settings
 This function defines the set of default settings associated with each new node instance. In a dictionary, you supply name-value pairs. The value type is important, for example, by forwarding a boolean value this setting is determined to be a boolean switch. Your code should then not set any other value type later. Without supplying any QML code for drawing user interface elements, optiSLang will add generic user interface elements, and these are determined by the value type given here. For instance, a boolean value induces optiSLang to display a check box in the node edit dialog box, whereas for string values a text entry field is created. The value types supported are boolean, integer, float, and string.
@@ -76,6 +86,8 @@ Note: In `default_settings`, you define the sequence of setting names and value 
 **Return Values**
 - List with zero to two elements containing `modifying_settings` and/or `non_modifying_settings` as Python objects or lists of tuples.
 
+<a id="execute_custom"></a>
+
 ### execute_custom
 This function serves as flexible, general-purpose, signal and information channel between the QML layer and the Python layer. When you access tabs, entries, and buttons in the QML-based settings user interface, the QML layer is running the process. If you need logic evaluation or other small computations, the QML layer allows for lines of JavaScript. However, if you cannot solve all settings-related work steps in the QML layer, then the `execute_custom` function allows you to trigger work in the Python layer and collect work results from there.
 
@@ -83,7 +95,7 @@ The execute_custom function can be triggered from the QML layer using the follow
 
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 
@@ -96,6 +108,8 @@ The function can be used for as many types of tasks as needed, and as often as n
 **Return Values**
 - Return cargo, can represent a JSON dictionary.
 
+<a id="check"></a>
+
 ### check
 This function is called at the start of execution. You can use it to check if there are any issues preventing successful execution, and if there are, provide an early stop to prevent a potential time-consuming run.
 
@@ -104,6 +118,8 @@ This function is called at the start of execution. You can use it to check if th
 
 **Return Values**
 - `RunStatus`: An object for documenting success and logging.
+
+<a id="reset"></a>
 
 ### reset
 This function is called when the node is reset.
@@ -115,15 +131,19 @@ This function is called when the node is reset.
 **Return Values**
 - `RunStatus`: An object for documenting success and logging.
 
+<a id="reset_hid"></a>
+
 ### reset_hid
 This function is called when the node is reset for a single HID.
 
 **Incoming Arguments**
 - [Common Incoming Key Word Arguments (KWARGs)](#table-7-common-incoming-key-word-arguments-kwargs)
-- `hid`: Hierarchical ID of a design variation, for example, `[0.99.4]`.
+- `input`: [HidSpecificInputDataIntegrations](#table-11-hidspecificinputdataintegrations-attributes) An aggregate of various input data.
 
 **Return Values**
 - `RunStatus`: An object for documenting success and logging.
+
+<a id="initialize"></a>
 
 ### initialize
 You can use the initialize and shutdown functions to create and close a Python work environment. In some use cases, it can be difficult to use separate, atomic, agnostic functions, so it may be easier to work in a session-based manner. Initialize and shutdown allow you to, for example, avoid loading a heavy solver program multiple times during the lifecycle for one design and repeatedly for many designs by keeping a session/connection with one solver program instance alive all the time.
@@ -138,6 +158,8 @@ You can find a simple demo exploiting the initialize-shutdown mechanism in the [
 **Return Values**
 - Returns nothing or None.
 
+<a id="shutdown"></a>
+
 ### shutdown
 You can use the initialize and shutdown functions to create and close a Python work environment. In some use cases, it can be difficult to use separate, atomic, agnostic functions, so it may be easier to work in a session-based manner. The shutdown function allows you to close logs, any other open files, terminate sub-processes, close client program sessions, remote connections, and so on. In short, close down and tidy up the session workspace you have created with INI and which has evolved over many cycles of calling the other elementary integration functions.
 
@@ -146,6 +168,8 @@ You can use the initialize and shutdown functions to create and close a Python w
 
 **Return Values**
 - Returns nothing or None.
+
+<a id="get_required_license_caps"></a>
 
 ### get_required_license_caps
 This function provides the license capabilities of the integration node plugin.
@@ -156,6 +180,8 @@ This function provides the license capabilities of the integration node plugin.
 **Return Values**
 - List of license capabilities as strings.
 
+<a id="migrate_settings"></a>
+
 ### migrate_settings
 This function can be used to update the settings of a node that was saved with an older version of the integration with different settings.
 
@@ -164,6 +190,8 @@ This function can be used to update the settings of a node that was saved with a
 
 **Return Values**
 - List with zero to two elements containing modifying_settings and/or non_modifying_settings as Python objects or lists of tuples.
+
+<a id="node_renamed"></a>
 
 ### node_renamed
 This function can be used to react on a change of the node's name.
@@ -176,6 +204,8 @@ This function can be used to react on a change of the node's name.
 **Return Values**
 - RunStatus: An object for documenting success and logging.
 
+<a id="data-exchange"></a>
+
 ## Data Exchange
 Data exchange is done using exported optiSLang built-in types, lists, and dictionaries.
 
@@ -187,6 +217,8 @@ The following types are essential for implementing the data exchange between opt
 - [OutputValueDefinition](#table-14-contents-of-outputvaluedefinition): An object for defining outputs.
 
 The following tables describe the standardized data structures of important objects transferred to several of the plugin functions where they are received in a structure of arguments.
+
+<a id="table-7-common-incoming-key-word-arguments-kwargs"></a>
 
 **Table 7: Common Incoming Key Word Arguments (KWARGs)**
 
@@ -202,6 +234,8 @@ The following tables describe the standardized data structures of important obje
 | reference_file_is_relative_to_working_directory | Bool | Optional: Whether or not the path to reference file is relative to the working directory. <br>Only available if `FileBased` is not set to `false` in the [configuration file](opti_api_python_nodes_config_files.md). |
 | reference_file<br>***Deprecated.*** | String | ***Deprecated.***<br>Optional: Path to the reference file. <br>Only available if `FileBased` is not set to `false` in the [configuration file](opti_api_python_nodes_config_files.md). |
 
+<a id="table-8-additional-incoming-kwargs-for-the-execute-function"></a>
+
 **Table 8: Additional Incoming KWARGs for the Execute Function**
 
 | Name | Type | Description |
@@ -209,6 +243,8 @@ The following tables describe the standardized data structures of important obje
 | input_container | List of `HidSpecificInputDataIntegrations` | Aggregate of arguments per HID. |
 | registered_inputs | Dictionary | Dictionary of inputs that are registered in optiSLang. |
 | registered_outputs | Dictionary | Dictionary of outputs that are registered in optiSLang. |
+
+<a id="table-9-optislang-variables-that-do-not-vary-per-hid"></a>
 
 **Table 9: optiSLang Variables That Do Not Vary Per HID**
 
@@ -222,6 +258,8 @@ The following tables describe the standardized data structures of important obje
 | OSL_RLS_FLG | String | A version suffix which is normally empty unless a specific build is set. |
 | OSL_PROJECT_DIR<br>***Deprecated.*** | String | ***Deprecated.***<br>Absolute path of the current project (`*.opd`). |
 
+<a id="table-10-optislang-variables-that-vary-per-hid-in-execute-function"></a>
+
 **Table 10: optiSLang Variables that Vary Per HID in Execute Function**
 
 | Name | Type | Description |
@@ -229,6 +267,8 @@ The following tables describe the standardized data structures of important obje
 | OSL_DESIGN_NO | String | Design number. |
 | OSL_DESIGN_NAME | String | Design directory name (for example, Design_0001). |
 | OSL_DESIGN_DIR | String | Absolute path of the current design directory. |
+
+<a id="table-11-hidspecificinputdataintegrations-attributes"></a>
 
 **Table 11: HidSpecificInputDataIntegrations Attributes**
 
@@ -244,6 +284,8 @@ The following tables describe the standardized data structures of important obje
 | parameter_values | PyOsDesignPoint | Parameter values for a specific HID. |
 | reference_file<br>***Deprecated.*** | String | ***Deprecated.***<br>Optional: Path to the reference file. <br>Only available if `FileBased` is not set to `false` in the [configuration file](opti_api_python_nodes_config_files.md). |
 
+<a id="table-12-hidspecificoutputdataintegrations-attributes"></a>
+
 **Table 12: HidSpecificOutputDataIntegrations Attributes**
 
 | Name | Type | Description |
@@ -253,6 +295,8 @@ The following tables describe the standardized data structures of important obje
 | status | RunStatus | An object for documenting success and logging. |
 | responses | PyOsDesignPoint | The responses and their values. |
 | adapted_parameter_values | PyOsDesignPoint | Optional: The parameter values used by the solver.<br>Normally these are equal to `parameter_values` of `HidSpecificInputDataIntegrations` but if the solver requires adaptation (formatting, precision) of the parameters, the integration author can communicate theses parameters and their values to optiSLang. They are then shown in the design table. |
+
+<a id="table-13-contents-of-inputvaluedefinition"></a>
 
 **Table 13: Contents of InputValueDefinition**
 
@@ -268,6 +312,8 @@ The following tables describe the standardized data structures of important obje
 | mean | Float | Optional: Mean of the data. |
 | std_dev_ | Float | Optional: Spread of the data. |
 
+<a id="table-14-contents-of-outputvaluedefinition"></a>
+
 **Table 14: Contents of OutputValueDefinition**
 
 | Name | Type | Description |
@@ -275,6 +321,8 @@ The following tables describe the standardized data structures of important obje
 | name | String | Name of the output. |
 | reference_value | PyOsDesignEntry | The input's reference value. |
 | additional_data | Dictionary | Specifies additional data (for example, unit). It is then used to create an additional column in the parameter registration in the node edit dialog box.<br>Tree view: When providing *entry_n* with *n* from 1-9 as `key` and a leaf name as `value`, a tree structure for grouping purposes can be created in the parameter registration. |
+
+<a id="essential-and-additional-files"></a>
 
 ## Essential and Additional Files
 The following image shows a standard set of files for creating a Python-based integration node.

--- a/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_mop.md
+++ b/docs/optislang/osl-interface-customization/versions/2027.R1.SP00/opti_api_python_nodes_mop.md
@@ -69,7 +69,7 @@ This function serves as flexible, general-purpose, signal and information channe
 The execute_custom function can be triggered from the QML layer using the following:
 ```javascript
 backend.executeCustom(JSON.stringify(info_container))
-```javascript
+```
 Information exchange between the QML and Python layers using `execute_custom` occurs using JSON which is represented as a dictionary on the Python side.
 
 The function can be used for as many types of tasks as needed, and as often as needed. Various different QML user interface elements created by you can trigger `execute_custom`, and in the QML code you can put together any kind of cargo-containing JSON to pass over to the Python layer. At the same time, in the Python layer, inside `execute_custom` you can trigger any kind of work on the Python side. When a task is resolved, you can send the result of the Python work back to the QML layer in the same way. A dictionary is used for the communication back to the QML layer.


### PR DESCRIPTION
## Summary

- Forward-port 26R1 oSL Interface Customization API doc fixes to **2027.R1.SP00 only**
- ScriptInterfaceVersion description (2710), Integration Node anchor links, `reset_hid` correction, load return-value list wording, and `execute_custom` code-fence fixes
- Work items: #1477573, #1477589, #1477693

**Replaces PR #470** — split per Melanie's one-version-folder-per-PR rule so Dev Portal migration triggers correctly. SP01 forward-port will follow in a separate PR after this merges.

## Test plan

- [ ] Verify the doc set renders correctly on the developer portal
- [ ] Confirm TOC navigation works end-to-end
- [ ] Verify all internal cross-links resolve correctly
- [ ] After merge, spot-check on https://developer-a.synopsys.com/