### PR TITLE
MOP Solver API — fix Mermaid 11 graph syntax and add Header files TOC (2026.R1.SP00)

### DIFF
--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2_8h.md
@@ -12,17 +12,15 @@ $Rev$
 * [mopsolver_api2_shared.h](mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h)
 
 ```mermaid
-graph LR
-1["mopsolver_api2.h"]
-click 1 "mopsolver__api2_8h.md#mopsolver__api2_8h"
-1 --> 2
-
-2["mopsolver_api2_shared.h"]
-click 2 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
-2 --> 3
-
-3["mopsolver_api_shared.h"]
-
+flowchart LR
+  n1["mopsolver_api2.h"]
+  n2["mopsolver_api2_shared.h"]
+  n3["mopsolver_api_shared.h"]
+  n1 --> n2
+  n2 --> n3
+  click n1 href "mopsolver__api2_8h.md#mopsolver__api2_8h"
+  click n2 href "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
+  click n3 href "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
 ```
 
 ## Functions

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__hash_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__hash_8h.md
@@ -9,17 +9,15 @@
 * [mopsolver_api2_shared.h](mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h)
 
 ```mermaid
-graph LR
-1["mopsolver_api2_hash.h"]
-click 1 "mopsolver__api2__hash_8h.md#mopsolver__api2__hash_8h"
-1 --> 2
-
-2["mopsolver_api2_shared.h"]
-click 2 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
-2 --> 3
-
-3["mopsolver_api_shared.h"]
-
+flowchart LR
+  n1["mopsolver_api2_hash.h"]
+  n2["mopsolver_api2_shared.h"]
+  n3["mopsolver_api_shared.h"]
+  n1 --> n2
+  n2 --> n3
+  click n1 href "mopsolver__api2__hash_8h.md#mopsolver__api2__hash_8h"
+  click n2 href "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
+  click n3 href "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
 ```
 
 ## Functions

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__shared_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__shared_8h.md
@@ -12,13 +12,12 @@ $Rev$
 * [mopsolver_api_shared.h](mopsolver__api__shared_8h.md#mopsolver__api__shared_8h)
 
 ```mermaid
-graph LR
-1["mopsolver_api2_shared.h"]
-click 1 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
-1 --> 2
-
-2["mopsolver_api_shared.h"]
-
+flowchart LR
+  n1["mopsolver_api2_shared.h"]
+  n2["mopsolver_api_shared.h"]
+  n1 --> n2
+  click n1 href "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
+  click n2 href "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
 ```
 
 ## Included by
@@ -27,17 +26,15 @@ click 1 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
 * [mopsolver_api2_hash.h](mopsolver__api2__hash_8h.md#mopsolver__api2__hash_8h)
 
 ```mermaid
-graph RL
-2["mopsolver_api2.h"]
-click 2 "mopsolver__api2_8h.md#mopsolver__api2_8h"
-
-3["mopsolver_api2_hash.h"]
-
-1["mopsolver_api2_shared.h"]
-click 1 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
-2 --> 1
-3 --> 1
-
+flowchart RL
+  n1["mopsolver_api2_shared.h"]
+  n2["mopsolver_api2.h"]
+  n3["mopsolver_api2_hash.h"]
+  n2 --> n1
+  n3 --> n1
+  click n1 href "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
+  click n2 href "mopsolver__api2_8h.md#mopsolver__api2_8h"
+  click n3 href "mopsolver__api2__hash_8h.md#mopsolver__api2__hash_8h"
 ```
 
 ## Enumeration types

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api_8h.md
@@ -12,13 +12,12 @@ $Rev$
 * [mopsolver_api_shared.h](mopsolver__api__shared_8h.md#mopsolver__api__shared_8h)
 
 ```mermaid
-graph LR
-1["mopsolver_api.h"]
-click 1 "mopsolver__api_8h.md#mopsolver__api_8h"
-1 --> 2
-
-2["mopsolver_api_shared.h"]
-
+flowchart LR
+  n1["mopsolver_api.h"]
+  n2["mopsolver_api_shared.h"]
+  n1 --> n2
+  click n1 href "mopsolver__api_8h.md#mopsolver__api_8h"
+  click n2 href "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
 ```
 
 ## Functions

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api__shared_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api__shared_8h.md
@@ -10,25 +10,21 @@
 * [mopsolver_api2_shared.h](mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h)
 
 ```mermaid
-graph RL
-2["mopsolver_api.h"]
-click 2 "mopsolver__api_8h.md#mopsolver__api_8h"
-
-4["mopsolver_api2.h"]
-click 4 "mopsolver__api2_8h.md#mopsolver__api2_8h"
-
-5["mopsolver_api2_hash.h"]
-
-3["mopsolver_api2_shared.h"]
-click 3 "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
-4 --> 3
-5 --> 3
-
-1["mopsolver_api_shared.h"]
-click 1 "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
-2 --> 1
-3 --> 1
-
+flowchart RL
+  n1["mopsolver_api_shared.h"]
+  n2["mopsolver_api.h"]
+  n3["mopsolver_api2_shared.h"]
+  n4["mopsolver_api2.h"]
+  n5["mopsolver_api2_hash.h"]
+  n4 --> n3
+  n5 --> n3
+  n2 --> n1
+  n3 --> n1
+  click n1 href "mopsolver__api__shared_8h.md#mopsolver__api__shared_8h"
+  click n2 href "mopsolver__api_8h.md#mopsolver__api_8h"
+  click n3 href "mopsolver__api2__shared_8h.md#mopsolver__api2__shared_8h"
+  click n4 href "mopsolver__api2_8h.md#mopsolver__api2_8h"
+  click n5 href "mopsolver__api2__hash_8h.md#mopsolver__api2__hash_8h"
 ```
 
 ## Macros

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__dlpublic_8h.md
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__dlpublic_8h.md
@@ -9,13 +9,11 @@
 * dlvisibility.h
 
 ```mermaid
-graph LR
-1["mopsolver_dlpublic.h"]
-click 1 "mopsolver__dlpublic_8h.md#mopsolver__dlpublic_8h"
-1 --> 2
-
-2["dlvisibility.h"]
-
+flowchart LR
+  n1["mopsolver_dlpublic.h"]
+  n2["dlvisibility.h"]
+  n1 --> n2
+  click n1 href "mopsolver__dlpublic_8h.md#mopsolver__dlpublic_8h"
 ```
 
 ## Macros

--- a/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/toc.yml
+++ b/docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/toc.yml
@@ -6,6 +6,20 @@
       href: global_contents.md
     - name: Files
       href: file_contents.md
+    - name: Header files
+      items:
+        - name: mopsolver_api2.h
+          href: mopsolver__api2_8h.md
+        - name: mopsolver_api2_shared.h
+          href: mopsolver__api2__shared_8h.md
+        - name: mopsolver_api.h
+          href: mopsolver__api_8h.md
+        - name: mopsolver_api2_hash.h
+          href: mopsolver__api2__hash_8h.md
+        - name: mopsolver_api_shared.h
+          href: mopsolver__api__shared_8h.md
+        - name: mopsolver_dlpublic.h
+          href: mopsolver__dlpublic_8h.md
 - name: Index pages
   items:
     - name: Global index


### PR DESCRIPTION
## Summary

- Fix Mermaid 11 syntax errors on MOP Solver API include-graph blocks in `2026.R1.SP00` (7 blocks across 6 header files): `graph` → `flowchart`, numeric node IDs → `n{id}`, `click href` syntax
- Add **Header files** subsection to `toc.yml` (6 entries) so header pages are browsable from the sidebar

## Test plan

- [ ] Dev Portal: `mopsolver__api2__shared_8h.md` — both Includes and Included-by graphs render (no Mermaid 11 syntax error banner)
- [ ] Dev Portal: `mopsolver__api__shared_8h.md` — 5-node Included-by graph renders
- [ ] Sidebar: Content → Header files → all 6 entries resolve
- [ ] Confirm TOC navigation works end-to-end

## Files changed

- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__shared_8h.md` (2 blocks)
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api__shared_8h.md`
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2__hash_8h.md`
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api2_8h.md`
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__api_8h.md`
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/mopsolver__dlpublic_8h.md`
- `docs/optislang/osl-mop-solver-api/versions/2026.R1.SP00/toc.yml`

## Notes

- Production readability fix on live `2026.R1.SP00` — `pr_target: main`
- No ADO ticket id yet (branch `LGP/26R1/mopsolver-mermaid-toc`); will link WI when created
- Related: API doc pipelines epic 1437278
