### PR TITLE
Add Changelog TOC entry for osl-python-api 2026.R1.SP00

### DIFF
--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/toc.yml
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/toc.yml
@@ -80,3 +80,7 @@
     href: modules/_optiSLang_Actors.md
   - name: _optiSLang_Kernel
     href: modules/_optiSLang_Kernel.md
+- name: Changelog
+  href: changelog.md
+- name: Changelog
+  href: changelog.md

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/toc.yml
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/toc.yml
@@ -82,5 +82,3 @@
     href: modules/_optiSLang_Kernel.md
 - name: Changelog
   href: changelog.md
-- name: Changelog
-  href: changelog.md


### PR DESCRIPTION
## Summary

- Add **Changelog** entry to `toc.yml` for `osl-python-api` `2026.R1.SP00` so the developer portal sidebar shows the existing `changelog.md`.
- SP03 already had this TOC link from the June compliance work; base 26R1 (SP00) was missed.

## Context

Melanie flagged that Changelog was visible in PR diffs but not on the portal for 26R1 — root cause was `changelog.md` present without a matching `toc.yml` href.

## Test plan

- [ ] Portal build for `optislang-python-api-2026-r1-sp00` shows **Changelog** in left nav
- [ ] Changelog page renders at `/docs/optislang-python-api-2026-r1-sp00/changelog.md`
- [ ] TOC navigation still works end-to-end
