### PR TITLE
Fix osl-python-api SP03 docfx version metadata on sandbox

### DIFF
--- a/docs/optislang/osl-python-api/versions/2026.R1.SP03/docfx.json
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP03/docfx.json
@@ -1,9 +1,9 @@
 {
     "build": {
         "globalMetadata": {
-            "title": "optiSLang Python API 2026 R1",
-            "summary": "Python API reference for scripting and automation in optiSLang, 2026 R1.",
-            "version": "2026 R1",
+            "title": "optiSLang Python API 2026 R1 SP03",
+            "summary": "Python API reference for scripting and automation in optiSLang, 2026 R1 SP03.",
+            "version": "2026 R1 SP03",
             "product": "optiSLang",
             "programming language": "Python",
             "product collection": "Connect",


### PR DESCRIPTION
## Summary

- Set `globalMetadata.title`, `summary`, and `version` to **2026 R1 SP03** in `docs/optislang/osl-python-api/versions/2026.R1.SP03/docfx.json`.
- Same remediation pattern as MC API SP03 docfx fix (bdb6b28af): wrong SP00-style version strings break portal migration for the SP03 folder.

## Test plan

- [ ] Only `2026.R1.SP03/docfx.json` changes in this PR.
- [ ] Migration preview shows SP03 package version as 2026 R1 SP03 on developer-a after merge.