### PR TITLE
1471466 - Fix SP03 docfx.json version metadata (follow-up to #444)

### DIFF
--- a/docs/modelcenter/modelcenter-api/versions/2026.R1.SP03/docfx.json
+++ b/docs/modelcenter/modelcenter-api/versions/2026.R1.SP03/docfx.json
@@ -1,9 +1,9 @@
 {
   "build": {
     "globalMetadata": {
-      "title": "ModelCenter APIs 2026 R1",
-      "summary": "COM and Java APIs for automating and extending ModelCenter 2026 R1.",
-      "version": "2026 R1",
+      "title": "ModelCenter APIs 2026 R1 SP03",
+      "summary": "COM and Java APIs for automating and extending ModelCenter 2026 R1 SP03.",
+      "version": "2026 R1 SP03",
       "product": "ModelCenter",
       "programming language": "",
       "product collection": "Connect",


### PR DESCRIPTION
## Summary

- Correct `globalMetadata` in `modelcenter-api/versions/2026.R1.SP03/docfx.json` after PR #444 merged with SP00-style version strings.
- Sets `title`, `summary`, and `version` to **2026 R1 SP03** so sandbox migration to main can run.
- API content unchanged from #444; metadata-only follow-up.

## Test plan

- [ ] Melanie review
- [ ] After merge, spot-check package metadata on https://developer-a.synopsys.com/

## ADO

Work item 1471466 — follow-up to https://github.com/ansys/DevRelDocs/pull/444