### PR TITLE
fix(osl-python-api): restore clickable cross-ref links in 2026.R1.SP00 modules

### DIFF
--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyARSM.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyARSM.md
@@ -4,32 +4,102 @@
 
 ## *class* PyARSM.Arsm
 
-- <a id="PyARSM.Arsm.__init__"></a>`__init__(arg2: [OptimizerSettingsARSM](#PyARSM.OptimizerSettingsARSM))`
-- <a id="PyARSM.Arsm.get_iteration_number"></a>`get_iteration_number() → int`
-- <a id="PyARSM.Arsm.set_responses"></a>`set_responses(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyARSM.Arsm.set_terminated"></a>`set_terminated()`
+<a id="PyARSM.Arsm.__init__"></a>
+
+#### \_\_init_\_(arg2: [OptimizerSettingsARSM](#PyARSM.OptimizerSettingsARSM))
+
+<a id="PyARSM.Arsm.get_iteration_number"></a>
+
+#### get_iteration_number() → int
+
+<a id="PyARSM.Arsm.set_responses"></a>
+
+#### set_responses(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyARSM.Arsm.set_terminated"></a>
+
+#### set_terminated()
 
 <a id="PyARSM.OptimizerSettingsARSM"></a>
 
 ## *class* PyARSM.OptimizerSettingsARSM
 
-- <a id="PyARSM.OptimizerSettingsARSM.__init__"></a>`__init__()`
-- <a id="PyARSM.OptimizerSettingsARSM.get_doe_settings"></a>`get_doe_settings() → [DOESettings](py_doe_settings.md#py_doe_settings.DOESettings)`
-- <a id="PyARSM.OptimizerSettingsARSM.get_max_iteration"></a>`get_max_iteration() → int`
-- <a id="PyARSM.OptimizerSettingsARSM.get_min_iteration"></a>`get_min_iteration() → int`
-- <a id="PyARSM.OptimizerSettingsARSM.get_min_objective_diff"></a>`get_min_objective_diff() → float`
-- <a id="PyARSM.OptimizerSettingsARSM.get_min_parameter_diff"></a>`get_min_parameter_diff() → float`
-- <a id="PyARSM.OptimizerSettingsARSM.get_min_range"></a>`get_min_range() → float`
-- <a id="PyARSM.OptimizerSettingsARSM.get_order"></a>`get_order() → int`
-- <a id="PyARSM.OptimizerSettingsARSM.get_start_range"></a>`get_start_range() → float`
-- <a id="PyARSM.OptimizerSettingsARSM.set_box_cox"></a>`set_box_cox(arg2: bool)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_doe_settings"></a>`set_doe_settings(arg2: [DOESettings](py_doe_settings.md#py_doe_settings.DOESettings))`
-- <a id="PyARSM.OptimizerSettingsARSM.set_evaluate_criteria"></a>`set_evaluate_criteria(arg2: bool)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_max_iteration"></a>`set_max_iteration(arg2: int)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_min_iteration"></a>`set_min_iteration(arg2: int)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_min_objective_diff"></a>`set_min_objective_diff(arg2: float)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_min_parameter_diff"></a>`set_min_parameter_diff(arg2: float)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_min_range"></a>`set_min_range(arg2: float)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_mixed_terms"></a>`set_mixed_terms(arg2: bool)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_order"></a>`set_order(arg2: int)`
-- <a id="PyARSM.OptimizerSettingsARSM.set_start_range"></a>`set_start_range(arg2: float)`
+<a id="PyARSM.OptimizerSettingsARSM.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyARSM.OptimizerSettingsARSM.get_doe_settings"></a>
+
+#### get_doe_settings() → [DOESettings](py_doe_settings.md#py_doe_settings.DOESettings)
+
+<a id="PyARSM.OptimizerSettingsARSM.get_max_iteration"></a>
+
+#### get_max_iteration() → int
+
+<a id="PyARSM.OptimizerSettingsARSM.get_min_iteration"></a>
+
+#### get_min_iteration() → int
+
+<a id="PyARSM.OptimizerSettingsARSM.get_min_objective_diff"></a>
+
+#### get_min_objective_diff() → float
+
+<a id="PyARSM.OptimizerSettingsARSM.get_min_parameter_diff"></a>
+
+#### get_min_parameter_diff() → float
+
+<a id="PyARSM.OptimizerSettingsARSM.get_min_range"></a>
+
+#### get_min_range() → float
+
+<a id="PyARSM.OptimizerSettingsARSM.get_order"></a>
+
+#### get_order() → int
+
+<a id="PyARSM.OptimizerSettingsARSM.get_start_range"></a>
+
+#### get_start_range() → float
+
+<a id="PyARSM.OptimizerSettingsARSM.set_box_cox"></a>
+
+#### set_box_cox(arg2: bool)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_doe_settings"></a>
+
+#### set_doe_settings(arg2: [DOESettings](py_doe_settings.md#py_doe_settings.DOESettings))
+
+<a id="PyARSM.OptimizerSettingsARSM.set_evaluate_criteria"></a>
+
+#### set_evaluate_criteria(arg2: bool)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_max_iteration"></a>
+
+#### set_max_iteration(arg2: int)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_min_iteration"></a>
+
+#### set_min_iteration(arg2: int)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_min_objective_diff"></a>
+
+#### set_min_objective_diff(arg2: float)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_min_parameter_diff"></a>
+
+#### set_min_parameter_diff(arg2: float)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_min_range"></a>
+
+#### set_min_range(arg2: float)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_mixed_terms"></a>
+
+#### set_mixed_terms(arg2: bool)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_order"></a>
+
+#### set_order(arg2: int)
+
+<a id="PyARSM.OptimizerSettingsARSM.set_start_range"></a>
+
+#### set_start_range(arg2: float)

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyMemetic.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyMemetic.md
@@ -4,16 +4,34 @@
 
 ## *class* PyMemetic.Memetic
 
-- <a id="PyMemetic.Memetic.__init__"></a>`__init__()`
-- `__init__(arg2: [MemeticSettings](#PyMemetic.MemeticSettings))`
+<a id="PyMemetic.Memetic.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [MemeticSettings](#PyMemetic.MemeticSettings))
 
 <a id="PyMemetic.MemeticSettings"></a>
 
 ## *class* PyMemetic.MemeticSettings
 
-- <a id="PyMemetic.MemeticSettings.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="PyMemetic.MemeticSettings.set_inner_optimizer_settings"></a>`set_inner_optimizer_settings(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))`
-- <a id="PyMemetic.MemeticSettings.set_outer_optimizer_settings"></a>`set_outer_optimizer_settings(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))`
-- <a id="PyMemetic.MemeticSettings.set_parameter_types"></a>`set_parameter_types(arg2: [DeterministicTypeVec](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicTypeVec))`
-- <a id="PyMemetic.MemeticSettings.set_seed"></a>`set_seed(arg2: int)`
+<a id="PyMemetic.MemeticSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="PyMemetic.MemeticSettings.set_inner_optimizer_settings"></a>
+
+#### set_inner_optimizer_settings(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))
+
+<a id="PyMemetic.MemeticSettings.set_outer_optimizer_settings"></a>
+
+#### set_outer_optimizer_settings(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))
+
+<a id="PyMemetic.MemeticSettings.set_parameter_types"></a>
+
+#### set_parameter_types(arg2: [DeterministicTypeVec](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicTypeVec))
+
+<a id="PyMemetic.MemeticSettings.set_seed"></a>
+
+#### set_seed(arg2: int)

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNLPQLP.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNLPQLP.md
@@ -6,52 +6,134 @@
 
 **Enumeration**
 
-- <a id="PyNLPQLP.DiffType.BACKWARD"></a>`BACKWARD *= PyNLPQLP.DiffType.BACKWARD*`
-- <a id="PyNLPQLP.DiffType.CENTRAL"></a>`CENTRAL *= PyNLPQLP.DiffType.CENTRAL*`
-- <a id="PyNLPQLP.DiffType.FORWARD"></a>`FORWARD *= PyNLPQLP.DiffType.FORWARD*`
-- <a id="PyNLPQLP.DiffType.FOURTH_ORDER"></a>`FOURTH_ORDER *= PyNLPQLP.DiffType.FOURTH_ORDER*`
+<a id="PyNLPQLP.DiffType.BACKWARD"></a>
+
+#### BACKWARD *= PyNLPQLP.DiffType.BACKWARD*
+
+<a id="PyNLPQLP.DiffType.CENTRAL"></a>
+
+#### CENTRAL *= PyNLPQLP.DiffType.CENTRAL*
+
+<a id="PyNLPQLP.DiffType.FORWARD"></a>
+
+#### FORWARD *= PyNLPQLP.DiffType.FORWARD*
+
+<a id="PyNLPQLP.DiffType.FOURTH_ORDER"></a>
+
+#### FOURTH_ORDER *= PyNLPQLP.DiffType.FOURTH_ORDER*
 
 <a id="PyNLPQLP.NLPQLP"></a>
 
 ## *class* PyNLPQLP.NLPQLP
 
-- <a id="PyNLPQLP.NLPQLP.__init__"></a>`__init__()`
-- `__init__(arg2: [SettingsNLPQLP](#PyNLPQLP.SettingsNLPQLP))`
+<a id="PyNLPQLP.NLPQLP.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [SettingsNLPQLP](#PyNLPQLP.SettingsNLPQLP))
 
 <a id="PyNLPQLP.SettingsNLPQLP"></a>
 
 ## *class* PyNLPQLP.SettingsNLPQLP
 
-- <a id="PyNLPQLP.SettingsNLPQLP.__init__"></a>`__init__()`
-- <a id="PyNLPQLP.SettingsNLPQLP.get_accuracy"></a>`get_accuracy() → float`<br>
-  Get tolerance by which optimality conditions are met.
-- <a id="PyNLPQLP.SettingsNLPQLP.get_gradient_dx"></a>`get_gradient_dx() → [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type)`<br>
-  Get differentiation step size.
-- <a id="PyNLPQLP.SettingsNLPQLP.get_line_search_stack_size"></a>`get_line_search_stack_size() → int`<br>
-  Get value of nonmonotonous line search stack size.
-- <a id="PyNLPQLP.SettingsNLPQLP.get_max_num_function_calls"></a>`get_max_num_function_calls() → int`<br>
-  Get the maximum allowed number of function calls.
-- <a id="PyNLPQLP.SettingsNLPQLP.get_max_step_size"></a>`get_max_step_size() → int`
-- <a id="PyNLPQLP.SettingsNLPQLP.get_number_of_parallel_line_searches"></a>`get_number_of_parallel_line_searches() → int`<br>
-  Get number of line searches running parallel.
-- <a id="PyNLPQLP.SettingsNLPQLP.get_numerical_differences"></a>`get_numerical_differences() → [DiffType](#PyNLPQLP.DiffType)`<br>
-  Get value used for the differentiaion scheme.
-- <a id="PyNLPQLP.SettingsNLPQLP.min_line_search_stepsize"></a>*property* `min_line_search_stepsize`<br>
-  Default 0 means auto detection of step size.
-- <a id="PyNLPQLP.SettingsNLPQLP.set_accuracy"></a>`set_accuracy(arg2: float)`<br>
-  Set tolerance by which optimality conditions are met.
-- <a id="PyNLPQLP.SettingsNLPQLP.set_gradient_dx"></a>`set_gradient_dx(arg2: float)`<br>
-  [0] Set differentiation step size. [1] Set differentiation step size.
-- `set_gradient_dx(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="PyNLPQLP.SettingsNLPQLP.set_line_search_stack_size"></a>`set_line_search_stack_size(arg2: int)`<br>
-  Set value of nonmonotonous line search stack size.
-- <a id="PyNLPQLP.SettingsNLPQLP.set_max_num_function_calls"></a>`set_max_num_function_calls(arg2: int)`<br>
-  Set the maximum allowed number of function calls.
-- <a id="PyNLPQLP.SettingsNLPQLP.set_max_step_size"></a>`set_max_step_size(arg2: float)`
-- `set_max_step_size(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="PyNLPQLP.SettingsNLPQLP.set_number_of_parallel_line_searches"></a>`set_number_of_parallel_line_searches(arg2: int)`<br>
-  Set number of line searches running parallel.
-- <a id="PyNLPQLP.SettingsNLPQLP.set_numerical_differences"></a>`set_numerical_differences(arg2: [DiffType](#PyNLPQLP.DiffType))`<br>
-  Set value used for the differentiaion scheme.
-- <a id="PyNLPQLP.SettingsNLPQLP.use_initial_stepsize_limit"></a>*property* `use_initial_stepsize_limit`<br>
-  Initial stepsize limit.
+<a id="PyNLPQLP.SettingsNLPQLP.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_accuracy"></a>
+
+#### get_accuracy() → float
+
+Get tolerance by which optimality conditions are met.
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_gradient_dx"></a>
+
+#### get_gradient_dx() → [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type)
+
+Get differentiation step size.
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_line_search_stack_size"></a>
+
+#### get_line_search_stack_size() → int
+
+Get value of nonmonotonous line search stack size.
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_max_num_function_calls"></a>
+
+#### get_max_num_function_calls() → int
+
+Get the maximum allowed number of function calls.
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_max_step_size"></a>
+
+#### get_max_step_size() → int
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_number_of_parallel_line_searches"></a>
+
+#### get_number_of_parallel_line_searches() → int
+
+Get number of line searches running parallel.
+
+<a id="PyNLPQLP.SettingsNLPQLP.get_numerical_differences"></a>
+
+#### get_numerical_differences() → [DiffType](#PyNLPQLP.DiffType)
+
+Get value used for the differentiaion scheme.
+
+<a id="PyNLPQLP.SettingsNLPQLP.min_line_search_stepsize"></a>
+
+#### *property* min_line_search_stepsize
+
+Default 0 means auto detection of step size.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_accuracy"></a>
+
+#### set_accuracy(arg2: float)
+
+Set tolerance by which optimality conditions are met.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_gradient_dx"></a>
+
+#### set_gradient_dx(arg2: float)
+
+#### set_gradient_dx(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+[0] Set differentiation step size.
+
+[1] Set differentiation step size.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_line_search_stack_size"></a>
+
+#### set_line_search_stack_size(arg2: int)
+
+Set value of nonmonotonous line search stack size.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_max_num_function_calls"></a>
+
+#### set_max_num_function_calls(arg2: int)
+
+Set the maximum allowed number of function calls.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_max_step_size"></a>
+
+#### set_max_step_size(arg2: float)
+
+#### set_max_step_size(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_number_of_parallel_line_searches"></a>
+
+#### set_number_of_parallel_line_searches(arg2: int)
+
+Set number of line searches running parallel.
+
+<a id="PyNLPQLP.SettingsNLPQLP.set_numerical_differences"></a>
+
+#### set_numerical_differences(arg2: [DiffType](#PyNLPQLP.DiffType))
+
+Set value used for the differentiaion scheme.
+
+<a id="PyNLPQLP.SettingsNLPQLP.use_initial_stepsize_limit"></a>
+
+#### *property* use_initial_stepsize_limit
+
+Initial stepsize limit.

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNOA.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNOA.md
@@ -6,22 +6,53 @@
 
 **Enumeration**
 
-- <a id="PyNOA.AdaptionMethods.Arithmetic"></a>`Arithmetic *= PyNOA.AdaptionMethods.Arithmetic*`
-- <a id="PyNOA.AdaptionMethods.Copy"></a>`Copy *= PyNOA.AdaptionMethods.Copy*`
-- <a id="PyNOA.AdaptionMethods.Multipoint"></a>`Multipoint *= PyNOA.AdaptionMethods.Multipoint*`
-- <a id="PyNOA.AdaptionMethods.PSO"></a>`PSO *= PyNOA.AdaptionMethods.PSO*`
-- <a id="PyNOA.AdaptionMethods.SBX"></a>`SBX *= PyNOA.AdaptionMethods.SBX*`
-- <a id="PyNOA.AdaptionMethods.Singlepoint"></a>`Singlepoint *= PyNOA.AdaptionMethods.Singlepoint*`
-- <a id="PyNOA.AdaptionMethods.Uniform"></a>`Uniform *= PyNOA.AdaptionMethods.Uniform*`
+<a id="PyNOA.AdaptionMethods.Arithmetic"></a>
+
+#### Arithmetic *= PyNOA.AdaptionMethods.Arithmetic*
+
+<a id="PyNOA.AdaptionMethods.Copy"></a>
+
+#### Copy *= PyNOA.AdaptionMethods.Copy*
+
+<a id="PyNOA.AdaptionMethods.Multipoint"></a>
+
+#### Multipoint *= PyNOA.AdaptionMethods.Multipoint*
+
+<a id="PyNOA.AdaptionMethods.PSO"></a>
+
+#### PSO *= PyNOA.AdaptionMethods.PSO*
+
+<a id="PyNOA.AdaptionMethods.SBX"></a>
+
+#### SBX *= PyNOA.AdaptionMethods.SBX*
+
+<a id="PyNOA.AdaptionMethods.Singlepoint"></a>
+
+#### Singlepoint *= PyNOA.AdaptionMethods.Singlepoint*
+
+<a id="PyNOA.AdaptionMethods.Uniform"></a>
+
+#### Uniform *= PyNOA.AdaptionMethods.Uniform*
 
 <a id="PyNOA.Design"></a>
 
 ## *class* PyNOA.Design
 
-- <a id="PyNOA.Design.__init__"></a>`__init__()`
-- <a id="PyNOA.Design.get_actual_number"></a>`get_actual_number() → int`
-- <a id="PyNOA.Design.get_objective"></a>`get_objective() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="PyNOA.Design.get_parameters"></a>`get_parameters() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
+<a id="PyNOA.Design.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA.Design.get_actual_number"></a>
+
+#### get_actual_number() → int
+
+<a id="PyNOA.Design.get_objective"></a>
+
+#### get_objective() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="PyNOA.Design.get_parameters"></a>
+
+#### get_parameters() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
 
 <a id="PyNOA.MutationMethods"></a>
 
@@ -29,146 +60,415 @@
 
 **Enumeration**
 
-- <a id="PyNOA.MutationMethods.ConstraintAdaptive"></a>`ConstraintAdaptive *= PyNOA.MutationMethods.ConstraintAdaptive*`
-- <a id="PyNOA.MutationMethods.ModulatedAdaptive"></a>`ModulatedAdaptive *= PyNOA.MutationMethods.ModulatedAdaptive*`
-- <a id="PyNOA.MutationMethods.NormalDistribution"></a>`NormalDistribution *= PyNOA.MutationMethods.NormalDistribution*`
-- <a id="PyNOA.MutationMethods.SelfAdaptive"></a>`SelfAdaptive *= PyNOA.MutationMethods.SelfAdaptive*`
+<a id="PyNOA.MutationMethods.ConstraintAdaptive"></a>
+
+#### ConstraintAdaptive *= PyNOA.MutationMethods.ConstraintAdaptive*
+
+<a id="PyNOA.MutationMethods.ModulatedAdaptive"></a>
+
+#### ModulatedAdaptive *= PyNOA.MutationMethods.ModulatedAdaptive*
+
+<a id="PyNOA.MutationMethods.NormalDistribution"></a>
+
+#### NormalDistribution *= PyNOA.MutationMethods.NormalDistribution*
+
+<a id="PyNOA.MutationMethods.SelfAdaptive"></a>
+
+#### SelfAdaptive *= PyNOA.MutationMethods.SelfAdaptive*
 
 <a id="PyNOA.NOA"></a>
 
 ## *class* PyNOA.NOA
 
-- <a id="PyNOA.NOA.__init__"></a>`__init__()`
-- `__init__(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))`
+<a id="PyNOA.NOA.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))
 
 <a id="PyNOA.NOASettings"></a>
 
 ## *class* PyNOA.NOASettings
 
-- <a id="PyNOA.NOASettings.__init__"></a>`__init__()`
-- <a id="PyNOA.NOASettings.append_adaption_method"></a>`append_adaption_method(arg2: [AdaptionMethods](#PyNOA.AdaptionMethods))`<br>
-  Append a new adaption method. Use set_adaption_method to reset.
-- <a id="PyNOA.NOASettings.change_default_settings"></a>`change_default_settings(population: int size, max: int. generations, lower: doubleVec bounds, upper: doubleVec bounds)`
-- <a id="PyNOA.NOASettings.get_adaption_methods"></a>`get_adaption_methods() → list`<br>
-  Get a list of all set adaption methods.
-- <a id="PyNOA.NOASettings.get_arch_size"></a>`get_arch_size() → int`<br>
-  Get maximum archive size.
-- <a id="PyNOA.NOASettings.get_cliff_value"></a>`get_cliff_value() → float`<br>
-  Get cliff for penalty term.
-- <a id="PyNOA.NOASettings.get_contraint_scaling_factor"></a>`get_contraint_scaling_factor() → float`<br>
-  Get scaling factor for constraints.
-- <a id="PyNOA.NOASettings.get_crossover_probabilities"></a>`get_crossover_probabilities() → list`<br>
-  Get a list of all crossover probabilities.
-- <a id="PyNOA.NOASettings.get_distribution_parameters"></a>`get_distribution_parameters() → list`<br>
-  Get a list of all distribution parameters.
-- <a id="PyNOA.NOASettings.get_fitness_scaling"></a>`get_fitness_scaling() → bool`<br>
-  Get use automatic fitness scaling.
-- <a id="PyNOA.NOASettings.get_hybrid"></a>`get_hybrid() → bool`<br>
-  Get use hybrid adaption.
-- <a id="PyNOA.NOASettings.get_max_archive_size"></a>`get_max_archive_size() → int`<br>
-  Return maximum archive size.
-- <a id="PyNOA.NOASettings.get_max_gen"></a>`get_max_gen() → int`<br>
-  Get maximum number of generations.
-- <a id="PyNOA.NOASettings.get_min_gen"></a>`get_min_gen() → int`<br>
-  Get minimum number of generations.
-- <a id="PyNOA.NOASettings.get_mut_gnr"></a>`get_mut_gnr() → float`<br>
-  Get number of mutating generations.
-- <a id="PyNOA.NOASettings.get_mut_rate"></a>`get_mut_rate() → float`<br>
-  Get probability of mutation.
-- <a id="PyNOA.NOASettings.get_mutate"></a>`get_mutate() → bool`<br>
-  Get whether to mutate or not.
-- <a id="PyNOA.NOASettings.get_mutation_method"></a>`get_mutation_method() → [MutationMethods](#PyNOA.MutationMethods)`<br>
-  Get mutation method.
-- <a id="PyNOA.NOASettings.get_mutation_std_dev"></a>`get_mutation_std_dev() → tuple`<br>
-  Get mutation standard deviation values.
-- <a id="PyNOA.NOASettings.get_number_of_parents"></a>`get_number_of_parents() → int`
-- <a id="PyNOA.NOASettings.get_numbers_of_crosspoints"></a>`get_numbers_of_crosspoints() → list`<br>
-  Get a list of all numbers of crosspoints.
-- <a id="PyNOA.NOASettings.get_penalty_method"></a>`get_penalty_method() → [PenaltyMethods](#PyNOA.PenaltyMethods)`<br>
-  Get penalty method to evaluate constraint violations.
-- <a id="PyNOA.NOASettings.get_ranking_method"></a>`get_ranking_method() → [RankingMethods](#PyNOA.RankingMethods)`<br>
-  Get ranking method.
-- <a id="PyNOA.NOASettings.get_seed"></a>`get_seed() → int`
-- <a id="PyNOA.NOASettings.get_selection_method"></a>`get_selection_method() → [SelectionMethods](#PyNOA.SelectionMethods)`<br>
-  Get selection method.
-- <a id="PyNOA.NOASettings.get_selection_pressure"></a>`get_selection_pressure() → float`<br>
-  Get value for selection pressure.
-- <a id="PyNOA.NOASettings.get_stagnation_generations"></a>`get_stagnation_generations() → int`<br>
-  Get convergence parameter.
-- <a id="PyNOA.NOASettings.get_stagnation_limit"></a>`get_stagnation_limit() → float`<br>
-  Get convergence parameter.
-- <a id="PyNOA.NOASettings.get_start_pop_size"></a>`get_start_pop_size() → int`
-- <a id="PyNOA.NOASettings.get_tournament_size"></a>`get_tournament_size() → int`<br>
-  Get number of designs to compare in tournament.
-- <a id="PyNOA.NOASettings.parameter_free"></a>*property* `parameter_free`<br>
-  Whether to use parameter free constraint handling in penalty method.
-- <a id="PyNOA.NOASettings.roulette_with_replacement"></a>*property* `roulette_with_replacement`<br>
-  Roulette selection applied with replacement.
-- <a id="PyNOA.NOASettings.set_adaption_method"></a>`set_adaption_method(arg2: [AdaptionMethods](#PyNOA.AdaptionMethods))`<br>
-  Reset adaption methods and set first adaption method.
-- <a id="PyNOA.NOASettings.set_arch_size"></a>`set_arch_size(arg2: int)`<br>
-  Set maximum archive size.
-- <a id="PyNOA.NOASettings.set_bounds"></a>`set_bounds(lower: doubleVec bounds, upper: doubleVec bounds)`<br>
-  Set limiting bound for each dimension.
-- <a id="PyNOA.NOASettings.set_cliff_value"></a>`set_cliff_value(arg2: float)`<br>
-  Set cliff for penalty term.
-- <a id="PyNOA.NOASettings.set_contraint_scaling_factor"></a>`set_contraint_scaling_factor(arg2: float)`<br>
-  Set scaling factor for constraints.
-- <a id="PyNOA.NOASettings.set_crossover_probability"></a>`set_crossover_probability(arg2: float)`<br>
-  Set crossover rate.
-- <a id="PyNOA.NOASettings.set_default"></a>`set_default(adaption: AdaptionMethods method, local: bool search)`<br>
-  Apply default settings.
-- <a id="PyNOA.NOASettings.set_distribution_parameter"></a>`set_distribution_parameter(arg2: float)`<br>
-  Set distribution parameter for SBX.
-- <a id="PyNOA.NOASettings.set_ea_balanced"></a>`set_ea_balanced()`<br>
-  Set defaults for EA - balanced.
-- <a id="PyNOA.NOASettings.set_ea_global"></a>`set_ea_global()`<br>
-  Set defaults for EA - global.
-- <a id="PyNOA.NOASettings.set_ea_local"></a>`set_ea_local()`<br>
-  Set defaults for EA - local.
-- <a id="PyNOA.NOASettings.set_fitness_scaling"></a>`set_fitness_scaling(arg2: bool)`<br>
-  Set use automatic fitness scaling.
-- <a id="PyNOA.NOASettings.set_hybrid"></a>`set_hybrid(arg2: bool)`<br>
-  Set use hybrid adaption.
-- <a id="PyNOA.NOASettings.set_max_gen"></a>`set_max_gen(arg2: int)`<br>
-  Set maximum number of generations.
-- <a id="PyNOA.NOASettings.set_min_gen"></a>`set_min_gen(arg2: int)`<br>
-  Set minimum number of generations.
-- <a id="PyNOA.NOASettings.set_mut_gnr"></a>`set_mut_gnr(arg2: float)`<br>
-  Set number of mutating generations.
-- <a id="PyNOA.NOASettings.set_mut_rate"></a>`set_mut_rate(arg2: float)`<br>
-  Set probability of mutation.
-- <a id="PyNOA.NOASettings.set_mutate"></a>`set_mutate(arg2: bool)`<br>
-  Set whether to mutate or not.
-- <a id="PyNOA.NOASettings.set_mutation_method"></a>`set_mutation_method(arg2: [MutationMethods](#PyNOA.MutationMethods))`<br>
-  Set mutation method.
-- <a id="PyNOA.NOASettings.set_mutation_std_dev"></a>`set_mutation_std_dev(lower: float bound continuous parameter, upper: float bound continuous parameter, lower: float bound discrete parameter, upper: float bound discrete parameter)`<br>
-  Set mutation standard deviation.
-- <a id="PyNOA.NOASettings.set_number_of_crosspoints"></a>`set_number_of_crosspoints(arg2: int)`<br>
-  Set number of crosspoints.
-- <a id="PyNOA.NOASettings.set_number_of_parents"></a>`set_number_of_parents(Set: int number of parents.)`
-- <a id="PyNOA.NOASettings.set_penalty_method"></a>`set_penalty_method(arg2: [PenaltyMethods](#PyNOA.PenaltyMethods))`<br>
-  Set penalty method to evaluate constraint violations.
-- <a id="PyNOA.NOASettings.set_pso_coefficients"></a>`set_pso_coefficients(intertia: float weight at first generation, intertia: float weight at last generation, personal: float acceleration coefficient at first generation, personal: float acceleration coefficient at last generation, global: float acceleration coefficient at first generation, global: float acceleration coefficient at last generation)`<br>
-  Set parameters relevant to PSO.
-- <a id="PyNOA.NOASettings.set_pso_global"></a>`set_pso_global()`<br>
-  Set defaults for PSO - global.
-- <a id="PyNOA.NOASettings.set_pso_local"></a>`set_pso_local()`<br>
-  Set defaults for PSO - local.
-- <a id="PyNOA.NOASettings.set_ranking_method"></a>`set_ranking_method(arg2: [RankingMethods](#PyNOA.RankingMethods))`<br>
-  Set ranking method.
-- <a id="PyNOA.NOASettings.set_seed"></a>`set_seed(arg2: int)`
-- <a id="PyNOA.NOASettings.set_selection_method"></a>`set_selection_method(arg2: [SelectionMethods](#PyNOA.SelectionMethods))`<br>
-  Set selection method.
-- <a id="PyNOA.NOASettings.set_selection_pressure"></a>`set_selection_pressure(arg2: float)`<br>
-  Set value for selection pressure.
-- <a id="PyNOA.NOASettings.set_stagnation_generations"></a>`set_stagnation_generations(arg2: int)`<br>
-  Set convergence parameter.
-- <a id="PyNOA.NOASettings.set_stagnation_limit"></a>`set_stagnation_limit(arg2: float)`<br>
-  Set convergence parameter.
-- <a id="PyNOA.NOASettings.set_start_pop_size"></a>`set_start_pop_size(Set: int start population size.)`
-- <a id="PyNOA.NOASettings.set_tournament_size"></a>`set_tournament_size(arg2: int)`<br>
-  Set number of designs to compare in tournament.
+<a id="PyNOA.NOASettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA.NOASettings.append_adaption_method"></a>
+
+#### append_adaption_method(arg2: [AdaptionMethods](#PyNOA.AdaptionMethods))
+
+Append a new adaption method. Use set_adaption_method to reset.
+
+<a id="PyNOA.NOASettings.change_default_settings"></a>
+
+#### change_default_settings(population: int size, max: int. generations, lower: doubleVec bounds, upper: doubleVec bounds)
+
+<a id="PyNOA.NOASettings.get_adaption_methods"></a>
+
+#### get_adaption_methods() → list
+
+Get a list of all set adaption methods.
+
+<a id="PyNOA.NOASettings.get_arch_size"></a>
+
+#### get_arch_size() → int
+
+Get maximum archive size.
+
+<a id="PyNOA.NOASettings.get_cliff_value"></a>
+
+#### get_cliff_value() → float
+
+Get cliff for penalty term.
+
+<a id="PyNOA.NOASettings.get_contraint_scaling_factor"></a>
+
+#### get_contraint_scaling_factor() → float
+
+Get scaling factor for constraints.
+
+<a id="PyNOA.NOASettings.get_crossover_probabilities"></a>
+
+#### get_crossover_probabilities() → list
+
+Get a list of all crossover probabilities.
+
+<a id="PyNOA.NOASettings.get_distribution_parameters"></a>
+
+#### get_distribution_parameters() → list
+
+Get a list of all distribution parameters.
+
+<a id="PyNOA.NOASettings.get_fitness_scaling"></a>
+
+#### get_fitness_scaling() → bool
+
+Get use automatic fitness scaling.
+
+<a id="PyNOA.NOASettings.get_hybrid"></a>
+
+#### get_hybrid() → bool
+
+Get use hybrid adaption.
+
+<a id="PyNOA.NOASettings.get_max_archive_size"></a>
+
+#### get_max_archive_size() → int
+
+Return maximum archive size.
+
+<a id="PyNOA.NOASettings.get_max_gen"></a>
+
+#### get_max_gen() → int
+
+Get maximum number of generations.
+
+<a id="PyNOA.NOASettings.get_min_gen"></a>
+
+#### get_min_gen() → int
+
+Get minimum number of generations.
+
+<a id="PyNOA.NOASettings.get_mut_gnr"></a>
+
+#### get_mut_gnr() → float
+
+Get number of mutating generations.
+
+<a id="PyNOA.NOASettings.get_mut_rate"></a>
+
+#### get_mut_rate() → float
+
+Get probability of mutation.
+
+<a id="PyNOA.NOASettings.get_mutate"></a>
+
+#### get_mutate() → bool
+
+Get whether to mutate or not.
+
+<a id="PyNOA.NOASettings.get_mutation_method"></a>
+
+#### get_mutation_method() → [MutationMethods](#PyNOA.MutationMethods)
+
+Get mutation method.
+
+<a id="PyNOA.NOASettings.get_mutation_std_dev"></a>
+
+#### get_mutation_std_dev() → tuple
+
+Get mutation standard deviation values.
+
+<a id="PyNOA.NOASettings.get_number_of_parents"></a>
+
+#### get_number_of_parents() → int
+
+<a id="PyNOA.NOASettings.get_numbers_of_crosspoints"></a>
+
+#### get_numbers_of_crosspoints() → list
+
+Get a list of all numbers of crosspoints.
+
+<a id="PyNOA.NOASettings.get_penalty_method"></a>
+
+#### get_penalty_method() → [PenaltyMethods](#PyNOA.PenaltyMethods)
+
+Get penalty method to evaluate constraint violations.
+
+<a id="PyNOA.NOASettings.get_ranking_method"></a>
+
+#### get_ranking_method() → [RankingMethods](#PyNOA.RankingMethods)
+
+Get ranking method.
+
+<a id="PyNOA.NOASettings.get_seed"></a>
+
+#### get_seed() → int
+
+<a id="PyNOA.NOASettings.get_selection_method"></a>
+
+#### get_selection_method() → [SelectionMethods](#PyNOA.SelectionMethods)
+
+Get selection method.
+
+<a id="PyNOA.NOASettings.get_selection_pressure"></a>
+
+#### get_selection_pressure() → float
+
+Get value for selection pressure.
+
+<a id="PyNOA.NOASettings.get_stagnation_generations"></a>
+
+#### get_stagnation_generations() → int
+
+Get convergence parameter.
+
+<a id="PyNOA.NOASettings.get_stagnation_limit"></a>
+
+#### get_stagnation_limit() → float
+
+Get convergence parameter.
+
+<a id="PyNOA.NOASettings.get_start_pop_size"></a>
+
+#### get_start_pop_size() → int
+
+<a id="PyNOA.NOASettings.get_tournament_size"></a>
+
+#### get_tournament_size() → int
+
+Get number of designs to compare in tournament.
+
+<a id="PyNOA.NOASettings.parameter_free"></a>
+
+#### *property* parameter_free
+
+Whether to use parameter free constraint handling in penalty method.
+
+<a id="PyNOA.NOASettings.roulette_with_replacement"></a>
+
+#### *property* roulette_with_replacement
+
+Roulette selection applied with replacement.
+
+<a id="PyNOA.NOASettings.set_adaption_method"></a>
+
+#### set_adaption_method(arg2: [AdaptionMethods](#PyNOA.AdaptionMethods))
+
+Reset adaption methods and set first adaption method.
+
+<a id="PyNOA.NOASettings.set_arch_size"></a>
+
+#### set_arch_size(arg2: int)
+
+Set maximum archive size.
+
+<a id="PyNOA.NOASettings.set_bounds"></a>
+
+#### set_bounds(lower: doubleVec bounds, upper: doubleVec bounds)
+
+Set limiting bound for each dimension.
+
+<a id="PyNOA.NOASettings.set_cliff_value"></a>
+
+#### set_cliff_value(arg2: float)
+
+Set cliff for penalty term.
+
+<a id="PyNOA.NOASettings.set_contraint_scaling_factor"></a>
+
+#### set_contraint_scaling_factor(arg2: float)
+
+Set scaling factor for constraints.
+
+<a id="PyNOA.NOASettings.set_crossover_probability"></a>
+
+#### set_crossover_probability(arg2: float)
+
+Set crossover rate.
+
+<a id="PyNOA.NOASettings.set_default"></a>
+
+#### set_default(adaption: AdaptionMethods method, local: bool search)
+
+Apply default settings.
+
+<a id="PyNOA.NOASettings.set_distribution_parameter"></a>
+
+#### set_distribution_parameter(arg2: float)
+
+Set distribution parameter for SBX.
+
+<a id="PyNOA.NOASettings.set_ea_balanced"></a>
+
+#### set_ea_balanced()
+
+Set defaults for EA - balanced.
+
+<a id="PyNOA.NOASettings.set_ea_global"></a>
+
+#### set_ea_global()
+
+Set defaults for EA - global.
+
+<a id="PyNOA.NOASettings.set_ea_local"></a>
+
+#### set_ea_local()
+
+Set defaults for EA - local.
+
+<a id="PyNOA.NOASettings.set_fitness_scaling"></a>
+
+#### set_fitness_scaling(arg2: bool)
+
+Set use automatic fitness scaling.
+
+<a id="PyNOA.NOASettings.set_hybrid"></a>
+
+#### set_hybrid(arg2: bool)
+
+Set use hybrid adaption.
+
+<a id="PyNOA.NOASettings.set_max_gen"></a>
+
+#### set_max_gen(arg2: int)
+
+Set maximum number of generations.
+
+<a id="PyNOA.NOASettings.set_min_gen"></a>
+
+#### set_min_gen(arg2: int)
+
+Set minimum number of generations.
+
+<a id="PyNOA.NOASettings.set_mut_gnr"></a>
+
+#### set_mut_gnr(arg2: float)
+
+Set number of mutating generations.
+
+<a id="PyNOA.NOASettings.set_mut_rate"></a>
+
+#### set_mut_rate(arg2: float)
+
+Set probability of mutation.
+
+<a id="PyNOA.NOASettings.set_mutate"></a>
+
+#### set_mutate(arg2: bool)
+
+Set whether to mutate or not.
+
+<a id="PyNOA.NOASettings.set_mutation_method"></a>
+
+#### set_mutation_method(arg2: [MutationMethods](#PyNOA.MutationMethods))
+
+Set mutation method.
+
+<a id="PyNOA.NOASettings.set_mutation_std_dev"></a>
+
+#### set_mutation_std_dev(lower: float bound continuous parameter, upper: float bound continuous parameter, lower: float bound discrete parameter, upper: float bound discrete parameter)
+
+Set mutation standard deviation.
+
+<a id="PyNOA.NOASettings.set_number_of_crosspoints"></a>
+
+#### set_number_of_crosspoints(arg2: int)
+
+Set number of crosspoints.
+
+<a id="PyNOA.NOASettings.set_number_of_parents"></a>
+
+#### set_number_of_parents(Set: int number of parents.)
+
+<a id="PyNOA.NOASettings.set_penalty_method"></a>
+
+#### set_penalty_method(arg2: [PenaltyMethods](#PyNOA.PenaltyMethods))
+
+Set penalty method to evaluate constraint violations.
+
+<a id="PyNOA.NOASettings.set_pso_coefficients"></a>
+
+#### set_pso_coefficients(intertia: float weight at first generation, intertia: float weight at last generation, personal: float acceleration coefficient at first generation, personal: float acceleration coefficient at last generation, global: float acceleration coefficient at first generation, global: float acceleration coefficient at last generation)
+
+Set parameters relevant to PSO.
+
+<a id="PyNOA.NOASettings.set_pso_global"></a>
+
+#### set_pso_global()
+
+Set defaults for PSO - global.
+
+<a id="PyNOA.NOASettings.set_pso_local"></a>
+
+#### set_pso_local()
+
+Set defaults for PSO - local.
+
+<a id="PyNOA.NOASettings.set_ranking_method"></a>
+
+#### set_ranking_method(arg2: [RankingMethods](#PyNOA.RankingMethods))
+
+Set ranking method.
+
+<a id="PyNOA.NOASettings.set_seed"></a>
+
+#### set_seed(arg2: int)
+
+<a id="PyNOA.NOASettings.set_selection_method"></a>
+
+#### set_selection_method(arg2: [SelectionMethods](#PyNOA.SelectionMethods))
+
+Set selection method.
+
+<a id="PyNOA.NOASettings.set_selection_pressure"></a>
+
+#### set_selection_pressure(arg2: float)
+
+Set value for selection pressure.
+
+<a id="PyNOA.NOASettings.set_stagnation_generations"></a>
+
+#### set_stagnation_generations(arg2: int)
+
+Set convergence parameter.
+
+<a id="PyNOA.NOASettings.set_stagnation_limit"></a>
+
+#### set_stagnation_limit(arg2: float)
+
+Set convergence parameter.
+
+<a id="PyNOA.NOASettings.set_start_pop_size"></a>
+
+#### set_start_pop_size(Set: int start population size.)
+
+<a id="PyNOA.NOASettings.set_tournament_size"></a>
+
+#### set_tournament_size(arg2: int)
+
+Set number of designs to compare in tournament.
 
 <a id="PyNOA.PenaltyMethods"></a>
 
@@ -176,9 +476,17 @@
 
 **Enumeration**
 
-- <a id="PyNOA.PenaltyMethods.DISTANCE"></a>`DISTANCE *= PyNOA.PenaltyMethods.DISTANCE*`
-- <a id="PyNOA.PenaltyMethods.HYBRID"></a>`HYBRID *= PyNOA.PenaltyMethods.HYBRID*`
-- <a id="PyNOA.PenaltyMethods.NUM_VIOLATIONS"></a>`NUM_VIOLATIONS *= PyNOA.PenaltyMethods.NUM_VIOLATIONS*`
+<a id="PyNOA.PenaltyMethods.DISTANCE"></a>
+
+#### DISTANCE *= PyNOA.PenaltyMethods.DISTANCE*
+
+<a id="PyNOA.PenaltyMethods.HYBRID"></a>
+
+#### HYBRID *= PyNOA.PenaltyMethods.HYBRID*
+
+<a id="PyNOA.PenaltyMethods.NUM_VIOLATIONS"></a>
+
+#### NUM_VIOLATIONS *= PyNOA.PenaltyMethods.NUM_VIOLATIONS*
 
 <a id="PyNOA.RankingMethods"></a>
 
@@ -186,11 +494,25 @@
 
 **Enumeration**
 
-- <a id="PyNOA.RankingMethods.CrowdingDensity"></a>`CrowdingDensity *= PyNOA.RankingMethods.CrowdingDensity*`
-- <a id="PyNOA.RankingMethods.CumulatedDensity"></a>`CumulatedDensity *= PyNOA.RankingMethods.CumulatedDensity*`
-- <a id="PyNOA.RankingMethods.Exponential"></a>`Exponential *= PyNOA.RankingMethods.Exponential*`
-- <a id="PyNOA.RankingMethods.Linear"></a>`Linear *= PyNOA.RankingMethods.Linear*`
-- <a id="PyNOA.RankingMethods.Pareto"></a>`Pareto *= PyNOA.RankingMethods.Pareto*`
+<a id="PyNOA.RankingMethods.CrowdingDensity"></a>
+
+#### CrowdingDensity *= PyNOA.RankingMethods.CrowdingDensity*
+
+<a id="PyNOA.RankingMethods.CumulatedDensity"></a>
+
+#### CumulatedDensity *= PyNOA.RankingMethods.CumulatedDensity*
+
+<a id="PyNOA.RankingMethods.Exponential"></a>
+
+#### Exponential *= PyNOA.RankingMethods.Exponential*
+
+<a id="PyNOA.RankingMethods.Linear"></a>
+
+#### Linear *= PyNOA.RankingMethods.Linear*
+
+<a id="PyNOA.RankingMethods.Pareto"></a>
+
+#### Pareto *= PyNOA.RankingMethods.Pareto*
 
 <a id="PyNOA.SelectionMethods"></a>
 
@@ -198,8 +520,22 @@
 
 **Enumeration**
 
-- <a id="PyNOA.SelectionMethods.ArchiveBest"></a>`ArchiveBest *= PyNOA.SelectionMethods.ArchiveBest*`
-- <a id="PyNOA.SelectionMethods.PopulationBest"></a>`PopulationBest *= PyNOA.SelectionMethods.PopulationBest*`
-- <a id="PyNOA.SelectionMethods.Roulette"></a>`Roulette *= PyNOA.SelectionMethods.Roulette*`
-- <a id="PyNOA.SelectionMethods.Stochastic"></a>`Stochastic *= PyNOA.SelectionMethods.Stochastic*`
-- <a id="PyNOA.SelectionMethods.Tournament"></a>`Tournament *= PyNOA.SelectionMethods.Tournament*`
+<a id="PyNOA.SelectionMethods.ArchiveBest"></a>
+
+#### ArchiveBest *= PyNOA.SelectionMethods.ArchiveBest*
+
+<a id="PyNOA.SelectionMethods.PopulationBest"></a>
+
+#### PopulationBest *= PyNOA.SelectionMethods.PopulationBest*
+
+<a id="PyNOA.SelectionMethods.Roulette"></a>
+
+#### Roulette *= PyNOA.SelectionMethods.Roulette*
+
+<a id="PyNOA.SelectionMethods.Stochastic"></a>
+
+#### Stochastic *= PyNOA.SelectionMethods.Stochastic*
+
+<a id="PyNOA.SelectionMethods.Tournament"></a>
+
+#### Tournament *= PyNOA.SelectionMethods.Tournament*

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNOA2.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyNOA2.md
@@ -4,7 +4,9 @@
 
 ## *class* PyNOA2.CMA
 
-- <a id="PyNOA2.CMA.__init__"></a>`__init__()`
+<a id="PyNOA2.CMA.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="PyNOA2.ConstraintHandling"></a>
 
@@ -12,14 +14,21 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.ConstraintHandling.PENALTY_DISTANCE"></a>`PENALTY_DISTANCE *= PyNOA2.ConstraintHandling.PENALTY_DISTANCE*`
-- <a id="PyNOA2.ConstraintHandling.PENALTY_RANK"></a>`PENALTY_RANK *= PyNOA2.ConstraintHandling.PENALTY_RANK*`
+<a id="PyNOA2.ConstraintHandling.PENALTY_DISTANCE"></a>
+
+#### PENALTY_DISTANCE *= PyNOA2.ConstraintHandling.PENALTY_DISTANCE*
+
+<a id="PyNOA2.ConstraintHandling.PENALTY_RANK"></a>
+
+#### PENALTY_RANK *= PyNOA2.ConstraintHandling.PENALTY_RANK*
 
 <a id="PyNOA2.EA"></a>
 
 ## *class* PyNOA2.EA
 
-- <a id="PyNOA2.EA.__init__"></a>`__init__()`
+<a id="PyNOA2.EA.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="PyNOA2.FitnessMethod"></a>
 
@@ -27,8 +36,13 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.FitnessMethod.PARETO_DOMINANCE"></a>`PARETO_DOMINANCE *= PyNOA2.FitnessMethod.PARETO_DOMINANCE*`
-- <a id="PyNOA2.FitnessMethod.WEIGHTED_SUM"></a>`WEIGHTED_SUM *= PyNOA2.FitnessMethod.WEIGHTED_SUM*`
+<a id="PyNOA2.FitnessMethod.PARETO_DOMINANCE"></a>
+
+#### PARETO_DOMINANCE *= PyNOA2.FitnessMethod.PARETO_DOMINANCE*
+
+<a id="PyNOA2.FitnessMethod.WEIGHTED_SUM"></a>
+
+#### WEIGHTED_SUM *= PyNOA2.FitnessMethod.WEIGHTED_SUM*
 
 <a id="PyNOA2.MutationMethod"></a>
 
@@ -36,122 +50,355 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.MutationMethod.NONE"></a>`NONE *= PyNOA2.MutationMethod.NONE*`
-- <a id="PyNOA2.MutationMethod.NORMAL_DISTRIBUTED"></a>`NORMAL_DISTRIBUTED *= PyNOA2.MutationMethod.NORMAL_DISTRIBUTED*`
-- <a id="PyNOA2.MutationMethod.SELF_ADAPTIVE"></a>`SELF_ADAPTIVE *= PyNOA2.MutationMethod.SELF_ADAPTIVE*`
+<a id="PyNOA2.MutationMethod.NONE"></a>
+
+#### NONE *= PyNOA2.MutationMethod.NONE*
+
+<a id="PyNOA2.MutationMethod.NORMAL_DISTRIBUTED"></a>
+
+#### NORMAL_DISTRIBUTED *= PyNOA2.MutationMethod.NORMAL_DISTRIBUTED*
+
+<a id="PyNOA2.MutationMethod.SELF_ADAPTIVE"></a>
+
+#### SELF_ADAPTIVE *= PyNOA2.MutationMethod.SELF_ADAPTIVE*
 
 <a id="PyNOA2.NOABase"></a>
 
 ## *class* PyNOA2.NOABase
 
-- <a id="PyNOA2.NOABase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="PyNOA2.NOABase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="PyNOA2.OptimizerSettingsCMA"></a>
 
 ## *class* PyNOA2.OptimizerSettingsCMA
 
-- <a id="PyNOA2.OptimizerSettingsCMA.__init__"></a>`__init__()`
-- <a id="PyNOA2.OptimizerSettingsCMA.get_initial_sigma"></a>`get_initial_sigma() → float`
-- <a id="PyNOA2.OptimizerSettingsCMA.get_parent_size"></a>`get_parent_size() → int`
-- <a id="PyNOA2.OptimizerSettingsCMA.set_defaults"></a>`set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))`
-- <a id="PyNOA2.OptimizerSettingsCMA.set_initial_sigma"></a>`set_initial_sigma(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsCMA.set_parent_size"></a>`set_parent_size(arg2: int)`
+<a id="PyNOA2.OptimizerSettingsCMA.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA2.OptimizerSettingsCMA.get_initial_sigma"></a>
+
+#### get_initial_sigma() → float
+
+<a id="PyNOA2.OptimizerSettingsCMA.get_parent_size"></a>
+
+#### get_parent_size() → int
+
+<a id="PyNOA2.OptimizerSettingsCMA.set_defaults"></a>
+
+#### set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))
+
+<a id="PyNOA2.OptimizerSettingsCMA.set_initial_sigma"></a>
+
+#### set_initial_sigma(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsCMA.set_parent_size"></a>
+
+#### set_parent_size(arg2: int)
 
 <a id="PyNOA2.OptimizerSettingsEA"></a>
 
 ## *class* PyNOA2.OptimizerSettingsEA
 
-- <a id="PyNOA2.OptimizerSettingsEA.__init__"></a>`__init__()`
-- <a id="PyNOA2.OptimizerSettingsEA.get_archive_size"></a>`get_archive_size() → int`
-- <a id="PyNOA2.OptimizerSettingsEA.get_crossover_probability"></a>`get_crossover_probability(arg2: int) → float`
-- <a id="PyNOA2.OptimizerSettingsEA.get_distribution_parameter"></a>`get_distribution_parameter(arg2: int) → float`
-- <a id="PyNOA2.OptimizerSettingsEA.get_mutation_method"></a>`get_mutation_method() → [MutationMethod](#PyNOA2.MutationMethod)`
-- <a id="PyNOA2.OptimizerSettingsEA.get_mutation_rate"></a>`get_mutation_rate() → float`
-- <a id="PyNOA2.OptimizerSettingsEA.get_mutation_stddev_begin"></a>`get_mutation_stddev_begin() → float`
-- <a id="PyNOA2.OptimizerSettingsEA.get_mutation_stddev_end"></a>`get_mutation_stddev_end() → float`
-- <a id="PyNOA2.OptimizerSettingsEA.get_num_crossover_points"></a>`get_num_crossover_points(arg2: int) → int`
-- <a id="PyNOA2.OptimizerSettingsEA.get_num_recombination_methods"></a>`get_num_recombination_methods() → int`
-- <a id="PyNOA2.OptimizerSettingsEA.get_parent_size"></a>`get_parent_size() → int`
-- <a id="PyNOA2.OptimizerSettingsEA.get_ranking_method"></a>`get_ranking_method() → [RankingMethod](#PyNOA2.RankingMethod)`
-- <a id="PyNOA2.OptimizerSettingsEA.get_recombination_method"></a>`get_recombination_method(arg2: int) → [RecombinationMethod](#PyNOA2.RecombinationMethod)`
-- <a id="PyNOA2.OptimizerSettingsEA.get_selection_method"></a>`get_selection_method() → [SelectionMethod](#PyNOA2.SelectionMethod)`
-- <a id="PyNOA2.OptimizerSettingsEA.get_tournament_size"></a>`get_tournament_size() → int`
-- <a id="PyNOA2.OptimizerSettingsEA.set_archive_size"></a>`set_archive_size(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_crossover_probability"></a>`set_crossover_probability(arg2: int, arg3: float)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_defaults"></a>`set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))`
-- <a id="PyNOA2.OptimizerSettingsEA.set_distribution_parameter"></a>`set_distribution_parameter(arg2: int, arg3: float)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_mutation_method"></a>`set_mutation_method(arg2: [MutationMethod](#PyNOA2.MutationMethod))`
-- <a id="PyNOA2.OptimizerSettingsEA.set_mutation_rate"></a>`set_mutation_rate(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_mutation_stddev"></a>`set_mutation_stddev(arg2: float, arg3: float)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_num_crossover_points"></a>`set_num_crossover_points(arg2: int, arg3: int)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_num_recombination_methods"></a>`set_num_recombination_methods(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_parent_size"></a>`set_parent_size(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsEA.set_ranking_method"></a>`set_ranking_method(arg2: [RankingMethod](#PyNOA2.RankingMethod))`
-- <a id="PyNOA2.OptimizerSettingsEA.set_recombination_method"></a>`set_recombination_method(arg2: int, arg3: [RecombinationMethod](#PyNOA2.RecombinationMethod))`
-- <a id="PyNOA2.OptimizerSettingsEA.set_selection_method"></a>`set_selection_method(arg2: [SelectionMethod](#PyNOA2.SelectionMethod))`
-- <a id="PyNOA2.OptimizerSettingsEA.set_tournament_size"></a>`set_tournament_size(arg2: int)`
+<a id="PyNOA2.OptimizerSettingsEA.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA2.OptimizerSettingsEA.get_archive_size"></a>
+
+#### get_archive_size() → int
+
+<a id="PyNOA2.OptimizerSettingsEA.get_crossover_probability"></a>
+
+#### get_crossover_probability(arg2: int) → float
+
+<a id="PyNOA2.OptimizerSettingsEA.get_distribution_parameter"></a>
+
+#### get_distribution_parameter(arg2: int) → float
+
+<a id="PyNOA2.OptimizerSettingsEA.get_mutation_method"></a>
+
+#### get_mutation_method() → [MutationMethod](#PyNOA2.MutationMethod)
+
+<a id="PyNOA2.OptimizerSettingsEA.get_mutation_rate"></a>
+
+#### get_mutation_rate() → float
+
+<a id="PyNOA2.OptimizerSettingsEA.get_mutation_stddev_begin"></a>
+
+#### get_mutation_stddev_begin() → float
+
+<a id="PyNOA2.OptimizerSettingsEA.get_mutation_stddev_end"></a>
+
+#### get_mutation_stddev_end() → float
+
+<a id="PyNOA2.OptimizerSettingsEA.get_num_crossover_points"></a>
+
+#### get_num_crossover_points(arg2: int) → int
+
+<a id="PyNOA2.OptimizerSettingsEA.get_num_recombination_methods"></a>
+
+#### get_num_recombination_methods() → int
+
+<a id="PyNOA2.OptimizerSettingsEA.get_parent_size"></a>
+
+#### get_parent_size() → int
+
+<a id="PyNOA2.OptimizerSettingsEA.get_ranking_method"></a>
+
+#### get_ranking_method() → [RankingMethod](#PyNOA2.RankingMethod)
+
+<a id="PyNOA2.OptimizerSettingsEA.get_recombination_method"></a>
+
+#### get_recombination_method(arg2: int) → [RecombinationMethod](#PyNOA2.RecombinationMethod)
+
+<a id="PyNOA2.OptimizerSettingsEA.get_selection_method"></a>
+
+#### get_selection_method() → [SelectionMethod](#PyNOA2.SelectionMethod)
+
+<a id="PyNOA2.OptimizerSettingsEA.get_tournament_size"></a>
+
+#### get_tournament_size() → int
+
+<a id="PyNOA2.OptimizerSettingsEA.set_archive_size"></a>
+
+#### set_archive_size(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_crossover_probability"></a>
+
+#### set_crossover_probability(arg2: int, arg3: float)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_defaults"></a>
+
+#### set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))
+
+<a id="PyNOA2.OptimizerSettingsEA.set_distribution_parameter"></a>
+
+#### set_distribution_parameter(arg2: int, arg3: float)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_mutation_method"></a>
+
+#### set_mutation_method(arg2: [MutationMethod](#PyNOA2.MutationMethod))
+
+<a id="PyNOA2.OptimizerSettingsEA.set_mutation_rate"></a>
+
+#### set_mutation_rate(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_mutation_stddev"></a>
+
+#### set_mutation_stddev(arg2: float, arg3: float)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_num_crossover_points"></a>
+
+#### set_num_crossover_points(arg2: int, arg3: int)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_num_recombination_methods"></a>
+
+#### set_num_recombination_methods(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_parent_size"></a>
+
+#### set_parent_size(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsEA.set_ranking_method"></a>
+
+#### set_ranking_method(arg2: [RankingMethod](#PyNOA2.RankingMethod))
+
+<a id="PyNOA2.OptimizerSettingsEA.set_recombination_method"></a>
+
+#### set_recombination_method(arg2: int, arg3: [RecombinationMethod](#PyNOA2.RecombinationMethod))
+
+<a id="PyNOA2.OptimizerSettingsEA.set_selection_method"></a>
+
+#### set_selection_method(arg2: [SelectionMethod](#PyNOA2.SelectionMethod))
+
+<a id="PyNOA2.OptimizerSettingsEA.set_tournament_size"></a>
+
+#### set_tournament_size(arg2: int)
 
 <a id="PyNOA2.OptimizerSettingsNOABase"></a>
 
 ## *class* PyNOA2.OptimizerSettingsNOABase
 
-- <a id="PyNOA2.OptimizerSettingsNOABase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_constraint_handling"></a>`get_constraint_handling() → [ConstraintHandling](#PyNOA2.ConstraintHandling)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_fitness_method"></a>`get_fitness_method() → [FitnessMethod](#PyNOA2.FitnessMethod)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_max_evaluations"></a>`get_max_evaluations() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_max_generations"></a>`get_max_generations() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_population_size"></a>`get_population_size() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_search_strategy"></a>`get_search_strategy() → [SearchStrategy](#PyNOA2.SearchStrategy)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_seed"></a>`get_seed() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_stagnation_generations"></a>`get_stagnation_generations() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.get_start_population_size"></a>`get_start_population_size() → int`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_constraint_handling"></a>`set_constraint_handling(arg2: [ConstraintHandling](#PyNOA2.ConstraintHandling))`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_fitness_method"></a>`set_fitness_method(arg2: [FitnessMethod](#PyNOA2.FitnessMethod))`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_max_generations"></a>`set_max_generations(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_population_size"></a>`set_population_size(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_seed"></a>`set_seed(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_stagnation_generations"></a>`set_stagnation_generations(arg2: int)`
-- <a id="PyNOA2.OptimizerSettingsNOABase.set_start_population_size"></a>`set_start_population_size(arg2: int)`
+<a id="PyNOA2.OptimizerSettingsNOABase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_constraint_handling"></a>
+
+#### get_constraint_handling() → [ConstraintHandling](#PyNOA2.ConstraintHandling)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_fitness_method"></a>
+
+#### get_fitness_method() → [FitnessMethod](#PyNOA2.FitnessMethod)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_max_evaluations"></a>
+
+#### get_max_evaluations() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_max_generations"></a>
+
+#### get_max_generations() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_population_size"></a>
+
+#### get_population_size() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_search_strategy"></a>
+
+#### get_search_strategy() → [SearchStrategy](#PyNOA2.SearchStrategy)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_seed"></a>
+
+#### get_seed() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_stagnation_generations"></a>
+
+#### get_stagnation_generations() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.get_start_population_size"></a>
+
+#### get_start_population_size() → int
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_constraint_handling"></a>
+
+#### set_constraint_handling(arg2: [ConstraintHandling](#PyNOA2.ConstraintHandling))
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_fitness_method"></a>
+
+#### set_fitness_method(arg2: [FitnessMethod](#PyNOA2.FitnessMethod))
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_max_generations"></a>
+
+#### set_max_generations(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_population_size"></a>
+
+#### set_population_size(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_seed"></a>
+
+#### set_seed(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_stagnation_generations"></a>
+
+#### set_stagnation_generations(arg2: int)
+
+<a id="PyNOA2.OptimizerSettingsNOABase.set_start_population_size"></a>
+
+#### set_start_population_size(arg2: int)
 
 <a id="PyNOA2.OptimizerSettingsPSO"></a>
 
 ## *class* PyNOA2.OptimizerSettingsPSO
 
-- <a id="PyNOA2.OptimizerSettingsPSO.__init__"></a>`__init__()`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_global_acccoeff_begin"></a>`get_global_acccoeff_begin() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_global_acccoeff_end"></a>`get_global_acccoeff_end() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_inertia_weight_begin"></a>`get_inertia_weight_begin() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_inertia_weight_end"></a>`get_inertia_weight_end() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_passive_congrcoeff_begin"></a>`get_passive_congrcoeff_begin() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_passive_congrcoeff_end"></a>`get_passive_congrcoeff_end() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_personal_acccoeff_begin"></a>`get_personal_acccoeff_begin() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.get_personal_acccoeff_end"></a>`get_personal_acccoeff_end() → float`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_defaults"></a>`set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_global_acccoeff_begin"></a>`set_global_acccoeff_begin(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_global_acccoeff_end"></a>`set_global_acccoeff_end(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_inertia_weight_begin"></a>`set_inertia_weight_begin(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_inertia_weight_end"></a>`set_inertia_weight_end(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_passive_congrcoeff_begin"></a>`set_passive_congrcoeff_begin(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_passive_congrcoeff_end"></a>`set_passive_congrcoeff_end(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_personal_acccoeff_begin"></a>`set_personal_acccoeff_begin(arg2: float)`
-- <a id="PyNOA2.OptimizerSettingsPSO.set_personal_acccoeff_end"></a>`set_personal_acccoeff_end(arg2: float)`
+<a id="PyNOA2.OptimizerSettingsPSO.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_global_acccoeff_begin"></a>
+
+#### get_global_acccoeff_begin() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_global_acccoeff_end"></a>
+
+#### get_global_acccoeff_end() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_inertia_weight_begin"></a>
+
+#### get_inertia_weight_begin() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_inertia_weight_end"></a>
+
+#### get_inertia_weight_end() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_passive_congrcoeff_begin"></a>
+
+#### get_passive_congrcoeff_begin() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_passive_congrcoeff_end"></a>
+
+#### get_passive_congrcoeff_end() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_personal_acccoeff_begin"></a>
+
+#### get_personal_acccoeff_begin() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.get_personal_acccoeff_end"></a>
+
+#### get_personal_acccoeff_end() → float
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_defaults"></a>
+
+#### set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_global_acccoeff_begin"></a>
+
+#### set_global_acccoeff_begin(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_global_acccoeff_end"></a>
+
+#### set_global_acccoeff_end(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_inertia_weight_begin"></a>
+
+#### set_inertia_weight_begin(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_inertia_weight_end"></a>
+
+#### set_inertia_weight_end(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_passive_congrcoeff_begin"></a>
+
+#### set_passive_congrcoeff_begin(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_passive_congrcoeff_end"></a>
+
+#### set_passive_congrcoeff_end(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_personal_acccoeff_begin"></a>
+
+#### set_personal_acccoeff_begin(arg2: float)
+
+<a id="PyNOA2.OptimizerSettingsPSO.set_personal_acccoeff_end"></a>
+
+#### set_personal_acccoeff_end(arg2: float)
 
 <a id="PyNOA2.OptimizerSettingsSDI"></a>
 
 ## *class* PyNOA2.OptimizerSettingsSDI
 
-- <a id="PyNOA2.OptimizerSettingsSDI.__init__"></a>`__init__()`
-- <a id="PyNOA2.OptimizerSettingsSDI.get_sampling_bounds_width"></a>`get_sampling_bounds_width() → float`
-- <a id="PyNOA2.OptimizerSettingsSDI.set_defaults"></a>`set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))`
-- <a id="PyNOA2.OptimizerSettingsSDI.set_sampling_bounds_width"></a>`set_sampling_bounds_width(arg2: float)`
+<a id="PyNOA2.OptimizerSettingsSDI.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PyNOA2.OptimizerSettingsSDI.get_sampling_bounds_width"></a>
+
+#### get_sampling_bounds_width() → float
+
+<a id="PyNOA2.OptimizerSettingsSDI.set_defaults"></a>
+
+#### set_defaults(arg2: int, arg3: [SearchStrategy](#PyNOA2.SearchStrategy))
+
+<a id="PyNOA2.OptimizerSettingsSDI.set_sampling_bounds_width"></a>
+
+#### set_sampling_bounds_width(arg2: float)
 
 <a id="PyNOA2.PSO"></a>
 
 ## *class* PyNOA2.PSO
 
-- <a id="PyNOA2.PSO.__init__"></a>`__init__()`
+<a id="PyNOA2.PSO.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="PyNOA2.RankingMethod"></a>
 
@@ -159,9 +406,17 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.RankingMethod.EXPONENTIAL"></a>`EXPONENTIAL *= PyNOA2.RankingMethod.EXPONENTIAL*`
-- <a id="PyNOA2.RankingMethod.LINEAR"></a>`LINEAR *= PyNOA2.RankingMethod.LINEAR*`
-- <a id="PyNOA2.RankingMethod.PARETO"></a>`PARETO *= PyNOA2.RankingMethod.PARETO*`
+<a id="PyNOA2.RankingMethod.EXPONENTIAL"></a>
+
+#### EXPONENTIAL *= PyNOA2.RankingMethod.EXPONENTIAL*
+
+<a id="PyNOA2.RankingMethod.LINEAR"></a>
+
+#### LINEAR *= PyNOA2.RankingMethod.LINEAR*
+
+<a id="PyNOA2.RankingMethod.PARETO"></a>
+
+#### PARETO *= PyNOA2.RankingMethod.PARETO*
 
 <a id="PyNOA2.RecombinationMethod"></a>
 
@@ -169,18 +424,37 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.RecombinationMethod.ARITHMETIC"></a>`ARITHMETIC *= PyNOA2.RecombinationMethod.ARITHMETIC*`
-- <a id="PyNOA2.RecombinationMethod.COPY"></a>`COPY *= PyNOA2.RecombinationMethod.COPY*`
-- <a id="PyNOA2.RecombinationMethod.MULTIPOINT"></a>`MULTIPOINT *= PyNOA2.RecombinationMethod.MULTIPOINT*`
-- <a id="PyNOA2.RecombinationMethod.SIMULATED_BINARY"></a>`SIMULATED_BINARY *= PyNOA2.RecombinationMethod.SIMULATED_BINARY*`
-- <a id="PyNOA2.RecombinationMethod.SINGLEPOINT"></a>`SINGLEPOINT *= PyNOA2.RecombinationMethod.SINGLEPOINT*`
-- <a id="PyNOA2.RecombinationMethod.UNIFORM"></a>`UNIFORM *= PyNOA2.RecombinationMethod.UNIFORM*`
+<a id="PyNOA2.RecombinationMethod.ARITHMETIC"></a>
+
+#### ARITHMETIC *= PyNOA2.RecombinationMethod.ARITHMETIC*
+
+<a id="PyNOA2.RecombinationMethod.COPY"></a>
+
+#### COPY *= PyNOA2.RecombinationMethod.COPY*
+
+<a id="PyNOA2.RecombinationMethod.MULTIPOINT"></a>
+
+#### MULTIPOINT *= PyNOA2.RecombinationMethod.MULTIPOINT*
+
+<a id="PyNOA2.RecombinationMethod.SIMULATED_BINARY"></a>
+
+#### SIMULATED_BINARY *= PyNOA2.RecombinationMethod.SIMULATED_BINARY*
+
+<a id="PyNOA2.RecombinationMethod.SINGLEPOINT"></a>
+
+#### SINGLEPOINT *= PyNOA2.RecombinationMethod.SINGLEPOINT*
+
+<a id="PyNOA2.RecombinationMethod.UNIFORM"></a>
+
+#### UNIFORM *= PyNOA2.RecombinationMethod.UNIFORM*
 
 <a id="PyNOA2.SDI"></a>
 
 ## *class* PyNOA2.SDI
 
-- <a id="PyNOA2.SDI.__init__"></a>`__init__()`
+<a id="PyNOA2.SDI.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="PyNOA2.SearchStrategy"></a>
 
@@ -188,9 +462,17 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.SearchStrategy.BALANCED"></a>`BALANCED *= PyNOA2.SearchStrategy.BALANCED*`
-- <a id="PyNOA2.SearchStrategy.GLOBAL"></a>`GLOBAL *= PyNOA2.SearchStrategy.GLOBAL*`
-- <a id="PyNOA2.SearchStrategy.LOCAL"></a>`LOCAL *= PyNOA2.SearchStrategy.LOCAL*`
+<a id="PyNOA2.SearchStrategy.BALANCED"></a>
+
+#### BALANCED *= PyNOA2.SearchStrategy.BALANCED*
+
+<a id="PyNOA2.SearchStrategy.GLOBAL"></a>
+
+#### GLOBAL *= PyNOA2.SearchStrategy.GLOBAL*
+
+<a id="PyNOA2.SearchStrategy.LOCAL"></a>
+
+#### LOCAL *= PyNOA2.SearchStrategy.LOCAL*
 
 <a id="PyNOA2.SelectionMethod"></a>
 
@@ -198,6 +480,14 @@
 
 **Enumeration**
 
-- <a id="PyNOA2.SelectionMethod.ROULETTE"></a>`ROULETTE *= PyNOA2.SelectionMethod.ROULETTE*`
-- <a id="PyNOA2.SelectionMethod.STOCHASTIC"></a>`STOCHASTIC *= PyNOA2.SelectionMethod.STOCHASTIC*`
-- <a id="PyNOA2.SelectionMethod.TOURNAMENT"></a>`TOURNAMENT *= PyNOA2.SelectionMethod.TOURNAMENT*`
+<a id="PyNOA2.SelectionMethod.ROULETTE"></a>
+
+#### ROULETTE *= PyNOA2.SelectionMethod.ROULETTE*
+
+<a id="PyNOA2.SelectionMethod.STOCHASTIC"></a>
+
+#### STOCHASTIC *= PyNOA2.SelectionMethod.STOCHASTIC*
+
+<a id="PyNOA2.SelectionMethod.TOURNAMENT"></a>
+
+#### TOURNAMENT *= PyNOA2.SelectionMethod.TOURNAMENT*

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyOptimizerBase.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyOptimizerBase.md
@@ -4,48 +4,164 @@
 
 ## *class* PyOptimizerBase.OptimizerBase
 
-- <a id="PyOptimizerBase.OptimizerBase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="PyOptimizerBase.OptimizerBase.adapt"></a>`adapt()`
-- <a id="PyOptimizerBase.OptimizerBase.appraise"></a>`appraise()`
-- <a id="PyOptimizerBase.OptimizerBase.finalize"></a>`finalize()`
-- <a id="PyOptimizerBase.OptimizerBase.get_awaiting_designs"></a>`get_awaiting_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_best_design_numbers"></a>`get_best_design_numbers() → object`
-- <a id="PyOptimizerBase.OptimizerBase.get_best_equalities"></a>`get_best_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_best_inequalities"></a>`get_best_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_best_inputs"></a>`get_best_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_best_objectives"></a>`get_best_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_criteria_success_info"></a>`get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_equalities"></a>`get_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_inequalities"></a>`get_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_inputs"></a>`get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_next_designs"></a>`get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.get_num_awaiting_designs"></a>`get_num_awaiting_designs() → int`
-- <a id="PyOptimizerBase.OptimizerBase.get_objectives"></a>`get_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PyOptimizerBase.OptimizerBase.initialize"></a>`initialize(arg2: [SettingsBase](#PyOptimizerBase.SettingsBase))`
-- <a id="PyOptimizerBase.OptimizerBase.is_converged"></a>`is_converged() → bool`
-- <a id="PyOptimizerBase.OptimizerBase.is_terminated"></a>`is_terminated() → bool`
-- <a id="PyOptimizerBase.OptimizerBase.set_criteria_success_info"></a>`set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))`
-- <a id="PyOptimizerBase.OptimizerBase.set_equalities"></a>`set_equalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyOptimizerBase.OptimizerBase.set_inequalities"></a>`set_inequalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyOptimizerBase.OptimizerBase.set_inputs"></a>`set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyOptimizerBase.OptimizerBase.set_objectives"></a>`set_objectives(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyOptimizerBase.OptimizerBase.set_terminated"></a>`set_terminated()`
+<a id="PyOptimizerBase.OptimizerBase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="PyOptimizerBase.OptimizerBase.adapt"></a>
+
+#### adapt()
+
+<a id="PyOptimizerBase.OptimizerBase.appraise"></a>
+
+#### appraise()
+
+<a id="PyOptimizerBase.OptimizerBase.finalize"></a>
+
+#### finalize()
+
+<a id="PyOptimizerBase.OptimizerBase.get_awaiting_designs"></a>
+
+#### get_awaiting_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_best_design_numbers"></a>
+
+#### get_best_design_numbers() → object
+
+<a id="PyOptimizerBase.OptimizerBase.get_best_equalities"></a>
+
+#### get_best_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_best_inequalities"></a>
+
+#### get_best_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_best_inputs"></a>
+
+#### get_best_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_best_objectives"></a>
+
+#### get_best_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_criteria_success_info"></a>
+
+#### get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_equalities"></a>
+
+#### get_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_inequalities"></a>
+
+#### get_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_inputs"></a>
+
+#### get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_next_designs"></a>
+
+#### get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.get_num_awaiting_designs"></a>
+
+#### get_num_awaiting_designs() → int
+
+<a id="PyOptimizerBase.OptimizerBase.get_objectives"></a>
+
+#### get_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PyOptimizerBase.OptimizerBase.initialize"></a>
+
+#### initialize(arg2: [SettingsBase](#PyOptimizerBase.SettingsBase))
+
+<a id="PyOptimizerBase.OptimizerBase.is_converged"></a>
+
+#### is_converged() → bool
+
+<a id="PyOptimizerBase.OptimizerBase.is_terminated"></a>
+
+#### is_terminated() → bool
+
+<a id="PyOptimizerBase.OptimizerBase.set_criteria_success_info"></a>
+
+#### set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))
+
+<a id="PyOptimizerBase.OptimizerBase.set_equalities"></a>
+
+#### set_equalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyOptimizerBase.OptimizerBase.set_inequalities"></a>
+
+#### set_inequalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyOptimizerBase.OptimizerBase.set_inputs"></a>
+
+#### set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyOptimizerBase.OptimizerBase.set_objectives"></a>
+
+#### set_objectives(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyOptimizerBase.OptimizerBase.set_terminated"></a>
+
+#### set_terminated()
 
 <a id="PyOptimizerBase.SettingsBase"></a>
 
 ## *class* PyOptimizerBase.SettingsBase
 
-- <a id="PyOptimizerBase.SettingsBase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="PyOptimizerBase.SettingsBase.get_num_equalities"></a>`get_num_equalities() → int`
-- <a id="PyOptimizerBase.SettingsBase.get_num_inequalities"></a>`get_num_inequalities() → int`
-- <a id="PyOptimizerBase.SettingsBase.get_num_inputs"></a>`get_num_inputs() → int`
-- <a id="PyOptimizerBase.SettingsBase.get_num_objectives"></a>`get_num_objectives() → int`
-- <a id="PyOptimizerBase.SettingsBase.set_defaults"></a>`set_defaults()`
-- <a id="PyOptimizerBase.SettingsBase.set_lower_bounds"></a>`set_lower_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="PyOptimizerBase.SettingsBase.set_num_inequalities"></a>`set_num_inequalities(arg2: int)`
-- <a id="PyOptimizerBase.SettingsBase.set_num_inputs"></a>`set_num_inputs(arg2: int)`
-- <a id="PyOptimizerBase.SettingsBase.set_num_objectives"></a>`set_num_objectives(arg2: int)`
-- <a id="PyOptimizerBase.SettingsBase.set_start_designs"></a>`set_start_designs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="PyOptimizerBase.SettingsBase.set_upper_bounds"></a>`set_upper_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
+<a id="PyOptimizerBase.SettingsBase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="PyOptimizerBase.SettingsBase.get_num_equalities"></a>
+
+#### get_num_equalities() → int
+
+<a id="PyOptimizerBase.SettingsBase.get_num_inequalities"></a>
+
+#### get_num_inequalities() → int
+
+<a id="PyOptimizerBase.SettingsBase.get_num_inputs"></a>
+
+#### get_num_inputs() → int
+
+<a id="PyOptimizerBase.SettingsBase.get_num_objectives"></a>
+
+#### get_num_objectives() → int
+
+<a id="PyOptimizerBase.SettingsBase.set_defaults"></a>
+
+#### set_defaults()
+
+<a id="PyOptimizerBase.SettingsBase.set_lower_bounds"></a>
+
+#### set_lower_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+<a id="PyOptimizerBase.SettingsBase.set_num_inequalities"></a>
+
+#### set_num_inequalities(arg2: int)
+
+<a id="PyOptimizerBase.SettingsBase.set_num_inputs"></a>
+
+#### set_num_inputs(arg2: int)
+
+<a id="PyOptimizerBase.SettingsBase.set_num_objectives"></a>
+
+#### set_num_objectives(arg2: int)
+
+<a id="PyOptimizerBase.SettingsBase.set_start_designs"></a>
+
+#### set_start_designs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="PyOptimizerBase.SettingsBase.set_upper_bounds"></a>
+
+#### set_upper_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyOptimizerGradientBase.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PyOptimizerGradientBase.md
@@ -4,5 +4,10 @@
 
 ## *class* PyOptimizerGradientBase.SettingsBase
 
-- <a id="PyOptimizerGradientBase.SettingsBase.SetMaxNumFunctionCalls"></a>`SetMaxNumFunctionCalls(arg2: int)`
-- <a id="PyOptimizerGradientBase.SettingsBase.__init__"></a>`__init__()`
+<a id="PyOptimizerGradientBase.SettingsBase.SetMaxNumFunctionCalls"></a>
+
+#### SetMaxNumFunctionCalls(arg2: int)
+
+<a id="PyOptimizerGradientBase.SettingsBase.__init__"></a>
+
+#### \_\_init_\_()

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PySimplex.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/PySimplex.md
@@ -4,33 +4,86 @@
 
 ## *class* PySimplex.OptimizerSettingsSimplex
 
-- <a id="PySimplex.OptimizerSettingsSimplex.__init__"></a>`__init__()`
-- <a id="PySimplex.OptimizerSettingsSimplex.get_max_iteration"></a>`get_max_iteration() → int`<br>
-  Get number of maximum iterations.
-- <a id="PySimplex.OptimizerSettingsSimplex.get_min_iteration_test"></a>`get_min_iteration_test() → int`<br>
-  Get number of minimum iterations before test.
-- <a id="PySimplex.OptimizerSettingsSimplex.get_min_objective_diff"></a>`get_min_objective_diff() → float`<br>
-  Get tolerance for objective test.
-- <a id="PySimplex.OptimizerSettingsSimplex.get_min_parameter_diff"></a>`get_min_parameter_diff() → float`<br>
-  Get tolerance for parameter test: convergence test.
-- <a id="PySimplex.OptimizerSettingsSimplex.get_start_range"></a>`get_start_range() → float`<br>
-  Get start range for Simplex.
-- <a id="PySimplex.OptimizerSettingsSimplex.set_max_iteration"></a>`set_max_iteration(arg2: int)`<br>
-  Set number of maximum iterations.
-- <a id="PySimplex.OptimizerSettingsSimplex.set_min_iteration_test"></a>`set_min_iteration_test(arg2: int)`<br>
-  Set number of minimum iterations before test.
-- <a id="PySimplex.OptimizerSettingsSimplex.set_min_objective_diff"></a>`set_min_objective_diff(arg2: float)`<br>
-  Set tolerance for objective test.
-- <a id="PySimplex.OptimizerSettingsSimplex.set_min_parameter_diff"></a>`set_min_parameter_diff(arg2: float)`<br>
-  Set tolerance for parameter test: convergence test.
-- <a id="PySimplex.OptimizerSettingsSimplex.set_start_range"></a>`set_start_range(arg2: float)`<br>
-  Set start range for Simplex.
+<a id="PySimplex.OptimizerSettingsSimplex.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="PySimplex.OptimizerSettingsSimplex.get_max_iteration"></a>
+
+#### get_max_iteration() → int
+
+Get number of maximum iterations.
+
+<a id="PySimplex.OptimizerSettingsSimplex.get_min_iteration_test"></a>
+
+#### get_min_iteration_test() → int
+
+Get number of minimum iterations before test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.get_min_objective_diff"></a>
+
+#### get_min_objective_diff() → float
+
+Get tolerance for objective test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.get_min_parameter_diff"></a>
+
+#### get_min_parameter_diff() → float
+
+Get tolerance for parameter test: convergence test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.get_start_range"></a>
+
+#### get_start_range() → float
+
+Get start range for Simplex.
+
+<a id="PySimplex.OptimizerSettingsSimplex.set_max_iteration"></a>
+
+#### set_max_iteration(arg2: int)
+
+Set number of maximum iterations.
+
+<a id="PySimplex.OptimizerSettingsSimplex.set_min_iteration_test"></a>
+
+#### set_min_iteration_test(arg2: int)
+
+Set number of minimum iterations before test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.set_min_objective_diff"></a>
+
+#### set_min_objective_diff(arg2: float)
+
+Set tolerance for objective test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.set_min_parameter_diff"></a>
+
+#### set_min_parameter_diff(arg2: float)
+
+Set tolerance for parameter test: convergence test.
+
+<a id="PySimplex.OptimizerSettingsSimplex.set_start_range"></a>
+
+#### set_start_range(arg2: float)
+
+Set start range for Simplex.
 
 <a id="PySimplex.Simplex"></a>
 
 ## *class* PySimplex.Simplex
 
-- <a id="PySimplex.Simplex.__init__"></a>`__init__(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))`
-- <a id="PySimplex.Simplex.get_best_design_history"></a>`get_best_design_history() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PySimplex.Simplex.get_iteration_history"></a>`get_iteration_history() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="PySimplex.Simplex.get_iteration_number"></a>`get_iteration_number() → int`
+<a id="PySimplex.Simplex.__init__"></a>
+
+#### \_\_init_\_(arg2: [PyOptimizerBase.SettingsBase](PyOptimizerBase.md#PyOptimizerBase.SettingsBase))
+
+<a id="PySimplex.Simplex.get_best_design_history"></a>
+
+#### get_best_design_history() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PySimplex.Simplex.get_iteration_history"></a>
+
+#### get_iteration_history() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="PySimplex.Simplex.get_iteration_number"></a>
+
+#### get_iteration_number() → int

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/_optiSLang_Actors.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/_optiSLang_Actors.md
@@ -4,23 +4,53 @@
 
 ## *class* \_optiSLang_Actors.AMOPActor
 
-- <a id="optiSLang_Actors.AMOPActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.AMOPActor.amop_settings"></a>*property* `amop_settings`
-- <a id="optiSLang_Actors.AMOPActor.mop_advanced_settings"></a>*property* `mop_advanced_settings`
-- <a id="optiSLang_Actors.AMOPActor.mop_automatic_settings"></a>*property* `mop_automatic_settings`
-- <a id="optiSLang_Actors.AMOPActor.parameter_importancy"></a>*property* `parameter_importancy`
-- <a id="optiSLang_Actors.AMOPActor.settings_type"></a>*property* `settings_type`
+<a id="optiSLang_Actors.AMOPActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.AMOPActor.amop_settings"></a>
+
+#### *property* amop_settings
+
+<a id="optiSLang_Actors.AMOPActor.mop_advanced_settings"></a>
+
+#### *property* mop_advanced_settings
+
+<a id="optiSLang_Actors.AMOPActor.mop_automatic_settings"></a>
+
+#### *property* mop_automatic_settings
+
+<a id="optiSLang_Actors.AMOPActor.parameter_importancy"></a>
+
+#### *property* parameter_importancy
+
+<a id="optiSLang_Actors.AMOPActor.settings_type"></a>
+
+#### *property* settings_type
 
 <a id="optiSLang_Actors.ARSMActor"></a>
 
 ## *class* \_optiSLang_Actors.ARSMActor
 
-- <a id="optiSLang_Actors.ARSMActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ARSMActor.doe_settings"></a>*property* `doe_settings`
-- <a id="optiSLang_Actors.ARSMActor.nlpqlp_settings"></a>*property* `nlpqlp_settings`
-- <a id="optiSLang_Actors.ARSMActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.ARSMActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ARSMActor.doe_settings"></a>
+
+#### *property* doe_settings
+
+<a id="optiSLang_Actors.ARSMActor.nlpqlp_settings"></a>
+
+#### *property* nlpqlp_settings
+
+<a id="optiSLang_Actors.ARSMActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.ARSMDSActor"></a>
 
@@ -28,120 +58,427 @@
 
 Reliability actor using ARSM with Directional Sampling.
 
-- <a id="optiSLang_Actors.ARSMDSActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ARSMDSActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.ARSMDSActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ARSMDSActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.AbaqusProcessActor"></a>
 
 ## *class* \_optiSLang_Actors.AbaqusProcessActor
 
-- <a id="optiSLang_Actors.AbaqusProcessActor.DBLBOTH"></a>`DBLBOTH *= _optiSLang_Actors.DoubleMode.DBLBOTH*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DBLCONSTRAINT"></a>`DBLCONSTRAINT *= _optiSLang_Actors.DoubleMode.DBLCONSTRAINT*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DBLEXPLICIT"></a>`DBLEXPLICIT *= _optiSLang_Actors.DoubleMode.DBLEXPLICIT*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DBLOFF"></a>`DBLOFF *= _optiSLang_Actors.DoubleMode.DBLOFF*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DBLUNSPECIFIED"></a>`DBLUNSPECIFIED *= _optiSLang_Actors.DoubleMode.DBLUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode"></a>`*class* DoubleMode`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLBOTH"></a>`DBLBOTH *= _optiSLang_Actors.DoubleMode.DBLBOTH*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLCONSTRAINT"></a>`DBLCONSTRAINT *= _optiSLang_Actors.DoubleMode.DBLCONSTRAINT*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLEXPLICIT"></a>`DBLEXPLICIT *= _optiSLang_Actors.DoubleMode.DBLEXPLICIT*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLOFF"></a>`DBLOFF *= _optiSLang_Actors.DoubleMode.DBLOFF*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLUNSPECIFIED"></a>`DBLUNSPECIFIED *= _optiSLang_Actors.DoubleMode.DBLUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.NUM_TYPES_DBL"></a>`NUM_TYPES_DBL *= _optiSLang_Actors.DoubleMode.NUM_TYPES_DBL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.EXECANALYSIS"></a>`EXECANALYSIS *= _optiSLang_Actors.ExecType.EXECANALYSIS*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.EXECDATACHECK"></a>`EXECDATACHECK *= _optiSLang_Actors.ExecType.EXECDATACHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.EXECPARAMETERCHECK"></a>`EXECPARAMETERCHECK *= _optiSLang_Actors.ExecType.EXECPARAMETERCHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.EXECPREPOST"></a>`EXECPREPOST *= _optiSLang_Actors.ExecType.EXECPREPOST*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.EXECSYNTAXCHECK"></a>`EXECSYNTAXCHECK *= _optiSLang_Actors.ExecType.EXECSYNTAXCHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType"></a>`*class* ExecType`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECANALYSIS"></a>`EXECANALYSIS *= _optiSLang_Actors.ExecType.EXECANALYSIS*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECDATACHECK"></a>`EXECDATACHECK *= _optiSLang_Actors.ExecType.EXECDATACHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECPARAMETERCHECK"></a>`EXECPARAMETERCHECK *= _optiSLang_Actors.ExecType.EXECPARAMETERCHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECPREPOST"></a>`EXECPREPOST *= _optiSLang_Actors.ExecType.EXECPREPOST*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECSYNTAXCHECK"></a>`EXECSYNTAXCHECK *= _optiSLang_Actors.ExecType.EXECSYNTAXCHECK*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ExecType.NUM_TYPES_EXEC"></a>`NUM_TYPES_EXEC *= _optiSLang_Actors.ExecType.NUM_TYPES_EXEC*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMPI"></a>`MPMPI *= _optiSLang_Actors.MPMode.MPMPI*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMode"></a>`*class* MPMode`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPMPI"></a>`MPMPI *= _optiSLang_Actors.MPMode.MPMPI*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPTHREADS"></a>`MPTHREADS *= _optiSLang_Actors.MPMode.MPTHREADS*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPUNSPECIFIED"></a>`MPUNSPECIFIED *= _optiSLang_Actors.MPMode.MPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPMode.NUM_TYPES_MP"></a>`NUM_TYPES_MP *= _optiSLang_Actors.MPMode.NUM_TYPES_MP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPTHREADS"></a>`MPTHREADS *= _optiSLang_Actors.MPMode.MPTHREADS*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.MPUNSPECIFIED"></a>`MPUNSPECIFIED *= _optiSLang_Actors.MPMode.MPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_DBL"></a>`NUM_TYPES_DBL *= _optiSLang_Actors.DoubleMode.NUM_TYPES_DBL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_EXEC"></a>`NUM_TYPES_EXEC *= _optiSLang_Actors.ExecType.NUM_TYPES_EXEC*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_MP"></a>`NUM_TYPES_MP *= _optiSLang_Actors.MPMode.NUM_TYPES_MP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_OP"></a>`NUM_TYPES_OP *= _optiSLang_Actors.OutputPrecision.NUM_TYPES_OP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_PAR"></a>`NUM_TYPES_PAR *= _optiSLang_Actors.ParallelType.NUM_TYPES_PAR*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_PP"></a>`NUM_TYPES_PP *= _optiSLang_Actors.PrePost.NUM_TYPES_PP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_SP"></a>`NUM_TYPES_SP *= _optiSLang_Actors.StdParallel.NUM_TYPES_SP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OPFULL"></a>`OPFULL *= _optiSLang_Actors.OutputPrecision.OPFULL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OPSINGLE"></a>`OPSINGLE *= _optiSLang_Actors.OutputPrecision.OPSINGLE*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OPUNSPECIFIED"></a>`OPUNSPECIFIED *= _optiSLang_Actors.OutputPrecision.OPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision"></a>`*class* OutputPrecision`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.NUM_TYPES_OP"></a>`NUM_TYPES_OP *= _optiSLang_Actors.OutputPrecision.NUM_TYPES_OP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPFULL"></a>`OPFULL *= _optiSLang_Actors.OutputPrecision.OPFULL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPSINGLE"></a>`OPSINGLE *= _optiSLang_Actors.OutputPrecision.OPSINGLE*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPUNSPECIFIED"></a>`OPUNSPECIFIED *= _optiSLang_Actors.OutputPrecision.OPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PARDOMAIN"></a>`PARDOMAIN *= _optiSLang_Actors.ParallelType.PARDOMAIN*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PARLOOP"></a>`PARLOOP *= _optiSLang_Actors.ParallelType.PARLOOP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PARUNSPECIFIED"></a>`PARUNSPECIFIED *= _optiSLang_Actors.ParallelType.PARUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PPCAE"></a>`PPCAE *= _optiSLang_Actors.PrePost.PPCAE*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PPVIEWER"></a>`PPVIEWER *= _optiSLang_Actors.PrePost.PPVIEWER*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ParallelType"></a>`*class* ParallelType`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.NUM_TYPES_PAR"></a>`NUM_TYPES_PAR *= _optiSLang_Actors.ParallelType.NUM_TYPES_PAR*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARDOMAIN"></a>`PARDOMAIN *= _optiSLang_Actors.ParallelType.PARDOMAIN*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARLOOP"></a>`PARLOOP *= _optiSLang_Actors.ParallelType.PARLOOP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARUNSPECIFIED"></a>`PARUNSPECIFIED *= _optiSLang_Actors.ParallelType.PARUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PrePost"></a>`*class* PrePost`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.PrePost.NUM_TYPES_PP"></a>`NUM_TYPES_PP *= _optiSLang_Actors.PrePost.NUM_TYPES_PP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PrePost.PPCAE"></a>`PPCAE *= _optiSLang_Actors.PrePost.PPCAE*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.PrePost.PPVIEWER"></a>`PPVIEWER *= _optiSLang_Actors.PrePost.PPVIEWER*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.SPALL"></a>`SPALL *= _optiSLang_Actors.StdParallel.SPALL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.SPSOLVER"></a>`SPSOLVER *= _optiSLang_Actors.StdParallel.SPSOLVER*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.SPUNSPECIFIED"></a>`SPUNSPECIFIED *= _optiSLang_Actors.StdParallel.SPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.StdParallel"></a>`*class* StdParallel`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.NUM_TYPES_SP"></a>`NUM_TYPES_SP *= _optiSLang_Actors.StdParallel.NUM_TYPES_SP*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPALL"></a>`SPALL *= _optiSLang_Actors.StdParallel.SPALL*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPSOLVER"></a>`SPSOLVER *= _optiSLang_Actors.StdParallel.SPSOLVER*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPUNSPECIFIED"></a>`SPUNSPECIFIED *= _optiSLang_Actors.StdParallel.SPUNSPECIFIED*`
-- <a id="optiSLang_Actors.AbaqusProcessActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.AbaqusProcessActor.abaqus_base"></a>*property* `abaqus_base`
-- <a id="optiSLang_Actors.AbaqusProcessActor.additional_args"></a>*property* `additional_args`
-- <a id="optiSLang_Actors.AbaqusProcessActor.cpus"></a>*property* `cpus`
-- <a id="optiSLang_Actors.AbaqusProcessActor.domain_num"></a>*property* `domain_num`
-- <a id="optiSLang_Actors.AbaqusProcessActor.double_mode"></a>*property* `double_mode`
-- <a id="optiSLang_Actors.AbaqusProcessActor.dynamic_load_balance"></a>*property* `dynamic_load_balance`
-- <a id="optiSLang_Actors.AbaqusProcessActor.execution_type"></a>*property* `execution_type`
-- <a id="optiSLang_Actors.AbaqusProcessActor.input_file"></a>*property* `input_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.interactive"></a>*property* `interactive`
-- <a id="optiSLang_Actors.AbaqusProcessActor.job_name"></a>*property* `job_name`
-- <a id="optiSLang_Actors.AbaqusProcessActor.madymo_input"></a>*property* `madymo_input`
-- <a id="optiSLang_Actors.AbaqusProcessActor.memory_size"></a>*property* `memory_size`
-- <a id="optiSLang_Actors.AbaqusProcessActor.mp_mode"></a>*property* `mp_mode`
-- <a id="optiSLang_Actors.AbaqusProcessActor.output_database_file"></a>*property* `output_database_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.output_precision"></a>*property* `output_precision`
-- <a id="optiSLang_Actors.AbaqusProcessActor.parallel_type"></a>*property* `parallel_type`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_custom_script_file"></a>*property* `pre_post_custom_script_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_database_file"></a>*property* `pre_post_database_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_env_startup"></a>*property* `pre_post_no_env_startup`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_gui_file"></a>*property* `pre_post_no_gui_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_saved_options"></a>*property* `pre_post_no_saved_options`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_startup_dialog"></a>*property* `pre_post_no_startup_dialog`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_script_file"></a>*property* `pre_post_script_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_startup_script_file"></a>*property* `pre_post_startup_script_file`
-- <a id="optiSLang_Actors.AbaqusProcessActor.pre_post_type"></a>*property* `pre_post_type`
-- <a id="optiSLang_Actors.AbaqusProcessActor.scratch_dir"></a>*property* `scratch_dir`
-- <a id="optiSLang_Actors.AbaqusProcessActor.standard_parallel"></a>*property* `standard_parallel`
-- <a id="optiSLang_Actors.AbaqusProcessActor.user_function"></a>*property* `user_function`
+<a id="optiSLang_Actors.AbaqusProcessActor.DBLBOTH"></a>
+
+#### DBLBOTH *= \_optiSLang_Actors.DoubleMode.DBLBOTH*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DBLCONSTRAINT"></a>
+
+#### DBLCONSTRAINT *= \_optiSLang_Actors.DoubleMode.DBLCONSTRAINT*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DBLEXPLICIT"></a>
+
+#### DBLEXPLICIT *= \_optiSLang_Actors.DoubleMode.DBLEXPLICIT*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DBLOFF"></a>
+
+#### DBLOFF *= \_optiSLang_Actors.DoubleMode.DBLOFF*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DBLUNSPECIFIED"></a>
+
+#### DBLUNSPECIFIED *= \_optiSLang_Actors.DoubleMode.DBLUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode"></a>
+
+#### *class* DoubleMode
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLBOTH"></a>
+
+#### DBLBOTH *= \_optiSLang_Actors.DoubleMode.DBLBOTH*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLCONSTRAINT"></a>
+
+#### DBLCONSTRAINT *= \_optiSLang_Actors.DoubleMode.DBLCONSTRAINT*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLEXPLICIT"></a>
+
+#### DBLEXPLICIT *= \_optiSLang_Actors.DoubleMode.DBLEXPLICIT*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLOFF"></a>
+
+#### DBLOFF *= \_optiSLang_Actors.DoubleMode.DBLOFF*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.DBLUNSPECIFIED"></a>
+
+#### DBLUNSPECIFIED *= \_optiSLang_Actors.DoubleMode.DBLUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.DoubleMode.NUM_TYPES_DBL"></a>
+
+#### NUM_TYPES_DBL *= \_optiSLang_Actors.DoubleMode.NUM_TYPES_DBL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.EXECANALYSIS"></a>
+
+#### EXECANALYSIS *= \_optiSLang_Actors.ExecType.EXECANALYSIS*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.EXECDATACHECK"></a>
+
+#### EXECDATACHECK *= \_optiSLang_Actors.ExecType.EXECDATACHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.EXECPARAMETERCHECK"></a>
+
+#### EXECPARAMETERCHECK *= \_optiSLang_Actors.ExecType.EXECPARAMETERCHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.EXECPREPOST"></a>
+
+#### EXECPREPOST *= \_optiSLang_Actors.ExecType.EXECPREPOST*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.EXECSYNTAXCHECK"></a>
+
+#### EXECSYNTAXCHECK *= \_optiSLang_Actors.ExecType.EXECSYNTAXCHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType"></a>
+
+#### *class* ExecType
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECANALYSIS"></a>
+
+#### EXECANALYSIS *= \_optiSLang_Actors.ExecType.EXECANALYSIS*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECDATACHECK"></a>
+
+#### EXECDATACHECK *= \_optiSLang_Actors.ExecType.EXECDATACHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECPARAMETERCHECK"></a>
+
+#### EXECPARAMETERCHECK *= \_optiSLang_Actors.ExecType.EXECPARAMETERCHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECPREPOST"></a>
+
+#### EXECPREPOST *= \_optiSLang_Actors.ExecType.EXECPREPOST*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.EXECSYNTAXCHECK"></a>
+
+#### EXECSYNTAXCHECK *= \_optiSLang_Actors.ExecType.EXECSYNTAXCHECK*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ExecType.NUM_TYPES_EXEC"></a>
+
+#### NUM_TYPES_EXEC *= \_optiSLang_Actors.ExecType.NUM_TYPES_EXEC*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMPI"></a>
+
+#### MPMPI *= \_optiSLang_Actors.MPMode.MPMPI*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMode"></a>
+
+#### *class* MPMode
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPMPI"></a>
+
+#### MPMPI *= \_optiSLang_Actors.MPMode.MPMPI*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPTHREADS"></a>
+
+#### MPTHREADS *= \_optiSLang_Actors.MPMode.MPTHREADS*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMode.MPUNSPECIFIED"></a>
+
+#### MPUNSPECIFIED *= \_optiSLang_Actors.MPMode.MPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPMode.NUM_TYPES_MP"></a>
+
+#### NUM_TYPES_MP *= \_optiSLang_Actors.MPMode.NUM_TYPES_MP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPTHREADS"></a>
+
+#### MPTHREADS *= \_optiSLang_Actors.MPMode.MPTHREADS*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.MPUNSPECIFIED"></a>
+
+#### MPUNSPECIFIED *= \_optiSLang_Actors.MPMode.MPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_DBL"></a>
+
+#### NUM_TYPES_DBL *= \_optiSLang_Actors.DoubleMode.NUM_TYPES_DBL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_EXEC"></a>
+
+#### NUM_TYPES_EXEC *= \_optiSLang_Actors.ExecType.NUM_TYPES_EXEC*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_MP"></a>
+
+#### NUM_TYPES_MP *= \_optiSLang_Actors.MPMode.NUM_TYPES_MP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_OP"></a>
+
+#### NUM_TYPES_OP *= \_optiSLang_Actors.OutputPrecision.NUM_TYPES_OP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_PAR"></a>
+
+#### NUM_TYPES_PAR *= \_optiSLang_Actors.ParallelType.NUM_TYPES_PAR*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_PP"></a>
+
+#### NUM_TYPES_PP *= \_optiSLang_Actors.PrePost.NUM_TYPES_PP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.NUM_TYPES_SP"></a>
+
+#### NUM_TYPES_SP *= \_optiSLang_Actors.StdParallel.NUM_TYPES_SP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OPFULL"></a>
+
+#### OPFULL *= \_optiSLang_Actors.OutputPrecision.OPFULL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OPSINGLE"></a>
+
+#### OPSINGLE *= \_optiSLang_Actors.OutputPrecision.OPSINGLE*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OPUNSPECIFIED"></a>
+
+#### OPUNSPECIFIED *= \_optiSLang_Actors.OutputPrecision.OPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision"></a>
+
+#### *class* OutputPrecision
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.NUM_TYPES_OP"></a>
+
+#### NUM_TYPES_OP *= \_optiSLang_Actors.OutputPrecision.NUM_TYPES_OP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPFULL"></a>
+
+#### OPFULL *= \_optiSLang_Actors.OutputPrecision.OPFULL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPSINGLE"></a>
+
+#### OPSINGLE *= \_optiSLang_Actors.OutputPrecision.OPSINGLE*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.OutputPrecision.OPUNSPECIFIED"></a>
+
+#### OPUNSPECIFIED *= \_optiSLang_Actors.OutputPrecision.OPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PARDOMAIN"></a>
+
+#### PARDOMAIN *= \_optiSLang_Actors.ParallelType.PARDOMAIN*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PARLOOP"></a>
+
+#### PARLOOP *= \_optiSLang_Actors.ParallelType.PARLOOP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PARUNSPECIFIED"></a>
+
+#### PARUNSPECIFIED *= \_optiSLang_Actors.ParallelType.PARUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PPCAE"></a>
+
+#### PPCAE *= \_optiSLang_Actors.PrePost.PPCAE*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PPVIEWER"></a>
+
+#### PPVIEWER *= \_optiSLang_Actors.PrePost.PPVIEWER*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ParallelType"></a>
+
+#### *class* ParallelType
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.NUM_TYPES_PAR"></a>
+
+#### NUM_TYPES_PAR *= \_optiSLang_Actors.ParallelType.NUM_TYPES_PAR*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARDOMAIN"></a>
+
+#### PARDOMAIN *= \_optiSLang_Actors.ParallelType.PARDOMAIN*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARLOOP"></a>
+
+#### PARLOOP *= \_optiSLang_Actors.ParallelType.PARLOOP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.ParallelType.PARUNSPECIFIED"></a>
+
+#### PARUNSPECIFIED *= \_optiSLang_Actors.ParallelType.PARUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PrePost"></a>
+
+#### *class* PrePost
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PrePost.NUM_TYPES_PP"></a>
+
+#### NUM_TYPES_PP *= \_optiSLang_Actors.PrePost.NUM_TYPES_PP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PrePost.PPCAE"></a>
+
+#### PPCAE *= \_optiSLang_Actors.PrePost.PPCAE*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.PrePost.PPVIEWER"></a>
+
+#### PPVIEWER *= \_optiSLang_Actors.PrePost.PPVIEWER*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.SPALL"></a>
+
+#### SPALL *= \_optiSLang_Actors.StdParallel.SPALL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.SPSOLVER"></a>
+
+#### SPSOLVER *= \_optiSLang_Actors.StdParallel.SPSOLVER*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.SPUNSPECIFIED"></a>
+
+#### SPUNSPECIFIED *= \_optiSLang_Actors.StdParallel.SPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.StdParallel"></a>
+
+#### *class* StdParallel
+
+**Enumeration**
+
+<a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.NUM_TYPES_SP"></a>
+
+#### NUM_TYPES_SP *= \_optiSLang_Actors.StdParallel.NUM_TYPES_SP*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPALL"></a>
+
+#### SPALL *= \_optiSLang_Actors.StdParallel.SPALL*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPSOLVER"></a>
+
+#### SPSOLVER *= \_optiSLang_Actors.StdParallel.SPSOLVER*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.StdParallel.SPUNSPECIFIED"></a>
+
+#### SPUNSPECIFIED *= \_optiSLang_Actors.StdParallel.SPUNSPECIFIED*
+
+<a id="optiSLang_Actors.AbaqusProcessActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.AbaqusProcessActor.abaqus_base"></a>
+
+#### *property* abaqus_base
+
+<a id="optiSLang_Actors.AbaqusProcessActor.additional_args"></a>
+
+#### *property* additional_args
+
+<a id="optiSLang_Actors.AbaqusProcessActor.cpus"></a>
+
+#### *property* cpus
+
+<a id="optiSLang_Actors.AbaqusProcessActor.domain_num"></a>
+
+#### *property* domain_num
+
+<a id="optiSLang_Actors.AbaqusProcessActor.double_mode"></a>
+
+#### *property* double_mode
+
+<a id="optiSLang_Actors.AbaqusProcessActor.dynamic_load_balance"></a>
+
+#### *property* dynamic_load_balance
+
+<a id="optiSLang_Actors.AbaqusProcessActor.execution_type"></a>
+
+#### *property* execution_type
+
+<a id="optiSLang_Actors.AbaqusProcessActor.input_file"></a>
+
+#### *property* input_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.interactive"></a>
+
+#### *property* interactive
+
+<a id="optiSLang_Actors.AbaqusProcessActor.job_name"></a>
+
+#### *property* job_name
+
+<a id="optiSLang_Actors.AbaqusProcessActor.madymo_input"></a>
+
+#### *property* madymo_input
+
+<a id="optiSLang_Actors.AbaqusProcessActor.memory_size"></a>
+
+#### *property* memory_size
+
+<a id="optiSLang_Actors.AbaqusProcessActor.mp_mode"></a>
+
+#### *property* mp_mode
+
+<a id="optiSLang_Actors.AbaqusProcessActor.output_database_file"></a>
+
+#### *property* output_database_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.output_precision"></a>
+
+#### *property* output_precision
+
+<a id="optiSLang_Actors.AbaqusProcessActor.parallel_type"></a>
+
+#### *property* parallel_type
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_custom_script_file"></a>
+
+#### *property* pre_post_custom_script_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_database_file"></a>
+
+#### *property* pre_post_database_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_env_startup"></a>
+
+#### *property* pre_post_no_env_startup
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_gui_file"></a>
+
+#### *property* pre_post_no_gui_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_saved_options"></a>
+
+#### *property* pre_post_no_saved_options
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_no_startup_dialog"></a>
+
+#### *property* pre_post_no_startup_dialog
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_script_file"></a>
+
+#### *property* pre_post_script_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_startup_script_file"></a>
+
+#### *property* pre_post_startup_script_file
+
+<a id="optiSLang_Actors.AbaqusProcessActor.pre_post_type"></a>
+
+#### *property* pre_post_type
+
+<a id="optiSLang_Actors.AbaqusProcessActor.scratch_dir"></a>
+
+#### *property* scratch_dir
+
+<a id="optiSLang_Actors.AbaqusProcessActor.standard_parallel"></a>
+
+#### *property* standard_parallel
+
+<a id="optiSLang_Actors.AbaqusProcessActor.user_function"></a>
+
+#### *property* user_function
 
 <a id="optiSLang_Actors.AdaptiveSamplingActor"></a>
 
@@ -149,94 +486,192 @@ Reliability actor using ARSM with Directional Sampling.
 
 Reliability actor using the Adaptive Sampling method.
 
-- <a id="optiSLang_Actors.AdaptiveSamplingActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.AdaptiveSamplingActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.AdaptiveSamplingActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.AdaptiveSamplingActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.AlgorithmPluginSystem"></a>
 
 ## *class* \_optiSLang_Actors.AlgorithmPluginSystem
 
-- <a id="optiSLang_Actors.AlgorithmPluginSystem.__init__"></a>`__init__(plugin: str name) → object`<br>
-  Create an algorithm plugin actor by name. The plugin must be loaded at runtime.
-- <a id="optiSLang_Actors.AlgorithmPluginSystem.get_internal_property_names"></a>`get_internal_property_names() → list`<br>
-  Get names of properties defined by the plugin internally
-- <a id="optiSLang_Actors.AlgorithmPluginSystem.get_plugin_id"></a>`get_plugin_id() → str`<br>
-  The plugin id.
+<a id="optiSLang_Actors.AlgorithmPluginSystem.__init__"></a>
+
+#### \_\_init_\_(plugin: str name) → object
+
+Create an algorithm plugin actor by name. The plugin must be loaded at runtime.
+
+<a id="optiSLang_Actors.AlgorithmPluginSystem.get_internal_property_names"></a>
+
+#### get_internal_property_names() → list
+
+Get names of properties defined by the plugin internally
+
+<a id="optiSLang_Actors.AlgorithmPluginSystem.get_plugin_id"></a>
+
+#### get_plugin_id() → str
+
+The plugin id.
 
 <a id="optiSLang_Actors.AlgorithmSystemActor"></a>
 
 ## *class* \_optiSLang_Actors.AlgorithmSystemActor
 
-- <a id="optiSLang_Actors.AlgorithmSystemActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.AlgorithmSystemActor.start_designs"></a>*property* `start_designs`
+<a id="optiSLang_Actors.AlgorithmSystemActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.AlgorithmSystemActor.start_designs"></a>
+
+#### *property* start_designs
 
 <a id="optiSLang_Actors.AnsysAPDLInputActor"></a>
 
 ## *class* \_optiSLang_Actors.AnsysAPDLInputActor
 
-- <a id="optiSLang_Actors.AnsysAPDLInputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.AnsysAPDLInputActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.AnsysAPDLInputActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.AnsysAPDLInputActor.register_location_as_parameter"></a>`register_location_as_parameter(arg2: str)`
-- <a id="optiSLang_Actors.AnsysAPDLInputActor.register_locations_as_parameter"></a>`register_locations_as_parameter()`
+<a id="optiSLang_Actors.AnsysAPDLInputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.AnsysAPDLInputActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.AnsysAPDLInputActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.AnsysAPDLInputActor.register_location_as_parameter"></a>
+
+#### register_location_as_parameter(arg2: str)
+
+<a id="optiSLang_Actors.AnsysAPDLInputActor.register_locations_as_parameter"></a>
+
+#### register_locations_as_parameter()
 
 <a id="optiSLang_Actors.AppendDesignsToBinFileActor"></a>
 
 ## *class* \_optiSLang_Actors.AppendDesignsToBinFileActor
 
-- <a id="optiSLang_Actors.AppendDesignsToBinFileActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.AppendDesignsToBinFileActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.BashScriptActor"></a>
 
 ## *class* \_optiSLang_Actors.BashScriptActor
 
-- <a id="optiSLang_Actors.BashScriptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.BashScriptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.BatchScriptActor"></a>
 
 ## *class* \_optiSLang_Actors.BatchScriptActor
 
-- <a id="optiSLang_Actors.BatchScriptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.BatchScriptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.CalculatorSetActor"></a>
 
 ## *class* \_optiSLang_Actors.CalculatorSetActor
 
-- <a id="optiSLang_Actors.CalculatorSetActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.CalculatorSetActor.add_internal_variable"></a>`add_internal_variable(location: DerivedLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.CalculatorSetActor.add_output"></a>`add_output(location: DerivedLocation)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- `add_output(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.CalculatorSetActor.add_response"></a>`add_response(location: DerivedLocation)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.CalculatorSetActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.CalculatorSetActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.CalculatorSetActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.CalculatorSetActor.unregister_from_internal_variables"></a>`unregister_from_internal_variables(arg2: str)`
+<a id="optiSLang_Actors.CalculatorSetActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.CalculatorSetActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: DerivedLocation)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.CalculatorSetActor.add_output"></a>
+
+#### add_output(location: DerivedLocation)
+
+#### add_output(derived_variable: DerivedLocation)
+
+#### add_output(arg2: str, arg3: str)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.CalculatorSetActor.add_response"></a>
+
+#### add_response(location: DerivedLocation)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(arg2: str, arg3: str)
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.CalculatorSetActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.CalculatorSetActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.CalculatorSetActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.CalculatorSetActor.unregister_from_internal_variables"></a>
+
+#### unregister_from_internal_variables(arg2: str)
 
 <a id="optiSLang_Actors.CatiaInputActor"></a>
 
 ## *class* \_optiSLang_Actors.CatiaInputActor
 
-- <a id="optiSLang_Actors.CatiaInputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.CatiaInputActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.CatiaInputActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
+<a id="optiSLang_Actors.CatiaInputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.CatiaInputActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.CatiaInputActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
 
 <a id="optiSLang_Actors.Continuation"></a>
 
@@ -246,9 +681,17 @@ Reliability actor using the Adaptive Sampling method.
 
 Integration actor continuation mode in case of predecessor failure
 
-- <a id="optiSLang_Actors.Continuation.CONTINUE"></a>`CONTINUE *= _optiSLang_Actors.Continuation.CONTINUE*`
-- <a id="optiSLang_Actors.Continuation.DEFAULT"></a>`DEFAULT *= _optiSLang_Actors.Continuation.DEFAULT*`
-- <a id="optiSLang_Actors.Continuation.SKIP"></a>`SKIP *= _optiSLang_Actors.Continuation.SKIP*`
+<a id="optiSLang_Actors.Continuation.CONTINUE"></a>
+
+#### CONTINUE *= \_optiSLang_Actors.Continuation.CONTINUE*
+
+<a id="optiSLang_Actors.Continuation.DEFAULT"></a>
+
+#### DEFAULT *= \_optiSLang_Actors.Continuation.DEFAULT*
+
+<a id="optiSLang_Actors.Continuation.SKIP"></a>
+
+#### SKIP *= \_optiSLang_Actors.Continuation.SKIP*
 
 <a id="optiSLang_Actors.CreateAlgorithmPluginActorTyped"></a>
 
@@ -272,153 +715,416 @@ Create instance of a plugin integration specified by plugin id.
 
 ## *class* \_optiSLang_Actors.CustomActor
 
-- <a id="optiSLang_Actors.CustomActor.__init__"></a>`__init__(custom_node_id: str) → object`<br>
-  Create a Custom Node by ID.
-- <a id="optiSLang_Actors.CustomActor.get_api_version"></a>`get_api_version() → int`<br>
-  The used API version.
-- <a id="optiSLang_Actors.CustomActor.get_default_settings"></a>`get_default_settings() → dict`<br>
-  The custom node’s user-defined default settings.
-- <a id="optiSLang_Actors.CustomActor.id"></a>*property* `id`<br>
-  The custom node’s ID as specified in the wrapper script filename.
-- <a id="optiSLang_Actors.CustomActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.CustomActor.modifying_settings"></a>*property* `modifying_settings`<br>
-  Settings that will affect the node’s run status when changed.
-- <a id="optiSLang_Actors.CustomActor.multi_design_launch_num"></a>*property* `multi_design_launch_num`
-- <a id="optiSLang_Actors.CustomActor.non_modifying_settings"></a>*property* `non_modifying_settings`<br>
-  Settings that will not affect the node’s run status when changed.
+<a id="optiSLang_Actors.CustomActor.__init__"></a>
+
+#### \_\_init_\_(custom_node_id: str) → object
+
+Create a Custom Node by ID.
+
+<a id="optiSLang_Actors.CustomActor.get_api_version"></a>
+
+#### get_api_version() → int
+
+The used API version.
+
+<a id="optiSLang_Actors.CustomActor.get_default_settings"></a>
+
+#### get_default_settings() → dict
+
+The custom node’s user-defined default settings.
+
+<a id="optiSLang_Actors.CustomActor.id"></a>
+
+#### *property* id
+
+The custom node’s ID as specified in the wrapper script filename.
+
+<a id="optiSLang_Actors.CustomActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.CustomActor.modifying_settings"></a>
+
+#### *property* modifying_settings
+
+Settings that will affect the node’s run status when changed.
+
+<a id="optiSLang_Actors.CustomActor.multi_design_launch_num"></a>
+
+#### *property* multi_design_launch_num
+
+<a id="optiSLang_Actors.CustomActor.non_modifying_settings"></a>
+
+#### *property* non_modifying_settings
+
+Settings that will not affect the node’s run status when changed.
 
 <a id="optiSLang_Actors.CustomAlgorithmActor"></a>
 
 ## *class* \_optiSLang_Actors.CustomAlgorithmActor
 
-- <a id="optiSLang_Actors.CustomAlgorithmActor.__init__"></a>`__init__(algorithm: str name) → object`<br>
-  Create a Custom Algorithm actor by name. The corresponding script must be located in CA path.
-- <a id="optiSLang_Actors.CustomAlgorithmActor.get_default_settings"></a>`get_default_settings() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="optiSLang_Actors.CustomAlgorithmActor.id"></a>*property* `id`<br>
-  The custom algorithm’s ID as specified in the wrapper script filename.
-- <a id="optiSLang_Actors.CustomAlgorithmActor.settings"></a>*property* `settings`
+<a id="optiSLang_Actors.CustomAlgorithmActor.__init__"></a>
+
+#### \_\_init_\_(algorithm: str name) → object
+
+Create a Custom Algorithm actor by name. The corresponding script must be located in CA path.
+
+<a id="optiSLang_Actors.CustomAlgorithmActor.get_default_settings"></a>
+
+#### get_default_settings() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="optiSLang_Actors.CustomAlgorithmActor.id"></a>
+
+#### *property* id
+
+The custom algorithm’s ID as specified in the wrapper script filename.
+
+<a id="optiSLang_Actors.CustomAlgorithmActor.settings"></a>
+
+#### *property* settings
 
 <a id="optiSLang_Actors.CustomIntegrationActor"></a>
 
 ## *class* \_optiSLang_Actors.CustomIntegrationActor
 
-- <a id="optiSLang_Actors.CustomIntegrationActor.__init__"></a>`__init__(integration: str name) → object`<br>
-  Create a Custom Python Integration actor by name. The script must be located in CI path.
-- <a id="optiSLang_Actors.CustomIntegrationActor.error_code"></a>*property* `error_code`
-- <a id="optiSLang_Actors.CustomIntegrationActor.get_api_version"></a>`get_api_version() → int`<br>
-  The used API version.
-- <a id="optiSLang_Actors.CustomIntegrationActor.get_default_settings"></a>`get_default_settings(arg2: bool) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="optiSLang_Actors.CustomIntegrationActor.id"></a>*property* `id`<br>
-  The custom integration’s ID as specified in the wrapper script filename.
-- <a id="optiSLang_Actors.CustomIntegrationActor.instant_variable_update"></a>*property* `instant_variable_update`
-- <a id="optiSLang_Actors.CustomIntegrationActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.CustomIntegrationActor.modifying_settings"></a>*property* `modifying_settings`<br>
-  Settings that will affect the node’s run status when changed.
-- <a id="optiSLang_Actors.CustomIntegrationActor.multi_design_launch_num"></a>*property* `multi_design_launch_num`
-- <a id="optiSLang_Actors.CustomIntegrationActor.non_modifying_settings"></a>*property* `non_modifying_settings`<br>
-  Settings that will not affect the node’s run status when changed.
-- <a id="optiSLang_Actors.CustomIntegrationActor.path"></a>*property* `path`
-- <a id="optiSLang_Actors.CustomIntegrationActor.settings"></a>*property* `settings`
+<a id="optiSLang_Actors.CustomIntegrationActor.__init__"></a>
+
+#### \_\_init_\_(integration: str name) → object
+
+Create a Custom Python Integration actor by name. The script must be located in CI path.
+
+<a id="optiSLang_Actors.CustomIntegrationActor.error_code"></a>
+
+#### *property* error_code
+
+<a id="optiSLang_Actors.CustomIntegrationActor.get_api_version"></a>
+
+#### get_api_version() → int
+
+The used API version.
+
+<a id="optiSLang_Actors.CustomIntegrationActor.get_default_settings"></a>
+
+#### get_default_settings(arg2: bool) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="optiSLang_Actors.CustomIntegrationActor.id"></a>
+
+#### *property* id
+
+The custom integration’s ID as specified in the wrapper script filename.
+
+<a id="optiSLang_Actors.CustomIntegrationActor.instant_variable_update"></a>
+
+#### *property* instant_variable_update
+
+<a id="optiSLang_Actors.CustomIntegrationActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.CustomIntegrationActor.modifying_settings"></a>
+
+#### *property* modifying_settings
+
+Settings that will affect the node’s run status when changed.
+
+<a id="optiSLang_Actors.CustomIntegrationActor.multi_design_launch_num"></a>
+
+#### *property* multi_design_launch_num
+
+<a id="optiSLang_Actors.CustomIntegrationActor.non_modifying_settings"></a>
+
+#### *property* non_modifying_settings
+
+Settings that will not affect the node’s run status when changed.
+
+<a id="optiSLang_Actors.CustomIntegrationActor.path"></a>
+
+#### *property* path
+
+<a id="optiSLang_Actors.CustomIntegrationActor.settings"></a>
+
+#### *property* settings
 
 <a id="optiSLang_Actors.CustomMopActor"></a>
 
 ## *class* \_optiSLang_Actors.CustomMopActor
 
-- <a id="optiSLang_Actors.CustomMopActor.__init__"></a>`__init__(custom_mop_node_id: str) → object`<br>
-  Create a Custom MOP Node by ID.
-- <a id="optiSLang_Actors.CustomMopActor.get_default_settings"></a>`get_default_settings() → dict`<br>
-  The custom MOP node’s user-defined default settings.
-- <a id="optiSLang_Actors.CustomMopActor.id"></a>*property* `id`<br>
-  The custom MOP node’s ID as specified in the wrapper script filename.
+<a id="optiSLang_Actors.CustomMopActor.__init__"></a>
+
+#### \_\_init_\_(custom_mop_node_id: str) → object
+
+Create a Custom MOP Node by ID.
+
+<a id="optiSLang_Actors.CustomMopActor.get_default_settings"></a>
+
+#### get_default_settings() → dict
+
+The custom MOP node’s user-defined default settings.
+
+<a id="optiSLang_Actors.CustomMopActor.id"></a>
+
+#### *property* id
+
+The custom MOP node’s ID as specified in the wrapper script filename.
 
 <a id="optiSLang_Actors.CustomizedBaseActor"></a>
 
 ## *class* \_optiSLang_Actors.CustomizedBaseActor
 
-- <a id="optiSLang_Actors.CustomizedBaseActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.CustomizedBaseActor.add_input"></a>`add_input(location: CustomizedBaseInfo)`<br>
-  [0] Assign location to an input slot. [1] Assign location to input slot.
-- `add_input(name: str and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))`
-- <a id="optiSLang_Actors.CustomizedBaseActor.add_internal_variable"></a>`add_internal_variable(location: CustomizedBaseInfo)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.CustomizedBaseActor.add_output"></a>`add_output(location: CustomizedBaseInfo)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot. [2] Assign location to output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- `add_output(name: str and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))`
-- <a id="optiSLang_Actors.CustomizedBaseActor.add_parameter"></a>`add_parameter(location: CustomizedBaseInfo)`<br>
-  [0] Assign location to a parameter. [1] Assign location to parameter.
-- `add_parameter(name: tuple and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))`
-- <a id="optiSLang_Actors.CustomizedBaseActor.add_response"></a>`add_response(location: CustomizedBaseInfo)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response. [2] Assign location to response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(name: tuple and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))`
-- <a id="optiSLang_Actors.CustomizedBaseActor.error_code"></a>*property* `error_code`
-- <a id="optiSLang_Actors.CustomizedBaseActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.CustomizedBaseActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.CustomizedBaseActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.CustomizedBaseActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.CustomizedBaseActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.CustomizedBaseActor.instant_variable_update"></a>*property* `instant_variable_update`
-- <a id="optiSLang_Actors.CustomizedBaseActor.path"></a>*property* `path`
-- <a id="optiSLang_Actors.CustomizedBaseActor.use_as_input_integration"></a>*property* `use_as_input_integration`
-- <a id="optiSLang_Actors.CustomizedBaseActor.use_as_output_integration"></a>*property* `use_as_output_integration`
-- <a id="optiSLang_Actors.CustomizedBaseActor.use_as_solver"></a>*property* `use_as_solver`
+<a id="optiSLang_Actors.CustomizedBaseActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.CustomizedBaseActor.add_input"></a>
+
+#### add_input(location: CustomizedBaseInfo)
+
+#### add_input(name: str and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))
+
+[0] Assign location to an input slot.
+
+[1] Assign location to input slot.
+
+<a id="optiSLang_Actors.CustomizedBaseActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: CustomizedBaseInfo)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.CustomizedBaseActor.add_output"></a>
+
+#### add_output(location: CustomizedBaseInfo)
+
+#### add_output(derived_variable: DerivedLocation)
+
+#### add_output(name: str and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+[2] Assign location to output slot.
+
+<a id="optiSLang_Actors.CustomizedBaseActor.add_parameter"></a>
+
+#### add_parameter(location: CustomizedBaseInfo)
+
+#### add_parameter(name: tuple and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))
+
+[0] Assign location to a parameter.
+
+[1] Assign location to parameter.
+
+<a id="optiSLang_Actors.CustomizedBaseActor.add_response"></a>
+
+#### add_response(location: CustomizedBaseInfo)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(name: tuple and PyOSDesignEntry, location: [CustomizedBaseInfo](#optiSLang_Actors.CustomizedBaseInfo))
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+[2] Assign location to response.
+
+<a id="optiSLang_Actors.CustomizedBaseActor.error_code"></a>
+
+#### *property* error_code
+
+<a id="optiSLang_Actors.CustomizedBaseActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.CustomizedBaseActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.CustomizedBaseActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.CustomizedBaseActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.CustomizedBaseActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.CustomizedBaseActor.instant_variable_update"></a>
+
+#### *property* instant_variable_update
+
+<a id="optiSLang_Actors.CustomizedBaseActor.path"></a>
+
+#### *property* path
+
+<a id="optiSLang_Actors.CustomizedBaseActor.use_as_input_integration"></a>
+
+#### *property* use_as_input_integration
+
+<a id="optiSLang_Actors.CustomizedBaseActor.use_as_output_integration"></a>
+
+#### *property* use_as_output_integration
+
+<a id="optiSLang_Actors.CustomizedBaseActor.use_as_solver"></a>
+
+#### *property* use_as_solver
 
 <a id="optiSLang_Actors.CustomizedBaseInfo"></a>
 
 ## *class* \_optiSLang_Actors.CustomizedBaseInfo
 
-- <a id="optiSLang_Actors.CustomizedBaseInfo.__init__"></a>`__init__()`<br>
-  [1] Create a CustomizedBaseInfo instance. [2] Create a CustomizedBaseInfo instance.
-- `__init__(location: str id, direction: IntegrationDirection)`
-- `__init__(complete: PyOSDesignPoint location info, direction: IntegrationDirection)`
-- <a id="optiSLang_Actors.CustomizedBaseInfo.direction"></a>*property* `direction`
-- <a id="optiSLang_Actors.CustomizedBaseInfo.name"></a>*property* `name`
+<a id="optiSLang_Actors.CustomizedBaseInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(location: str id, direction: IntegrationDirection)
+
+#### \_\_init_\_(complete: PyOSDesignPoint location info, direction: IntegrationDirection)
+
+[1] Create a CustomizedBaseInfo instance.
+
+[2] Create a CustomizedBaseInfo instance.
+
+<a id="optiSLang_Actors.CustomizedBaseInfo.direction"></a>
+
+#### *property* direction
+
+<a id="optiSLang_Actors.CustomizedBaseInfo.name"></a>
+
+#### *property* name
 
 <a id="optiSLang_Actors.DCSActor"></a>
 
 ## *class* \_optiSLang_Actors.DCSActor
 
-- <a id="optiSLang_Actors.DCSActor.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.DCSActor.add_input"></a>`add_input(location: DPSLocation)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.DCSActor.add_internal_variable"></a>`add_internal_variable(location: DPSLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.DCSActor.add_output"></a>`add_output(location: DPSLocation)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.DCSActor.add_parameter"></a>`add_parameter(location: DPSLocation)`<br>
-  [0] Assign location to a parameter.
-- `add_parameter(arg2: str) → str`
-- <a id="optiSLang_Actors.DCSActor.add_response"></a>`add_response(location: DPSLocation)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(arg2: str) → str`
-- <a id="optiSLang_Actors.DCSActor.configuration"></a>*property* `configuration`
-- <a id="optiSLang_Actors.DCSActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.DCSActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.DCSActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.DCSActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.DCSActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.DCSActor.login"></a>`login(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.DCSActor.max_submission_batch_size"></a>*property* `max_submission_batch_size`
-- <a id="optiSLang_Actors.DCSActor.output_files_to_fetch"></a>*property* `output_files_to_fetch`
-- <a id="optiSLang_Actors.DCSActor.project"></a>*property* `project`
-- <a id="optiSLang_Actors.DCSActor.refresh_token"></a>*property* `refresh_token`
-- <a id="optiSLang_Actors.DCSActor.url"></a>*property* `url`
+<a id="optiSLang_Actors.DCSActor.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.DCSActor.add_input"></a>
+
+#### add_input(location: DPSLocation)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.DCSActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: DPSLocation)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.DCSActor.add_output"></a>
+
+#### add_output(location: DPSLocation)
+
+#### add_output(derived_variable: DerivedLocation)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.DCSActor.add_parameter"></a>
+
+#### add_parameter(location: DPSLocation)
+
+#### add_parameter(arg2: str) → str
+
+[0] Assign location to a parameter.
+
+<a id="optiSLang_Actors.DCSActor.add_response"></a>
+
+#### add_response(location: DPSLocation)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(arg2: str) → str
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.DCSActor.configuration"></a>
+
+#### *property* configuration
+
+<a id="optiSLang_Actors.DCSActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.DCSActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.DCSActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.DCSActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.DCSActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.DCSActor.login"></a>
+
+#### login(arg2: str, arg3: str)
+
+<a id="optiSLang_Actors.DCSActor.max_submission_batch_size"></a>
+
+#### *property* max_submission_batch_size
+
+<a id="optiSLang_Actors.DCSActor.output_files_to_fetch"></a>
+
+#### *property* output_files_to_fetch
+
+<a id="optiSLang_Actors.DCSActor.project"></a>
+
+#### *property* project
+
+<a id="optiSLang_Actors.DCSActor.refresh_token"></a>
+
+#### *property* refresh_token
+
+<a id="optiSLang_Actors.DCSActor.url"></a>
+
+#### *property* url
 
 <a id="optiSLang_Actors.DPSActor"></a>
 
@@ -430,108 +1136,245 @@ alias of [`DCSActor`](#optiSLang_Actors.DCSActor)
 
 ## *class* \_optiSLang_Actors.DPSLocation
 
-- <a id="optiSLang_Actors.DPSLocation.__init__"></a>`__init__()`<br>
-  [1] Create a DPSLocation instance.
-- `__init__(location: str id, direction: IntegrationDirection)`
-- <a id="optiSLang_Actors.DPSLocation.direction"></a>*property* `direction`
-- <a id="optiSLang_Actors.DPSLocation.name"></a>*property* `name`
+<a id="optiSLang_Actors.DPSLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(location: str id, direction: IntegrationDirection)
+
+[1] Create a DPSLocation instance.
+
+<a id="optiSLang_Actors.DPSLocation.direction"></a>
+
+#### *property* direction
+
+<a id="optiSLang_Actors.DPSLocation.name"></a>
+
+#### *property* name
 
 <a id="optiSLang_Actors.DataExportActor"></a>
 
 ## *class* \_optiSLang_Actors.DataExportActor
 
-- <a id="optiSLang_Actors.DataExportActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DataExportActor.failure_treatment"></a>*property* `failure_treatment`
-- <a id="optiSLang_Actors.DataExportActor.path"></a>*property* `path`
+<a id="optiSLang_Actors.DataExportActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DataExportActor.failure_treatment"></a>
+
+#### *property* failure_treatment
+
+<a id="optiSLang_Actors.DataExportActor.path"></a>
+
+#### *property* path
 
 <a id="optiSLang_Actors.DataImportActor"></a>
 
 ## *class* \_optiSLang_Actors.DataImportActor
 
-- <a id="optiSLang_Actors.DataImportActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DataImportActor.failure_treatment"></a>*property* `failure_treatment`
-- <a id="optiSLang_Actors.DataImportActor.path"></a>*property* `path`
+<a id="optiSLang_Actors.DataImportActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DataImportActor.failure_treatment"></a>
+
+#### *property* failure_treatment
+
+<a id="optiSLang_Actors.DataImportActor.path"></a>
+
+#### *property* path
 
 <a id="optiSLang_Actors.DataMiningActor"></a>
 
 ## *class* \_optiSLang_Actors.DataMiningActor
 
-- <a id="optiSLang_Actors.DataMiningActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DataMiningActor.init_append_best_designs"></a>`init_append_best_designs()`<br>
-  Configure node with functionality to append best designs to an MDB file.
+<a id="optiSLang_Actors.DataMiningActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DataMiningActor.init_append_best_designs"></a>
+
+#### init_append_best_designs()
+
+Configure node with functionality to append best designs to an MDB file.
 
 <a id="optiSLang_Actors.DerivedLocation"></a>
 
 ## *class* \_optiSLang_Actors.DerivedLocation
 
-- <a id="optiSLang_Actors.DerivedLocation.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.DerivedLocation.expression"></a>*property* `expression`
-- <a id="optiSLang_Actors.DerivedLocation.location_id"></a>*property* `location_id`
+<a id="optiSLang_Actors.DerivedLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+<a id="optiSLang_Actors.DerivedLocation.expression"></a>
+
+#### *property* expression
+
+<a id="optiSLang_Actors.DerivedLocation.location_id"></a>
+
+#### *property* location_id
 
 <a id="optiSLang_Actors.DesignCounts"></a>
 
 ## *class* \_optiSLang_Actors.DesignCounts
 
-- <a id="optiSLang_Actors.DesignCounts.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.DesignCounts.get_estimated"></a>`get_estimated() → object`
-- <a id="optiSLang_Actors.DesignCounts.get_upper_bound"></a>`get_upper_bound() → object`
+<a id="optiSLang_Actors.DesignCounts.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.DesignCounts.get_estimated"></a>
+
+#### get_estimated() → object
+
+<a id="optiSLang_Actors.DesignCounts.get_upper_bound"></a>
+
+#### get_upper_bound() → object
 
 <a id="optiSLang_Actors.DesignExportActor"></a>
 
 ## *class* \_optiSLang_Actors.DesignExportActor
 
-- <a id="optiSLang_Actors.DesignExportActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DesignExportActor.csv_delimiter"></a>*property* `csv_delimiter`
-- <a id="optiSLang_Actors.DesignExportActor.design_exporter"></a>*property* `design_exporter`
-- <a id="optiSLang_Actors.DesignExportActor.export_format"></a>*property* `export_format`
-- <a id="optiSLang_Actors.DesignExportActor.json_legacy_mode"></a>*property* `json_legacy_mode`
-- <a id="optiSLang_Actors.DesignExportActor.json_prettified_mode"></a>*property* `json_prettified_mode`
-- <a id="optiSLang_Actors.DesignExportActor.json_signal_data"></a>*property* `json_signal_data`
-- <a id="optiSLang_Actors.DesignExportActor.mdb_path"></a>*property* `mdb_path`
-- <a id="optiSLang_Actors.DesignExportActor.out_path"></a>*property* `out_path`
+<a id="optiSLang_Actors.DesignExportActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DesignExportActor.csv_delimiter"></a>
+
+#### *property* csv_delimiter
+
+<a id="optiSLang_Actors.DesignExportActor.design_exporter"></a>
+
+#### *property* design_exporter
+
+<a id="optiSLang_Actors.DesignExportActor.export_format"></a>
+
+#### *property* export_format
+
+<a id="optiSLang_Actors.DesignExportActor.json_legacy_mode"></a>
+
+#### *property* json_legacy_mode
+
+<a id="optiSLang_Actors.DesignExportActor.json_prettified_mode"></a>
+
+#### *property* json_prettified_mode
+
+<a id="optiSLang_Actors.DesignExportActor.json_signal_data"></a>
+
+#### *property* json_signal_data
+
+<a id="optiSLang_Actors.DesignExportActor.mdb_path"></a>
+
+#### *property* mdb_path
+
+<a id="optiSLang_Actors.DesignExportActor.out_path"></a>
+
+#### *property* out_path
 
 <a id="optiSLang_Actors.DesignImportActor"></a>
 
 ## *class* \_optiSLang_Actors.DesignImportActor
 
-- <a id="optiSLang_Actors.DesignImportActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DesignImportActor.csv_delimiter"></a>*property* `csv_delimiter`
-- <a id="optiSLang_Actors.DesignImportActor.design_importer"></a>*property* `design_importer`
-- <a id="optiSLang_Actors.DesignImportActor.dimension_settings"></a>*property* `dimension_settings`
-- <a id="optiSLang_Actors.DesignImportActor.import_format"></a>*property* `import_format`
-- <a id="optiSLang_Actors.DesignImportActor.in_path"></a>*property* `in_path`
-- <a id="optiSLang_Actors.DesignImportActor.settings_file_path"></a>*property* `settings_file_path`
-- <a id="optiSLang_Actors.DesignImportActor.sheet_name"></a>*property* `sheet_name`
-- <a id="optiSLang_Actors.DesignImportActor.use_import_settings"></a>*property* `use_import_settings`
-- <a id="optiSLang_Actors.DesignImportActor.use_import_settings_file"></a>*property* `use_import_settings_file`
+<a id="optiSLang_Actors.DesignImportActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DesignImportActor.csv_delimiter"></a>
+
+#### *property* csv_delimiter
+
+<a id="optiSLang_Actors.DesignImportActor.design_importer"></a>
+
+#### *property* design_importer
+
+<a id="optiSLang_Actors.DesignImportActor.dimension_settings"></a>
+
+#### *property* dimension_settings
+
+<a id="optiSLang_Actors.DesignImportActor.import_format"></a>
+
+#### *property* import_format
+
+<a id="optiSLang_Actors.DesignImportActor.in_path"></a>
+
+#### *property* in_path
+
+<a id="optiSLang_Actors.DesignImportActor.settings_file_path"></a>
+
+#### *property* settings_file_path
+
+<a id="optiSLang_Actors.DesignImportActor.sheet_name"></a>
+
+#### *property* sheet_name
+
+<a id="optiSLang_Actors.DesignImportActor.use_import_settings"></a>
+
+#### *property* use_import_settings
+
+<a id="optiSLang_Actors.DesignImportActor.use_import_settings_file"></a>
+
+#### *property* use_import_settings_file
 
 <a id="optiSLang_Actors.DesignImportDimensionEntry"></a>
 
 ## *class* \_optiSLang_Actors.DesignImportDimensionEntry
 
-- <a id="optiSLang_Actors.DesignImportDimensionEntry.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.DesignImportDimensionEntry.column"></a>*property* `column`<br>
-  Column in data set.
-- <a id="optiSLang_Actors.DesignImportDimensionEntry.name"></a>*property* `name`<br>
-  Name ot the imported dimension.
-- <a id="optiSLang_Actors.DesignImportDimensionEntry.type"></a>*property* `type`<br>
-  Type of the imported dimension.
+<a id="optiSLang_Actors.DesignImportDimensionEntry.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.DesignImportDimensionEntry.column"></a>
+
+#### *property* column
+
+Column in data set.
+
+<a id="optiSLang_Actors.DesignImportDimensionEntry.name"></a>
+
+#### *property* name
+
+Name ot the imported dimension.
+
+<a id="optiSLang_Actors.DesignImportDimensionEntry.type"></a>
+
+#### *property* type
+
+Type of the imported dimension.
 
 <a id="optiSLang_Actors.DesignImportDimensionsVector"></a>
 
 ## *class* \_optiSLang_Actors.DesignImportDimensionsVector
 
-- <a id="optiSLang_Actors.DesignImportDimensionsVector.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.DesignImportDimensionsVector.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.DesignImportDimensionsVector.entry_export_list"></a>`entry_export_list() → object`
-- <a id="optiSLang_Actors.DesignImportDimensionsVector.push_back"></a>`push_back(arg2: [DesignImportDimensionEntry](#optiSLang_Actors.DesignImportDimensionEntry))`
-- <a id="optiSLang_Actors.DesignImportDimensionsVector.size"></a>`size() → int`
+<a id="optiSLang_Actors.DesignImportDimensionsVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.DesignImportDimensionsVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.DesignImportDimensionsVector.entry_export_list"></a>
+
+#### entry_export_list() → object
+
+<a id="optiSLang_Actors.DesignImportDimensionsVector.push_back"></a>
+
+#### push_back(arg2: [DesignImportDimensionEntry](#optiSLang_Actors.DesignImportDimensionEntry))
+
+<a id="optiSLang_Actors.DesignImportDimensionsVector.size"></a>
+
+#### size() → int
 
 <a id="optiSLang_Actors.DirectionalSamplingActor"></a>
 
@@ -539,792 +1382,2423 @@ alias of [`DCSActor`](#optiSLang_Actors.DCSActor)
 
 Reliability actor using Directional Sampling.
 
-- <a id="optiSLang_Actors.DirectionalSamplingActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.DirectionalSamplingActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.DirectionalSamplingActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.DirectionalSamplingActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.DistinctWorkingDirActor"></a>
 
 ## *class* \_optiSLang_Actors.DistinctWorkingDirActor
 
-- <a id="optiSLang_Actors.DistinctWorkingDirActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.DistinctWorkingDirActor.distinct_working_directory"></a>*property* `distinct_working_directory`
+<a id="optiSLang_Actors.DistinctWorkingDirActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.DistinctWorkingDirActor.distinct_working_directory"></a>
+
+#### *property* distinct_working_directory
 
 <a id="optiSLang_Actors.EAActor"></a>
 
 ## *class* \_optiSLang_Actors.EAActor
 
-- <a id="optiSLang_Actors.EAActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.EAActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ETK"></a>
 
 ## *class* \_optiSLang_Actors.ETK
 
-- <a id="optiSLang_Actors.ETK.AMESimOutputVariable"></a>`*class* AMESimOutputVariable`
-- <a id="optiSLang_Actors.ETK.AMESimOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable"></a>`*class* AdamsOutputVariable`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.__init__"></a>`__init__()`
-- `__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.component"></a>*property* `component`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.component_index"></a>*property* `component_index`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.data"></a>*property* `data`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.entity"></a>*property* `entity`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.entity_type"></a>*property* `entity_type`
-- <a id="optiSLang_Actors.ETK.AdamsOutputVariable.step"></a>*property* `step`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable"></a>`*class* AnsysOutputVariable`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.__init__"></a>`__init__()`
-- `__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.extraction_type"></a>*property* `extraction_type`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.kind"></a>*property* `kind`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.node_channel"></a>*property* `node_channel`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.node_number"></a>*property* `node_number`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.number"></a>*property* `number`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.range"></a>*property* `range`
-- <a id="optiSLang_Actors.ETK.AnsysOutputVariable.type"></a>*property* `type`
-- <a id="optiSLang_Actors.ETK.AutoParamOutputVariable"></a>`*class* AutoParamOutputVariable`
-- <a id="optiSLang_Actors.ETK.AutoParamOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.CFturboOutputVariable"></a>`*class* CFturboOutputVariable`
-- <a id="optiSLang_Actors.ETK.CFturboOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.CetolOutputVariable"></a>`*class* CetolOutputVariable`
-- <a id="optiSLang_Actors.ETK.CetolOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.ColumnReader"></a>`*class* ColumnReader`
-- <a id="optiSLang_Actors.ETK.ColumnReader.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- <a id="optiSLang_Actors.ETK.ColumnReader.initial_offset"></a>*property* `initial_offset`
-- <a id="optiSLang_Actors.ETK.ColumnReader.width"></a>*property* `width`
-- <a id="optiSLang_Actors.ETK.CustomizedOutputVariable"></a>`*class* CustomizedOutputVariable`
-- <a id="optiSLang_Actors.ETK.CustomizedOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.CustomizedOutputVariable.set_custom_id"></a>`set_custom_id(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor"></a>`*class* ETKAbaqusActor`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable"></a>`*class* ODBFieldOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.component_name"></a>*property* `component_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.element_types"></a>*property* `element_types`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.field_output_name"></a>*property* `field_output_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.frame"></a>*property* `frame`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.has_invariant"></a>`has_invariant() → bool`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.invariant"></a>*property* `invariant`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.position"></a>*property* `position`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.reset_invariant"></a>`reset_invariant()`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.section_point_name"></a>*property* `section_point_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.section_points"></a>*property* `section_points`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.set_infos"></a>*property* `set_infos`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.set_type"></a>*property* `set_type`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.use_last_frame"></a>*property* `use_last_frame`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable"></a>`*class* ODBHistoryOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_description"></a>*property* `history_output_description`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_name"></a>*property* `history_output_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.point_position"></a>*property* `point_position`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.region_name"></a>*property* `region_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.tip_set_info"></a>*property* `tip_set_info`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.tipset_bound"></a>*property* `tipset_bound`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfo"></a>`*class* ODBSectionPointInfo`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfo.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: str)`
-- `__init__(arg2: int, arg3: str, arg4: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet"></a>`*class* ODBSectionPointInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__and__"></a>`__and__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__contains__"></a>`__contains__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__or__"></a>`__or__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__sub__"></a>`__sub__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__xor__"></a>`__xor__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.add"></a>`add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.difference"></a>`difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.intersection"></a>`intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.remove"></a>`remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.union"></a>`union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfo"></a>`*class* ODBSetInfo`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfo.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet"></a>`*class* ODBSetInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__and__"></a>`__and__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__contains__"></a>`__contains__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__or__"></a>`__or__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__sub__"></a>`__sub__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__xor__"></a>`__xor__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.add"></a>`add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.difference"></a>`difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.intersection"></a>`intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.remove"></a>`remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.union"></a>`union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKAbaqusActor.free_cached_resources"></a>`free_cached_resources()`
-- <a id="optiSLang_Actors.ETK.ETKActor"></a>`*class* ETKActor`
-- <a id="optiSLang_Actors.ETK.ETKActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKActor.imported_files"></a>*property* `imported_files`
-- <a id="optiSLang_Actors.ETK.ETKActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.ETK.ETKActorBase"></a>`*class* ETKActorBase`
-- <a id="optiSLang_Actors.ETK.ETKActorBase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.ETKActorBase.add_internal_variable"></a>`add_internal_variable(location: ETKLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- `add_internal_variable(arg2: [Variable](#optiSLang_Actors.ETK.Variable))`
-- <a id="optiSLang_Actors.ETK.ETKActorBase.add_output"></a>`add_output(location: ETKLocation)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- `add_output(arg2: Variable)`
-- <a id="optiSLang_Actors.ETK.ETKActorBase.add_response"></a>`add_response(location: ETKLocation)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(arg2: Variable)`
-- `add_response(arg2: str, arg3: PyOSDesignEntry, arg4: DerivedLocation) → str`
-- `add_response(arg2: str, arg3: PyOSDesignEntry, arg4: Variable) → str`
-- <a id="optiSLang_Actors.ETK.ETKActorBase.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.ETK.ETKActorBase.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.ETK.ETKActorBase.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.ETK.ETKActorBase.register_as_internal_location"></a>`register_as_internal_location(location: ETKLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `register_as_internal_location(derived_variable: DerivedLocation)`
-- `register_as_internal_location(arg2: [Variable](#optiSLang_Actors.ETK.Variable))`
-- <a id="optiSLang_Actors.ETK.ETKActorSingle"></a>`*class* ETKActorSingle`
-- <a id="optiSLang_Actors.ETK.ETKActorSingle.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.ETKActorSingle.file"></a>*property* `file`
-- <a id="optiSLang_Actors.ETK.ETKActorSingle.path"></a>*property* `path`
-- <a id="optiSLang_Actors.ETK.ETKActorSingle.splitted_path"></a>*property* `splitted_path`
-- <a id="optiSLang_Actors.ETK.ETKFile"></a>`*class* ETKFile`
-- <a id="optiSLang_Actors.ETK.ETKFile.__init__"></a>`__init__()`
-- `__init__(arg2: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath), arg3: str)`
-- <a id="optiSLang_Actors.ETK.ETKFile.path"></a>*property* `path`
-- <a id="optiSLang_Actors.ETK.ETKFile.type"></a>*property* `type`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer"></a>`*class* ETKFileContainer`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.append"></a>`append(arg2: object)`
-- `append(arg2: [ETKFile](#optiSLang_Actors.ETK.ETKFile))`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.extend"></a>`extend(arg2: object)`
-- <a id="optiSLang_Actors.ETK.ETKFileContainer.size"></a>`size() → int`
-- <a id="optiSLang_Actors.ETK.ETKFloEFDActor"></a>`*class* ETKFloEFDActor`
-- <a id="optiSLang_Actors.ETK.ETKFloEFDActor.FloEFDOutputVariable"></a>`*class* FloEFDOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKFloEFDActor.FloEFDOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.ETKFloEFDActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKLocation"></a>`*class* ETKLocation`
-- <a id="optiSLang_Actors.ETK.ETKLocation.__init__"></a>`__init__()`
-- `__init__(arg2: [Variable](#optiSLang_Actors.ETK.Variable))`
-- `__init__(arg2: [Variable](#optiSLang_Actors.ETK.Variable), arg3: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath))`
-- <a id="optiSLang_Actors.ETK.ETKLocation.etk_variable"></a>*property* `etk_variable`
-- <a id="optiSLang_Actors.ETK.ETKLocation.file_path"></a>*property* `file_path`
-- <a id="optiSLang_Actors.ETK.ETKSimPackActor"></a>`*class* ETKSimPackActor`
-- <a id="optiSLang_Actors.ETK.ETKSimPackActor.SimPackOutputVariable"></a>`*class* SimPackOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKSimPackActor.SimPackOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.ETKSimPackActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor"></a>`*class* ETKTextOutputActor`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader"></a>`*class* ColumnReader`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.initial_offset"></a>*property* `initial_offset`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.width"></a>*property* `width`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater"></a>`*class* IncrementRepeater`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- `__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.increment"></a>*property* `increment`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.max_increment"></a>*property* `max_increment`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.offset"></a>*property* `offset`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.LineReader"></a>`*class* LineReader`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.LineReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.MarkerRepeater"></a>`*class* MarkerRepeater`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.MarkerRepeater.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher"></a>`*class* RegexSearcher`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.end_search_string"></a>*property* `end_search_string`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.end_search_string_is_regex"></a>*property* `end_search_string_is_regex`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.search_string"></a>*property* `search_string`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.search_string_is_regex"></a>*property* `search_string_is_regex`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RepeaterArgs"></a>`*class* RepeaterArgs`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.RepeaterArgs.__init__"></a>`__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker"></a>`*class* TextMarker`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.append"></a>`append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.get_child"></a>`get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.get_row_reader"></a>`get_row_reader() → bool`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.has_child"></a>`has_child() → bool`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.has_repeater"></a>`has_repeater() → bool`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.is_row_reader"></a>`is_row_reader() → bool`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.repeater"></a>*property* `repeater`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable"></a>`*class* TextOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.__init__"></a>`__init__()`<br>
-  [7] Creates TextOutputVariable using token reader. [8] Creates TextOutputVariable using token reader. [9] Creates TextOutputVariable using column reader. [10] Creates TextOutputVariable using column reader.
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.prefer_signal"></a>*property* `prefer_signal`<br>
-  Prefer as signal.
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.reader"></a>*property* `reader`<br>
-  Contains the variable’s reader.
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader"></a>`*class* TokenReader`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader.separator"></a>*property* `separator`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.ETKTextOutputActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.ETK.ETKTurboOptActor"></a>`*class* ETKTurboOptActor`
-- <a id="optiSLang_Actors.ETK.ETKTurboOptActor.TurboOptOutputVariable"></a>`*class* TurboOptOutputVariable`
-- <a id="optiSLang_Actors.ETK.ETKTurboOptActor.TurboOptOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.ETKTurboOptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.EdysonOutputVariable"></a>`*class* EdysonOutputVariable`
-- <a id="optiSLang_Actors.ETK.EdysonOutputVariable.__init__"></a>`__init__()`
-- `__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="optiSLang_Actors.ETK.EdysonOutputVariable.get_available_components"></a>`get_available_components() → [stringVec](stdcpp_python_export.md#stdcpp_python_export.stringVec)`
-- <a id="optiSLang_Actors.ETK.EdysonOutputVariable.selected_components"></a>*property* `selected_components`
-- <a id="optiSLang_Actors.ETK.ExtOutOutputVariable"></a>`*class* ExtOutOutputVariable`
-- <a id="optiSLang_Actors.ETK.ExtOutOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.FileLocation"></a>`*class* FileLocation`
-- <a id="optiSLang_Actors.ETK.FileLocation.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.FileVariable"></a>`*class* FileVariable`
-- <a id="optiSLang_Actors.ETK.FileVariable.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.FloEFDOutputVariable"></a>`*class* FloEFDOutputVariable`
-- <a id="optiSLang_Actors.ETK.FloEFDOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.IncrementRepeater"></a>`*class* IncrementRepeater`
-- <a id="optiSLang_Actors.ETK.IncrementRepeater.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- `__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETK.IncrementRepeater.increment"></a>*property* `increment`
-- <a id="optiSLang_Actors.ETK.IncrementRepeater.max_increment"></a>*property* `max_increment`
-- <a id="optiSLang_Actors.ETK.IncrementRepeater.offset"></a>*property* `offset`
-- <a id="optiSLang_Actors.ETK.LSDYNAOutputVariable"></a>`*class* LSDYNAOutputVariable`
-- <a id="optiSLang_Actors.ETK.LSDYNAOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.LineReader"></a>`*class* LineReader`
-- <a id="optiSLang_Actors.ETK.LineReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.MarkerRepeater"></a>`*class* MarkerRepeater`
-- <a id="optiSLang_Actors.ETK.MarkerRepeater.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable"></a>`*class* ODBFieldOutputVariable`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.component_name"></a>*property* `component_name`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.element_types"></a>*property* `element_types`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.field_output_name"></a>*property* `field_output_name`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.frame"></a>*property* `frame`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.has_invariant"></a>`has_invariant() → bool`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.invariant"></a>*property* `invariant`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.position"></a>*property* `position`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.reset_invariant"></a>`reset_invariant()`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.section_point_name"></a>*property* `section_point_name`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.section_points"></a>*property* `section_points`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.set_infos"></a>*property* `set_infos`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.set_type"></a>*property* `set_type`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.use_last_frame"></a>*property* `use_last_frame`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable"></a>`*class* ODBHistoryOutputVariable`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.history_output_description"></a>*property* `history_output_description`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.history_output_name"></a>*property* `history_output_name`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.point_position"></a>*property* `point_position`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.region_name"></a>*property* `region_name`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.tip_set_info"></a>*property* `tip_set_info`
-- <a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.tipset_bound"></a>*property* `tipset_bound`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfo"></a>`*class* ODBSectionPointInfo`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfo.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: str)`
-- `__init__(arg2: int, arg3: str, arg4: str)`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet"></a>`*class* ODBSectionPointInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__and__"></a>`__and__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__contains__"></a>`__contains__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__or__"></a>`__or__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__sub__"></a>`__sub__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__xor__"></a>`__xor__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.add"></a>`add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.difference"></a>`difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.intersection"></a>`intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.remove"></a>`remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.union"></a>`union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfo"></a>`*class* ODBSetInfo`
-- <a id="optiSLang_Actors.ETK.ODBSetInfo.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet"></a>`*class* ODBSetInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__and__"></a>`__and__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__contains__"></a>`__contains__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__or__"></a>`__or__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__sub__"></a>`__sub__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.__xor__"></a>`__xor__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.add"></a>`add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.difference"></a>`difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.intersection"></a>`intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.remove"></a>`remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETK.ODBSetInfoSet.union"></a>`union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETK.PythonBasedOutputVariable"></a>`*class* PythonBasedOutputVariable`
-- <a id="optiSLang_Actors.ETK.PythonBasedOutputVariable.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.PythonBasedOutputVariable.id_list"></a>*property* `id_list`
-- <a id="optiSLang_Actors.ETK.RegexSearcher"></a>`*class* RegexSearcher`
-- <a id="optiSLang_Actors.ETK.RegexSearcher.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETK.RegexSearcher.end_search_string"></a>*property* `end_search_string`
-- <a id="optiSLang_Actors.ETK.RegexSearcher.end_search_string_is_regex"></a>*property* `end_search_string_is_regex`
-- <a id="optiSLang_Actors.ETK.RegexSearcher.search_string"></a>*property* `search_string`
-- <a id="optiSLang_Actors.ETK.RegexSearcher.search_string_is_regex"></a>*property* `search_string_is_regex`
-- <a id="optiSLang_Actors.ETK.RepeaterArgs"></a>`*class* RepeaterArgs`
-- <a id="optiSLang_Actors.ETK.RepeaterArgs.__init__"></a>`__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETK.SimPackOutputVariable"></a>`*class* SimPackOutputVariable`
-- <a id="optiSLang_Actors.ETK.SimPackOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.TextMarker"></a>`*class* TextMarker`
-- <a id="optiSLang_Actors.ETK.TextMarker.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.TextMarker.append"></a>`append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))`
-- <a id="optiSLang_Actors.ETK.TextMarker.get_child"></a>`get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)`
-- <a id="optiSLang_Actors.ETK.TextMarker.get_row_reader"></a>`get_row_reader() → bool`
-- <a id="optiSLang_Actors.ETK.TextMarker.has_child"></a>`has_child() → bool`
-- <a id="optiSLang_Actors.ETK.TextMarker.has_repeater"></a>`has_repeater() → bool`
-- <a id="optiSLang_Actors.ETK.TextMarker.is_row_reader"></a>`is_row_reader() → bool`
-- <a id="optiSLang_Actors.ETK.TextMarker.repeater"></a>*property* `repeater`
-- <a id="optiSLang_Actors.ETK.TextOutputVariable"></a>`*class* TextOutputVariable`
-- <a id="optiSLang_Actors.ETK.TextOutputVariable.__init__"></a>`__init__()`<br>
-  [7] Creates TextOutputVariable using token reader. [8] Creates TextOutputVariable using token reader. [9] Creates TextOutputVariable using column reader. [10] Creates TextOutputVariable using column reader.
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- <a id="optiSLang_Actors.ETK.TextOutputVariable.prefer_signal"></a>*property* `prefer_signal`<br>
-  Prefer as signal.
-- <a id="optiSLang_Actors.ETK.TextOutputVariable.reader"></a>*property* `reader`<br>
-  Contains the variable’s reader.
-- <a id="optiSLang_Actors.ETK.TokenReader"></a>`*class* TokenReader`
-- <a id="optiSLang_Actors.ETK.TokenReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETK.TokenReader.separator"></a>*property* `separator`
-- <a id="optiSLang_Actors.ETK.TurboOptOutputVariable"></a>`*class* TurboOptOutputVariable`
-- <a id="optiSLang_Actors.ETK.TurboOptOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETK.Variable"></a>`*class* Variable`
-- <a id="optiSLang_Actors.ETK.Variable.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETK.Variable.ident"></a>*property* `ident`
-- <a id="optiSLang_Actors.ETK.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="optiSLang_Actors.ETK.AMESimOutputVariable"></a>
+
+#### *class* AMESimOutputVariable
+
+<a id="optiSLang_Actors.ETK.AMESimOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable"></a>
+
+#### *class* AdamsOutputVariable
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.component"></a>
+
+#### *property* component
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.component_index"></a>
+
+#### *property* component_index
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.data"></a>
+
+#### *property* data
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.entity"></a>
+
+#### *property* entity
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.entity_type"></a>
+
+#### *property* entity_type
+
+<a id="optiSLang_Actors.ETK.AdamsOutputVariable.step"></a>
+
+#### *property* step
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable"></a>
+
+#### *class* AnsysOutputVariable
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.extraction_type"></a>
+
+#### *property* extraction_type
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.kind"></a>
+
+#### *property* kind
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.node_channel"></a>
+
+#### *property* node_channel
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.node_number"></a>
+
+#### *property* node_number
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.number"></a>
+
+#### *property* number
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.range"></a>
+
+#### *property* range
+
+<a id="optiSLang_Actors.ETK.AnsysOutputVariable.type"></a>
+
+#### *property* type
+
+<a id="optiSLang_Actors.ETK.AutoParamOutputVariable"></a>
+
+#### *class* AutoParamOutputVariable
+
+<a id="optiSLang_Actors.ETK.AutoParamOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.CFturboOutputVariable"></a>
+
+#### *class* CFturboOutputVariable
+
+<a id="optiSLang_Actors.ETK.CFturboOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.CetolOutputVariable"></a>
+
+#### *class* CetolOutputVariable
+
+<a id="optiSLang_Actors.ETK.CetolOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.ColumnReader"></a>
+
+#### *class* ColumnReader
+
+<a id="optiSLang_Actors.ETK.ColumnReader.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="optiSLang_Actors.ETK.ColumnReader.initial_offset"></a>
+
+#### *property* initial_offset
+
+<a id="optiSLang_Actors.ETK.ColumnReader.width"></a>
+
+#### *property* width
+
+<a id="optiSLang_Actors.ETK.CustomizedOutputVariable"></a>
+
+#### *class* CustomizedOutputVariable
+
+<a id="optiSLang_Actors.ETK.CustomizedOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.CustomizedOutputVariable.set_custom_id"></a>
+
+#### set_custom_id(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor"></a>
+
+#### *class* ETKAbaqusActor
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable"></a>
+
+#### *class* ODBFieldOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.component_name"></a>
+
+#### *property* component_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.element_types"></a>
+
+#### *property* element_types
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.field_output_name"></a>
+
+#### *property* field_output_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.frame"></a>
+
+#### *property* frame
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.has_invariant"></a>
+
+#### has_invariant() → bool
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.invariant"></a>
+
+#### *property* invariant
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.position"></a>
+
+#### *property* position
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.reset_invariant"></a>
+
+#### reset_invariant()
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.section_point_name"></a>
+
+#### *property* section_point_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.section_points"></a>
+
+#### *property* section_points
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.set_infos"></a>
+
+#### *property* set_infos
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.set_type"></a>
+
+#### *property* set_type
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBFieldOutputVariable.use_last_frame"></a>
+
+#### *property* use_last_frame
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable"></a>
+
+#### *class* ODBHistoryOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_description"></a>
+
+#### *property* history_output_description
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_name"></a>
+
+#### *property* history_output_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.point_position"></a>
+
+#### *property* point_position
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.region_name"></a>
+
+#### *property* region_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.tip_set_info"></a>
+
+#### *property* tip_set_info
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBHistoryOutputVariable.tipset_bound"></a>
+
+#### *property* tipset_bound
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfo"></a>
+
+#### *class* ODBSectionPointInfo
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: str)
+
+#### \_\_init_\_(arg2: int, arg3: str, arg4: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet"></a>
+
+#### *class* ODBSectionPointInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.add"></a>
+
+#### add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.difference"></a>
+
+#### difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.remove"></a>
+
+#### remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSectionPointInfoSet.union"></a>
+
+#### union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfo"></a>
+
+#### *class* ODBSetInfo
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet"></a>
+
+#### *class* ODBSetInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.add"></a>
+
+#### add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.difference"></a>
+
+#### difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.remove"></a>
+
+#### remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.ODBSetInfoSet.union"></a>
+
+#### union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKAbaqusActor.free_cached_resources"></a>
+
+#### free_cached_resources()
+
+<a id="optiSLang_Actors.ETK.ETKActor"></a>
+
+#### *class* ETKActor
+
+<a id="optiSLang_Actors.ETK.ETKActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKActor.imported_files"></a>
+
+#### *property* imported_files
+
+<a id="optiSLang_Actors.ETK.ETKActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.ETK.ETKActorBase"></a>
+
+#### *class* ETKActorBase
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.add_internal_variable"></a>
+
+#### add_internal_variable(location: ETKLocation)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+#### add_internal_variable(arg2: [Variable](#optiSLang_Actors.ETK.Variable))
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.add_output"></a>
+
+#### add_output(location: ETKLocation)
+
+#### add_output(derived_variable: DerivedLocation)
+
+#### add_output(arg2: Variable)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.add_response"></a>
+
+#### add_response(location: ETKLocation)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(arg2: Variable)
+
+#### add_response(arg2: str, arg3: PyOSDesignEntry, arg4: DerivedLocation) → str
+
+#### add_response(arg2: str, arg3: PyOSDesignEntry, arg4: Variable) → str
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.ETK.ETKActorBase.register_as_internal_location"></a>
+
+#### register_as_internal_location(location: ETKLocation)
+
+#### register_as_internal_location(derived_variable: DerivedLocation)
+
+#### register_as_internal_location(arg2: [Variable](#optiSLang_Actors.ETK.Variable))
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.ETK.ETKActorSingle"></a>
+
+#### *class* ETKActorSingle
+
+<a id="optiSLang_Actors.ETK.ETKActorSingle.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.ETKActorSingle.file"></a>
+
+#### *property* file
+
+<a id="optiSLang_Actors.ETK.ETKActorSingle.path"></a>
+
+#### *property* path
+
+<a id="optiSLang_Actors.ETK.ETKActorSingle.splitted_path"></a>
+
+#### *property* splitted_path
+
+<a id="optiSLang_Actors.ETK.ETKFile"></a>
+
+#### *class* ETKFile
+
+<a id="optiSLang_Actors.ETK.ETKFile.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath), arg3: str)
+
+<a id="optiSLang_Actors.ETK.ETKFile.path"></a>
+
+#### *property* path
+
+<a id="optiSLang_Actors.ETK.ETKFile.type"></a>
+
+#### *property* type
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer"></a>
+
+#### *class* ETKFileContainer
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.append"></a>
+
+#### append(arg2: object)
+
+#### append(arg2: [ETKFile](#optiSLang_Actors.ETK.ETKFile))
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="optiSLang_Actors.ETK.ETKFileContainer.size"></a>
+
+#### size() → int
+
+<a id="optiSLang_Actors.ETK.ETKFloEFDActor"></a>
+
+#### *class* ETKFloEFDActor
+
+<a id="optiSLang_Actors.ETK.ETKFloEFDActor.FloEFDOutputVariable"></a>
+
+#### *class* FloEFDOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKFloEFDActor.FloEFDOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.ETKFloEFDActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKLocation"></a>
+
+#### *class* ETKLocation
+
+<a id="optiSLang_Actors.ETK.ETKLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Variable](#optiSLang_Actors.ETK.Variable))
+
+#### \_\_init_\_(arg2: [Variable](#optiSLang_Actors.ETK.Variable), arg3: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath))
+
+<a id="optiSLang_Actors.ETK.ETKLocation.etk_variable"></a>
+
+#### *property* etk_variable
+
+<a id="optiSLang_Actors.ETK.ETKLocation.file_path"></a>
+
+#### *property* file_path
+
+<a id="optiSLang_Actors.ETK.ETKSimPackActor"></a>
+
+#### *class* ETKSimPackActor
+
+<a id="optiSLang_Actors.ETK.ETKSimPackActor.SimPackOutputVariable"></a>
+
+#### *class* SimPackOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKSimPackActor.SimPackOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.ETKSimPackActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor"></a>
+
+#### *class* ETKTextOutputActor
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader"></a>
+
+#### *class* ColumnReader
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.initial_offset"></a>
+
+#### *property* initial_offset
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.ColumnReader.width"></a>
+
+#### *property* width
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater"></a>
+
+#### *class* IncrementRepeater
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.increment"></a>
+
+#### *property* increment
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.max_increment"></a>
+
+#### *property* max_increment
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.IncrementRepeater.offset"></a>
+
+#### *property* offset
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.LineReader"></a>
+
+#### *class* LineReader
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.LineReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.MarkerRepeater"></a>
+
+#### *class* MarkerRepeater
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.MarkerRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher"></a>
+
+#### *class* RegexSearcher
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.end_search_string"></a>
+
+#### *property* end_search_string
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.end_search_string_is_regex"></a>
+
+#### *property* end_search_string_is_regex
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.search_string"></a>
+
+#### *property* search_string
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RegexSearcher.search_string_is_regex"></a>
+
+#### *property* search_string_is_regex
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RepeaterArgs"></a>
+
+#### *class* RepeaterArgs
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.RepeaterArgs.__init__"></a>
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker"></a>
+
+#### *class* TextMarker
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.append"></a>
+
+#### append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.get_child"></a>
+
+#### get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.get_row_reader"></a>
+
+#### get_row_reader() → bool
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.has_child"></a>
+
+#### has_child() → bool
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.has_repeater"></a>
+
+#### has_repeater() → bool
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.is_row_reader"></a>
+
+#### is_row_reader() → bool
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextMarker.repeater"></a>
+
+#### *property* repeater
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable"></a>
+
+#### *class* TextOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+[7] Creates TextOutputVariable using token reader.
+
+[8] Creates TextOutputVariable using token reader.
+
+[9] Creates TextOutputVariable using column reader.
+
+[10] Creates TextOutputVariable using column reader.
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.prefer_signal"></a>
+
+#### *property* prefer_signal
+
+Prefer as signal.
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TextOutputVariable.reader"></a>
+
+#### *property* reader
+
+Contains the variable’s reader.
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader"></a>
+
+#### *class* TokenReader
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.TokenReader.separator"></a>
+
+#### *property* separator
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.ETKTextOutputActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.ETK.ETKTurboOptActor"></a>
+
+#### *class* ETKTurboOptActor
+
+<a id="optiSLang_Actors.ETK.ETKTurboOptActor.TurboOptOutputVariable"></a>
+
+#### *class* TurboOptOutputVariable
+
+<a id="optiSLang_Actors.ETK.ETKTurboOptActor.TurboOptOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.ETKTurboOptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.EdysonOutputVariable"></a>
+
+#### *class* EdysonOutputVariable
+
+<a id="optiSLang_Actors.ETK.EdysonOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="optiSLang_Actors.ETK.EdysonOutputVariable.get_available_components"></a>
+
+#### get_available_components() → [stringVec](stdcpp_python_export.md#stdcpp_python_export.stringVec)
+
+<a id="optiSLang_Actors.ETK.EdysonOutputVariable.selected_components"></a>
+
+#### *property* selected_components
+
+<a id="optiSLang_Actors.ETK.ExtOutOutputVariable"></a>
+
+#### *class* ExtOutOutputVariable
+
+<a id="optiSLang_Actors.ETK.ExtOutOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.FileLocation"></a>
+
+#### *class* FileLocation
+
+<a id="optiSLang_Actors.ETK.FileLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.FileVariable"></a>
+
+#### *class* FileVariable
+
+<a id="optiSLang_Actors.ETK.FileVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.FloEFDOutputVariable"></a>
+
+#### *class* FloEFDOutputVariable
+
+<a id="optiSLang_Actors.ETK.FloEFDOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.IncrementRepeater"></a>
+
+#### *class* IncrementRepeater
+
+<a id="optiSLang_Actors.ETK.IncrementRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETK.IncrementRepeater.increment"></a>
+
+#### *property* increment
+
+<a id="optiSLang_Actors.ETK.IncrementRepeater.max_increment"></a>
+
+#### *property* max_increment
+
+<a id="optiSLang_Actors.ETK.IncrementRepeater.offset"></a>
+
+#### *property* offset
+
+<a id="optiSLang_Actors.ETK.LSDYNAOutputVariable"></a>
+
+#### *class* LSDYNAOutputVariable
+
+<a id="optiSLang_Actors.ETK.LSDYNAOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.LineReader"></a>
+
+#### *class* LineReader
+
+<a id="optiSLang_Actors.ETK.LineReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.MarkerRepeater"></a>
+
+#### *class* MarkerRepeater
+
+<a id="optiSLang_Actors.ETK.MarkerRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable"></a>
+
+#### *class* ODBFieldOutputVariable
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.component_name"></a>
+
+#### *property* component_name
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.element_types"></a>
+
+#### *property* element_types
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.field_output_name"></a>
+
+#### *property* field_output_name
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.frame"></a>
+
+#### *property* frame
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.has_invariant"></a>
+
+#### has_invariant() → bool
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.invariant"></a>
+
+#### *property* invariant
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.position"></a>
+
+#### *property* position
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.reset_invariant"></a>
+
+#### reset_invariant()
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.section_point_name"></a>
+
+#### *property* section_point_name
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.section_points"></a>
+
+#### *property* section_points
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.set_infos"></a>
+
+#### *property* set_infos
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.set_type"></a>
+
+#### *property* set_type
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETK.ODBFieldOutputVariable.use_last_frame"></a>
+
+#### *property* use_last_frame
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable"></a>
+
+#### *class* ODBHistoryOutputVariable
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.history_output_description"></a>
+
+#### *property* history_output_description
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.history_output_name"></a>
+
+#### *property* history_output_name
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.point_position"></a>
+
+#### *property* point_position
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.region_name"></a>
+
+#### *property* region_name
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.tip_set_info"></a>
+
+#### *property* tip_set_info
+
+<a id="optiSLang_Actors.ETK.ODBHistoryOutputVariable.tipset_bound"></a>
+
+#### *property* tipset_bound
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfo"></a>
+
+#### *class* ODBSectionPointInfo
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: str)
+
+#### \_\_init_\_(arg2: int, arg3: str, arg4: str)
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet"></a>
+
+#### *class* ODBSectionPointInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.add"></a>
+
+#### add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.difference"></a>
+
+#### difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.remove"></a>
+
+#### remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ODBSectionPointInfoSet.union"></a>
+
+#### union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfo"></a>
+
+#### *class* ODBSetInfo
+
+<a id="optiSLang_Actors.ETK.ODBSetInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet"></a>
+
+#### *class* ODBSetInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.add"></a>
+
+#### add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.difference"></a>
+
+#### difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.remove"></a>
+
+#### remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETK.ODBSetInfoSet.union"></a>
+
+#### union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETK.PythonBasedOutputVariable"></a>
+
+#### *class* PythonBasedOutputVariable
+
+<a id="optiSLang_Actors.ETK.PythonBasedOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.PythonBasedOutputVariable.id_list"></a>
+
+#### *property* id_list
+
+<a id="optiSLang_Actors.ETK.RegexSearcher"></a>
+
+#### *class* RegexSearcher
+
+<a id="optiSLang_Actors.ETK.RegexSearcher.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETK.RegexSearcher.end_search_string"></a>
+
+#### *property* end_search_string
+
+<a id="optiSLang_Actors.ETK.RegexSearcher.end_search_string_is_regex"></a>
+
+#### *property* end_search_string_is_regex
+
+<a id="optiSLang_Actors.ETK.RegexSearcher.search_string"></a>
+
+#### *property* search_string
+
+<a id="optiSLang_Actors.ETK.RegexSearcher.search_string_is_regex"></a>
+
+#### *property* search_string_is_regex
+
+<a id="optiSLang_Actors.ETK.RepeaterArgs"></a>
+
+#### *class* RepeaterArgs
+
+<a id="optiSLang_Actors.ETK.RepeaterArgs.__init__"></a>
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETK.SimPackOutputVariable"></a>
+
+#### *class* SimPackOutputVariable
+
+<a id="optiSLang_Actors.ETK.SimPackOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.TextMarker"></a>
+
+#### *class* TextMarker
+
+<a id="optiSLang_Actors.ETK.TextMarker.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.TextMarker.append"></a>
+
+#### append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))
+
+<a id="optiSLang_Actors.ETK.TextMarker.get_child"></a>
+
+#### get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)
+
+<a id="optiSLang_Actors.ETK.TextMarker.get_row_reader"></a>
+
+#### get_row_reader() → bool
+
+<a id="optiSLang_Actors.ETK.TextMarker.has_child"></a>
+
+#### has_child() → bool
+
+<a id="optiSLang_Actors.ETK.TextMarker.has_repeater"></a>
+
+#### has_repeater() → bool
+
+<a id="optiSLang_Actors.ETK.TextMarker.is_row_reader"></a>
+
+#### is_row_reader() → bool
+
+<a id="optiSLang_Actors.ETK.TextMarker.repeater"></a>
+
+#### *property* repeater
+
+<a id="optiSLang_Actors.ETK.TextOutputVariable"></a>
+
+#### *class* TextOutputVariable
+
+<a id="optiSLang_Actors.ETK.TextOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+[7] Creates TextOutputVariable using token reader.
+
+[8] Creates TextOutputVariable using token reader.
+
+[9] Creates TextOutputVariable using column reader.
+
+[10] Creates TextOutputVariable using column reader.
+
+<a id="optiSLang_Actors.ETK.TextOutputVariable.prefer_signal"></a>
+
+#### *property* prefer_signal
+
+Prefer as signal.
+
+<a id="optiSLang_Actors.ETK.TextOutputVariable.reader"></a>
+
+#### *property* reader
+
+Contains the variable’s reader.
+
+<a id="optiSLang_Actors.ETK.TokenReader"></a>
+
+#### *class* TokenReader
+
+<a id="optiSLang_Actors.ETK.TokenReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETK.TokenReader.separator"></a>
+
+#### *property* separator
+
+<a id="optiSLang_Actors.ETK.TurboOptOutputVariable"></a>
+
+#### *class* TurboOptOutputVariable
+
+<a id="optiSLang_Actors.ETK.TurboOptOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETK.Variable"></a>
+
+#### *class* Variable
+
+<a id="optiSLang_Actors.ETK.Variable.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETK.Variable.ident"></a>
+
+#### *property* ident
+
+<a id="optiSLang_Actors.ETK.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="optiSLang_Actors.ETKAbaqusActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKAbaqusActor
 
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable"></a>`*class* ODBFieldOutputVariable`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.component_name"></a>*property* `component_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.element_types"></a>*property* `element_types`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.field_output_name"></a>*property* `field_output_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.frame"></a>*property* `frame`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.has_invariant"></a>`has_invariant() → bool`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.invariant"></a>*property* `invariant`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.position"></a>*property* `position`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.reset_invariant"></a>`reset_invariant()`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.section_point_name"></a>*property* `section_point_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.section_points"></a>*property* `section_points`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.set_infos"></a>*property* `set_infos`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.set_type"></a>*property* `set_type`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.use_last_frame"></a>*property* `use_last_frame`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable"></a>`*class* ODBHistoryOutputVariable`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_description"></a>*property* `history_output_description`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_name"></a>*property* `history_output_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.point_position"></a>*property* `point_position`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.region_name"></a>*property* `region_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.step_name"></a>*property* `step_name`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.tip_set_info"></a>*property* `tip_set_info`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.tipset_bound"></a>*property* `tipset_bound`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo"></a>`*class* ODBSectionPointInfo`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: str)`
-- `__init__(arg2: int, arg3: str, arg4: str)`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet"></a>`*class* ODBSectionPointInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__and__"></a>`__and__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__contains__"></a>`__contains__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__or__"></a>`__or__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__sub__"></a>`__sub__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__xor__"></a>`__xor__(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.add"></a>`add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.difference"></a>`difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.intersection"></a>`intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.remove"></a>`remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.union"></a>`union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfo"></a>`*class* ODBSetInfo`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfo.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))`
-- `__init__(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet"></a>`*class* ODBSetInfoSet`<br>
-  A mutable set.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__and__"></a>`__and__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__contains__"></a>`__contains__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__delitem__"></a>`__delitem__(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__hash__"></a>`__hash__()`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__or__"></a>`__or__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__sub__"></a>`__sub__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__xor__"></a>`__xor__(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.add"></a>`add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Add element.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.difference"></a>`difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.intersection"></a>`intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the intersection of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.remove"></a>`remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))`<br>
-  Remove element.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.symmetric_difference"></a>`symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.union"></a>`union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)`<br>
-  Return the union of this set and other.
-- <a id="optiSLang_Actors.ETKAbaqusActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETKAbaqusActor.free_cached_resources"></a>`free_cached_resources()`
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable"></a>
+
+#### *class* ODBFieldOutputVariable
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.component_name"></a>
+
+#### *property* component_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.element_types"></a>
+
+#### *property* element_types
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.field_output_name"></a>
+
+#### *property* field_output_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.frame"></a>
+
+#### *property* frame
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.has_invariant"></a>
+
+#### has_invariant() → bool
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.invariant"></a>
+
+#### *property* invariant
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.position"></a>
+
+#### *property* position
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.reset_invariant"></a>
+
+#### reset_invariant()
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.section_point_name"></a>
+
+#### *property* section_point_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.section_points"></a>
+
+#### *property* section_points
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.set_infos"></a>
+
+#### *property* set_infos
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.set_type"></a>
+
+#### *property* set_type
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBFieldOutputVariable.use_last_frame"></a>
+
+#### *property* use_last_frame
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable"></a>
+
+#### *class* ODBHistoryOutputVariable
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_description"></a>
+
+#### *property* history_output_description
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.history_output_name"></a>
+
+#### *property* history_output_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.point_position"></a>
+
+#### *property* point_position
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.region_name"></a>
+
+#### *property* region_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.step_name"></a>
+
+#### *property* step_name
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.tip_set_info"></a>
+
+#### *property* tip_set_info
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBHistoryOutputVariable.tipset_bound"></a>
+
+#### *property* tipset_bound
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo"></a>
+
+#### *class* ODBSectionPointInfo
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: str)
+
+#### \_\_init_\_(arg2: int, arg3: str, arg4: str)
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet"></a>
+
+#### *class* ODBSectionPointInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo)) → bool
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.add"></a>
+
+#### add(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.difference"></a>
+
+#### difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.remove"></a>
+
+#### remove(element: [ODBSectionPointInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet.union"></a>
+
+#### union(other: [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)) → [ODBSectionPointInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSectionPointInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfo"></a>
+
+#### *class* ODBSetInfo
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList))
+
+#### \_\_init_\_(arg2: str, arg3: [SetLocation](#optiSLang_Actors.SetLocation), arg4: [SetType](#optiSLang_Actors.SetType), arg5: [StrList](stdcpp_python_export.md#stdcpp_python_export.StrList), arg6: str)
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet"></a>
+
+#### *class* ODBSetInfoSet
+
+A mutable set.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo)) → bool
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.add"></a>
+
+#### add(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Add element.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.difference"></a>
+
+#### difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements of this set that are not in other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.intersection"></a>
+
+#### intersection(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the intersection of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.remove"></a>
+
+#### remove(element: [ODBSetInfo](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfo))
+
+Remove element.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet.union"></a>
+
+#### union(other: [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)) → [ODBSetInfoSet](#optiSLang_Actors.ETKAbaqusActor.ODBSetInfoSet)
+
+Return the union of this set and other.
+
+<a id="optiSLang_Actors.ETKAbaqusActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETKAbaqusActor.free_cached_resources"></a>
+
+#### free_cached_resources()
 
 <a id="optiSLang_Actors.ETKActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKActor
 
-- <a id="optiSLang_Actors.ETKActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETKActor.imported_files"></a>*property* `imported_files`
-- <a id="optiSLang_Actors.ETKActor.max_parallel"></a>*property* `max_parallel`
+<a id="optiSLang_Actors.ETKActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETKActor.imported_files"></a>
+
+#### *property* imported_files
+
+<a id="optiSLang_Actors.ETKActor.max_parallel"></a>
+
+#### *property* max_parallel
 
 <a id="optiSLang_Actors.ETKFloEFDActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKFloEFDActor
 
-- <a id="optiSLang_Actors.ETKFloEFDActor.FloEFDOutputVariable"></a>`*class* FloEFDOutputVariable`
-- <a id="optiSLang_Actors.ETKFloEFDActor.FloEFDOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETKFloEFDActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.ETKFloEFDActor.FloEFDOutputVariable"></a>
+
+#### *class* FloEFDOutputVariable
+
+<a id="optiSLang_Actors.ETKFloEFDActor.FloEFDOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETKFloEFDActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ETKSimPackActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKSimPackActor
 
-- <a id="optiSLang_Actors.ETKSimPackActor.SimPackOutputVariable"></a>`*class* SimPackOutputVariable`
-- <a id="optiSLang_Actors.ETKSimPackActor.SimPackOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETKSimPackActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.ETKSimPackActor.SimPackOutputVariable"></a>
+
+#### *class* SimPackOutputVariable
+
+<a id="optiSLang_Actors.ETKSimPackActor.SimPackOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETKSimPackActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ETKTextOutputActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKTextOutputActor
 
-- <a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader"></a>`*class* ColumnReader`
-- <a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.initial_offset"></a>*property* `initial_offset`
-- <a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.width"></a>*property* `width`
-- <a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater"></a>`*class* IncrementRepeater`
-- <a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: int, arg3: int)`
-- `__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.increment"></a>*property* `increment`
-- <a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.max_increment"></a>*property* `max_increment`
-- <a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.offset"></a>*property* `offset`
-- <a id="optiSLang_Actors.ETKTextOutputActor.LineReader"></a>`*class* LineReader`
-- <a id="optiSLang_Actors.ETKTextOutputActor.LineReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETKTextOutputActor.MarkerRepeater"></a>`*class* MarkerRepeater`
-- <a id="optiSLang_Actors.ETKTextOutputActor.MarkerRepeater.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher"></a>`*class* RegexSearcher`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.end_search_string"></a>*property* `end_search_string`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.end_search_string_is_regex"></a>*property* `end_search_string_is_regex`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.search_string"></a>*property* `search_string`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.search_string_is_regex"></a>*property* `search_string_is_regex`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RepeaterArgs"></a>`*class* RepeaterArgs`
-- <a id="optiSLang_Actors.ETKTextOutputActor.RepeaterArgs.__init__"></a>`__init__(arg2: int, arg3: int, arg4: int)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker"></a>`*class* TextMarker`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.append"></a>`append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.get_child"></a>`get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.get_row_reader"></a>`get_row_reader() → bool`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.has_child"></a>`has_child() → bool`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.has_repeater"></a>`has_repeater() → bool`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.is_row_reader"></a>`is_row_reader() → bool`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.repeater"></a>*property* `repeater`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable"></a>`*class* TextOutputVariable`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.__init__"></a>`__init__()`<br>
-  [7] Creates TextOutputVariable using token reader. [8] Creates TextOutputVariable using token reader. [9] Creates TextOutputVariable using column reader. [10] Creates TextOutputVariable using column reader.
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)`
-- `__init__(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- `__init__(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.prefer_signal"></a>*property* `prefer_signal`<br>
-  Prefer as signal.
-- <a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.reader"></a>*property* `reader`<br>
-  Contains the variable’s reader.
-- <a id="optiSLang_Actors.ETKTextOutputActor.TokenReader"></a>`*class* TokenReader`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TokenReader.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ETKTextOutputActor.TokenReader.separator"></a>*property* `separator`
-- <a id="optiSLang_Actors.ETKTextOutputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ETKTextOutputActor.max_parallel"></a>*property* `max_parallel`
+<a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader"></a>
+
+#### *class* ColumnReader
+
+<a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.initial_offset"></a>
+
+#### *property* initial_offset
+
+<a id="optiSLang_Actors.ETKTextOutputActor.ColumnReader.width"></a>
+
+#### *property* width
+
+<a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater"></a>
+
+#### *class* IncrementRepeater
+
+<a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.increment"></a>
+
+#### *property* increment
+
+<a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.max_increment"></a>
+
+#### *property* max_increment
+
+<a id="optiSLang_Actors.ETKTextOutputActor.IncrementRepeater.offset"></a>
+
+#### *property* offset
+
+<a id="optiSLang_Actors.ETKTextOutputActor.LineReader"></a>
+
+#### *class* LineReader
+
+<a id="optiSLang_Actors.ETKTextOutputActor.LineReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETKTextOutputActor.MarkerRepeater"></a>
+
+#### *class* MarkerRepeater
+
+<a id="optiSLang_Actors.ETKTextOutputActor.MarkerRepeater.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher"></a>
+
+#### *class* RegexSearcher
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.end_search_string"></a>
+
+#### *property* end_search_string
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.end_search_string_is_regex"></a>
+
+#### *property* end_search_string_is_regex
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.search_string"></a>
+
+#### *property* search_string
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RegexSearcher.search_string_is_regex"></a>
+
+#### *property* search_string_is_regex
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RepeaterArgs"></a>
+
+#### *class* RepeaterArgs
+
+<a id="optiSLang_Actors.ETKTextOutputActor.RepeaterArgs.__init__"></a>
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker"></a>
+
+#### *class* TextMarker
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.append"></a>
+
+#### append(arg2: [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker))
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.get_child"></a>
+
+#### get_child() → [TextMarker](#optiSLang_Actors.ETKTextOutputActor.TextMarker)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.get_row_reader"></a>
+
+#### get_row_reader() → bool
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.has_child"></a>
+
+#### has_child() → bool
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.has_repeater"></a>
+
+#### has_repeater() → bool
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.is_row_reader"></a>
+
+#### is_row_reader() → bool
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextMarker.repeater"></a>
+
+#### *property* repeater
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable"></a>
+
+#### *class* TextOutputVariable
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str)
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Token: RepeaterArgs repeater arguments)
+
+#### \_\_init_\_(Output: Path file path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+#### \_\_init_\_(Output: Path file path, Base: Path path, Variable: str name, Line: RepeaterArgs reapeater arguments, Column: RepeaterArgs repeater arguments, Column: int offset, Column: int width)
+
+[7] Creates TextOutputVariable using token reader.
+
+[8] Creates TextOutputVariable using token reader.
+
+[9] Creates TextOutputVariable using column reader.
+
+[10] Creates TextOutputVariable using column reader.
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.prefer_signal"></a>
+
+#### *property* prefer_signal
+
+Prefer as signal.
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TextOutputVariable.reader"></a>
+
+#### *property* reader
+
+Contains the variable’s reader.
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TokenReader"></a>
+
+#### *class* TokenReader
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TokenReader.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ETKTextOutputActor.TokenReader.separator"></a>
+
+#### *property* separator
+
+<a id="optiSLang_Actors.ETKTextOutputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ETKTextOutputActor.max_parallel"></a>
+
+#### *property* max_parallel
 
 <a id="optiSLang_Actors.ETKTurboOptActor"></a>
 
 ## *class* \_optiSLang_Actors.ETKTurboOptActor
 
-- <a id="optiSLang_Actors.ETKTurboOptActor.TurboOptOutputVariable"></a>`*class* TurboOptOutputVariable`
-- <a id="optiSLang_Actors.ETKTurboOptActor.TurboOptOutputVariable.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`
-- <a id="optiSLang_Actors.ETKTurboOptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.ETKTurboOptActor.TurboOptOutputVariable"></a>
+
+#### *class* TurboOptOutputVariable
+
+<a id="optiSLang_Actors.ETKTurboOptActor.TurboOptOutputVariable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: str, arg5: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+<a id="optiSLang_Actors.ETKTurboOptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ExecutionPolicy"></a>
 
 ## *class* \_optiSLang_Actors.ExecutionPolicy
 
-- <a id="optiSLang_Actors.ExecutionPolicy.__init__"></a>`__init__(continuation_behaviour: Continuation=_optiSLang_Actors.Continuation.DEFAULT, expressions: WStrList)`
-- `__init__(, continuation_behaviour: Continuation=_optiSLang_Actors.Continuation.DEFAULT [, expressions_mode: Expressions=_optiSLang_Actors.Expressions.FULFILL_ALL]])`
-- <a id="optiSLang_Actors.ExecutionPolicy.continuation_behaviour"></a>*property* `continuation_behaviour`<br>
-  Continuation behaviour in case of predecessor failure
-- <a id="optiSLang_Actors.ExecutionPolicy.expressions"></a>*property* `expressions`<br>
-  Expression conditions
-- <a id="optiSLang_Actors.ExecutionPolicy.expressions_mode"></a>*property* `expressions_mode`<br>
-  Fulfillment mode for expression conditions
+<a id="optiSLang_Actors.ExecutionPolicy.__init__"></a>
+
+#### \_\_init_\_(continuation_behaviour: Continuation=_optiSLang_Actors.Continuation.DEFAULT, expressions: WStrList)
+
+#### \_\_init_\_(, continuation_behaviour: Continuation=_optiSLang_Actors.Continuation.DEFAULT [, expressions_mode: Expressions=_optiSLang_Actors.Expressions.FULFILL_ALL]])
+
+<a id="optiSLang_Actors.ExecutionPolicy.continuation_behaviour"></a>
+
+#### *property* continuation_behaviour
+
+Continuation behaviour in case of predecessor failure
+
+<a id="optiSLang_Actors.ExecutionPolicy.expressions"></a>
+
+#### *property* expressions
+
+Expression conditions
+
+<a id="optiSLang_Actors.ExecutionPolicy.expressions_mode"></a>
+
+#### *property* expressions_mode
+
+Fulfillment mode for expression conditions
 
 <a id="optiSLang_Actors.ExportFailureTreatment"></a>
 
@@ -1332,8 +3806,13 @@ Reliability actor using Directional Sampling.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ExportFailureTreatment.ALWAYS_SUCCEED"></a>`ALWAYS_SUCCEED *= _optiSLang_Actors.ExportFailureTreatment.ALWAYS_SUCCEED*`
-- <a id="optiSLang_Actors.ExportFailureTreatment.FAIL_ON_WRITE_ERROR"></a>`FAIL_ON_WRITE_ERROR *= _optiSLang_Actors.ExportFailureTreatment.FAIL_ON_WRITE_ERROR*`
+<a id="optiSLang_Actors.ExportFailureTreatment.ALWAYS_SUCCEED"></a>
+
+#### ALWAYS_SUCCEED *= \_optiSLang_Actors.ExportFailureTreatment.ALWAYS_SUCCEED*
+
+<a id="optiSLang_Actors.ExportFailureTreatment.FAIL_ON_WRITE_ERROR"></a>
+
+#### FAIL_ON_WRITE_ERROR *= \_optiSLang_Actors.ExportFailureTreatment.FAIL_ON_WRITE_ERROR*
 
 <a id="optiSLang_Actors.ExportFormat"></a>
 
@@ -1341,10 +3820,21 @@ Reliability actor using Directional Sampling.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ExportFormat.CSV"></a>`CSV *= _optiSLang_Actors.ExportFormat.CSV*`
-- <a id="optiSLang_Actors.ExportFormat.EXCEL"></a>`EXCEL *= _optiSLang_Actors.ExportFormat.EXCEL*`
-- <a id="optiSLang_Actors.ExportFormat.GENERIC"></a>`GENERIC *= _optiSLang_Actors.ExportFormat.GENERIC*`
-- <a id="optiSLang_Actors.ExportFormat.JSON"></a>`JSON *= _optiSLang_Actors.ExportFormat.JSON*`
+<a id="optiSLang_Actors.ExportFormat.CSV"></a>
+
+#### CSV *= \_optiSLang_Actors.ExportFormat.CSV*
+
+<a id="optiSLang_Actors.ExportFormat.EXCEL"></a>
+
+#### EXCEL *= \_optiSLang_Actors.ExportFormat.EXCEL*
+
+<a id="optiSLang_Actors.ExportFormat.GENERIC"></a>
+
+#### GENERIC *= \_optiSLang_Actors.ExportFormat.GENERIC*
+
+<a id="optiSLang_Actors.ExportFormat.JSON"></a>
+
+#### JSON *= \_optiSLang_Actors.ExportFormat.JSON*
 
 <a id="optiSLang_Actors.Expressions"></a>
 
@@ -1354,9 +3844,17 @@ Reliability actor using Directional Sampling.
 
 Integration actor expression conditions fulfillment mode
 
-- <a id="optiSLang_Actors.Expressions.DISABLED"></a>`DISABLED *= _optiSLang_Actors.Expressions.DISABLED*`
-- <a id="optiSLang_Actors.Expressions.FULFILL_ALL"></a>`FULFILL_ALL *= _optiSLang_Actors.Expressions.FULFILL_ALL*`
-- <a id="optiSLang_Actors.Expressions.FULFILL_ANY"></a>`FULFILL_ANY *= _optiSLang_Actors.Expressions.FULFILL_ANY*`
+<a id="optiSLang_Actors.Expressions.DISABLED"></a>
+
+#### DISABLED *= \_optiSLang_Actors.Expressions.DISABLED*
+
+<a id="optiSLang_Actors.Expressions.FULFILL_ALL"></a>
+
+#### FULFILL_ALL *= \_optiSLang_Actors.Expressions.FULFILL_ALL*
+
+<a id="optiSLang_Actors.Expressions.FULFILL_ANY"></a>
+
+#### FULFILL_ANY *= \_optiSLang_Actors.Expressions.FULFILL_ANY*
 
 <a id="optiSLang_Actors.ExtrapolationType"></a>
 
@@ -1364,9 +3862,17 @@ Integration actor expression conditions fulfillment mode
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ExtrapolationType.EXTRAPOLATE"></a>`EXTRAPOLATE *= _optiSLang_Actors.ExtrapolationType.EXTRAPOLATE*`
-- <a id="optiSLang_Actors.ExtrapolationType.INITIAL_SAMPLING_BOUNDS"></a>`INITIAL_SAMPLING_BOUNDS *= _optiSLang_Actors.ExtrapolationType.INITIAL_SAMPLING_BOUNDS*`
-- <a id="optiSLang_Actors.ExtrapolationType.REDUCED_SAMPLING_BOUNDS"></a>`REDUCED_SAMPLING_BOUNDS *= _optiSLang_Actors.ExtrapolationType.REDUCED_SAMPLING_BOUNDS*`
+<a id="optiSLang_Actors.ExtrapolationType.EXTRAPOLATE"></a>
+
+#### EXTRAPOLATE *= \_optiSLang_Actors.ExtrapolationType.EXTRAPOLATE*
+
+<a id="optiSLang_Actors.ExtrapolationType.INITIAL_SAMPLING_BOUNDS"></a>
+
+#### INITIAL_SAMPLING_BOUNDS *= \_optiSLang_Actors.ExtrapolationType.INITIAL_SAMPLING_BOUNDS*
+
+<a id="optiSLang_Actors.ExtrapolationType.REDUCED_SAMPLING_BOUNDS"></a>
+
+#### REDUCED_SAMPLING_BOUNDS *= \_optiSLang_Actors.ExtrapolationType.REDUCED_SAMPLING_BOUNDS*
 
 <a id="optiSLang_Actors.FORMActor"></a>
 
@@ -1374,15 +3880,23 @@ Integration actor expression conditions fulfillment mode
 
 Reliability actor using First Order Reliability Method.
 
-- <a id="optiSLang_Actors.FORMActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.FORMActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.FORMActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.FORMActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.FloEFDInputActor"></a>
 
 ## *class* \_optiSLang_Actors.FloEFDInputActor
 
-- <a id="optiSLang_Actors.FloEFDInputActor.__init__"></a>`__init__(arg2: str)`
+<a id="optiSLang_Actors.FloEFDInputActor.__init__"></a>
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.GetLoadedCIPlugins"></a>
 
@@ -1398,49 +3912,133 @@ List customization plugins that are loaded at runtime.
 
 ## *class* \_optiSLang_Actors.HPSActor
 
-- <a id="optiSLang_Actors.HPSActor.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.HPSActor.add_input"></a>`add_input(location: HPSLocation)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.HPSActor.add_internal_variable"></a>`add_internal_variable(location: HPSLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.HPSActor.add_output"></a>`add_output(location: HPSLocation)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.HPSActor.add_parameter"></a>`add_parameter(location: HPSLocation)`<br>
-  [0] Assign location to a parameter.
-- `add_parameter(arg2: str) → str`
-- <a id="optiSLang_Actors.HPSActor.add_response"></a>`add_response(location: HPSLocation)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(arg2: str) → str`
-- <a id="optiSLang_Actors.HPSActor.designs_per_process"></a>*property* `designs_per_process`
-- <a id="optiSLang_Actors.HPSActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.HPSActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.HPSActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.HPSActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.HPSActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.HPSActor.job_definition"></a>*property* `job_definition`
-- <a id="optiSLang_Actors.HPSActor.login"></a>`login(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.HPSActor.output_files_to_fetch"></a>*property* `output_files_to_fetch`
-- <a id="optiSLang_Actors.HPSActor.project"></a>*property* `project`
-- <a id="optiSLang_Actors.HPSActor.refresh_token"></a>*property* `refresh_token`
-- <a id="optiSLang_Actors.HPSActor.url"></a>*property* `url`
+<a id="optiSLang_Actors.HPSActor.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.HPSActor.add_input"></a>
+
+#### add_input(location: HPSLocation)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.HPSActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: HPSLocation)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.HPSActor.add_output"></a>
+
+#### add_output(location: HPSLocation)
+
+#### add_output(derived_variable: DerivedLocation)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.HPSActor.add_parameter"></a>
+
+#### add_parameter(location: HPSLocation)
+
+#### add_parameter(arg2: str) → str
+
+[0] Assign location to a parameter.
+
+<a id="optiSLang_Actors.HPSActor.add_response"></a>
+
+#### add_response(location: HPSLocation)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(arg2: str) → str
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.HPSActor.designs_per_process"></a>
+
+#### *property* designs_per_process
+
+<a id="optiSLang_Actors.HPSActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.HPSActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.HPSActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.HPSActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.HPSActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.HPSActor.job_definition"></a>
+
+#### *property* job_definition
+
+<a id="optiSLang_Actors.HPSActor.login"></a>
+
+#### login(arg2: str, arg3: str)
+
+<a id="optiSLang_Actors.HPSActor.output_files_to_fetch"></a>
+
+#### *property* output_files_to_fetch
+
+<a id="optiSLang_Actors.HPSActor.project"></a>
+
+#### *property* project
+
+<a id="optiSLang_Actors.HPSActor.refresh_token"></a>
+
+#### *property* refresh_token
+
+<a id="optiSLang_Actors.HPSActor.url"></a>
+
+#### *property* url
 
 <a id="optiSLang_Actors.HPSLocation"></a>
 
 ## *class* \_optiSLang_Actors.HPSLocation
 
-- <a id="optiSLang_Actors.HPSLocation.__init__"></a>`__init__()`<br>
-  [1] Create a HPSLocation instance.
-- `__init__(location: str id, direction: IntegrationDirection)`
-- <a id="optiSLang_Actors.HPSLocation.direction"></a>*property* `direction`
-- <a id="optiSLang_Actors.HPSLocation.name"></a>*property* `name`
+<a id="optiSLang_Actors.HPSLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(location: str id, direction: IntegrationDirection)
+
+[1] Create a HPSLocation instance.
+
+<a id="optiSLang_Actors.HPSLocation.direction"></a>
+
+#### *property* direction
+
+<a id="optiSLang_Actors.HPSLocation.name"></a>
+
+#### *property* name
 
 <a id="optiSLang_Actors.ISPUDActor"></a>
 
@@ -1448,9 +4046,15 @@ List customization plugins that are loaded at runtime.
 
 Reliability actor that utilizes Importance Sampling Using the Design Point.
 
-- <a id="optiSLang_Actors.ISPUDActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ISPUDActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.ISPUDActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ISPUDActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.ImportDimensionType"></a>
 
@@ -1458,10 +4062,21 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ImportDimensionType.DesignId"></a>`DesignId *= _optiSLang_Actors.ImportDimensionType.DesignId*`
-- <a id="optiSLang_Actors.ImportDimensionType.DontImport"></a>`DontImport *= _optiSLang_Actors.ImportDimensionType.DontImport*`
-- <a id="optiSLang_Actors.ImportDimensionType.Parameter"></a>`Parameter *= _optiSLang_Actors.ImportDimensionType.Parameter*`
-- <a id="optiSLang_Actors.ImportDimensionType.Response"></a>`Response *= _optiSLang_Actors.ImportDimensionType.Response*`
+<a id="optiSLang_Actors.ImportDimensionType.DesignId"></a>
+
+#### DesignId *= \_optiSLang_Actors.ImportDimensionType.DesignId*
+
+<a id="optiSLang_Actors.ImportDimensionType.DontImport"></a>
+
+#### DontImport *= \_optiSLang_Actors.ImportDimensionType.DontImport*
+
+<a id="optiSLang_Actors.ImportDimensionType.Parameter"></a>
+
+#### Parameter *= \_optiSLang_Actors.ImportDimensionType.Parameter*
+
+<a id="optiSLang_Actors.ImportDimensionType.Response"></a>
+
+#### Response *= \_optiSLang_Actors.ImportDimensionType.Response*
 
 <a id="optiSLang_Actors.ImportFailureTreatment"></a>
 
@@ -1469,10 +4084,21 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ImportFailureTreatment.ALWAYS_SUCCEED"></a>`ALWAYS_SUCCEED *= _optiSLang_Actors.ImportFailureTreatment.ALWAYS_SUCCEED*`
-- <a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_MISSING_ENTRY"></a>`FAIL_ON_MISSING_ENTRY *= _optiSLang_Actors.ImportFailureTreatment.FAIL_ON_MISSING_ENTRY*`
-- <a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_READ_ERROR"></a>`FAIL_ON_READ_ERROR *= _optiSLang_Actors.ImportFailureTreatment.FAIL_ON_READ_ERROR*`
-- <a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_TYPE_MISMATCH"></a>`FAIL_ON_TYPE_MISMATCH *= _optiSLang_Actors.ImportFailureTreatment.FAIL_ON_TYPE_MISMATCH*`
+<a id="optiSLang_Actors.ImportFailureTreatment.ALWAYS_SUCCEED"></a>
+
+#### ALWAYS_SUCCEED *= \_optiSLang_Actors.ImportFailureTreatment.ALWAYS_SUCCEED*
+
+<a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_MISSING_ENTRY"></a>
+
+#### FAIL_ON_MISSING_ENTRY *= \_optiSLang_Actors.ImportFailureTreatment.FAIL_ON_MISSING_ENTRY*
+
+<a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_READ_ERROR"></a>
+
+#### FAIL_ON_READ_ERROR *= \_optiSLang_Actors.ImportFailureTreatment.FAIL_ON_READ_ERROR*
+
+<a id="optiSLang_Actors.ImportFailureTreatment.FAIL_ON_TYPE_MISMATCH"></a>
+
+#### FAIL_ON_TYPE_MISMATCH *= \_optiSLang_Actors.ImportFailureTreatment.FAIL_ON_TYPE_MISMATCH*
 
 <a id="optiSLang_Actors.ImportFormat"></a>
 
@@ -1480,58 +4106,166 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ImportFormat.CSV"></a>`CSV *= _optiSLang_Actors.ImportFormat.CSV*`
-- <a id="optiSLang_Actors.ImportFormat.EXCEL"></a>`EXCEL *= _optiSLang_Actors.ImportFormat.EXCEL*`
-- <a id="optiSLang_Actors.ImportFormat.GENERIC"></a>`GENERIC *= _optiSLang_Actors.ImportFormat.GENERIC*`
-- <a id="optiSLang_Actors.ImportFormat.JSON"></a>`JSON *= _optiSLang_Actors.ImportFormat.JSON*`
+<a id="optiSLang_Actors.ImportFormat.CSV"></a>
+
+#### CSV *= \_optiSLang_Actors.ImportFormat.CSV*
+
+<a id="optiSLang_Actors.ImportFormat.EXCEL"></a>
+
+#### EXCEL *= \_optiSLang_Actors.ImportFormat.EXCEL*
+
+<a id="optiSLang_Actors.ImportFormat.GENERIC"></a>
+
+#### GENERIC *= \_optiSLang_Actors.ImportFormat.GENERIC*
+
+<a id="optiSLang_Actors.ImportFormat.JSON"></a>
+
+#### JSON *= \_optiSLang_Actors.ImportFormat.JSON*
 
 <a id="optiSLang_Actors.IntegrationBaseActor"></a>
 
 ## *class* \_optiSLang_Actors.IntegrationBaseActor
 
-- <a id="optiSLang_Actors.IntegrationBaseActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.IntegrationBaseActor.add_input"></a>`add_input(location: str)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.IntegrationBaseActor.add_internal_variable"></a>`add_internal_variable(location: str)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.add_output"></a>`add_output(location: str)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.add_parameter"></a>`add_parameter(location: str)`<br>
-  Assign location to a parameter.
-- <a id="optiSLang_Actors.IntegrationBaseActor.add_response"></a>`add_response(location: str)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- `add_response(arg2: tuple) → str`
-- `add_response(arg2: tuple) → str`
-- <a id="optiSLang_Actors.IntegrationBaseActor.error_code"></a>*property* `error_code`
-- <a id="optiSLang_Actors.IntegrationBaseActor.execution_policy"></a>*property* `execution_policy`
-- <a id="optiSLang_Actors.IntegrationBaseActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.IntegrationBaseActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.IntegrationBaseActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.IntegrationBaseActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.IntegrationBaseActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.IntegrationBaseActor.instant_variable_update"></a>*property* `instant_variable_update`
-- <a id="optiSLang_Actors.IntegrationBaseActor.load"></a>`load() → bool`<br>
-  [0] Initialize integration according to specified properties [1] Initialize integration according to specified json-string content
-- `load(json: str) → bool`
-- <a id="optiSLang_Actors.IntegrationBaseActor.remove_input"></a>`remove_input(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.remove_internal_variable"></a>`remove_internal_variable(arg2: str) → bool`
-- <a id="optiSLang_Actors.IntegrationBaseActor.remove_output"></a>`remove_output(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.remove_parameter"></a>`remove_parameter(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.remove_response"></a>`remove_response(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationBaseActor.reread_parameter_reference_values"></a>`reread_parameter_reference_values(, publish_reference_changes: bool=True [, invalidate_on_fail: bool=False]])`<br>
-  Re-reads parameter reference values and optionally updates values held by the parent system
-- <a id="optiSLang_Actors.IntegrationBaseActor.reread_response_reference_values"></a>`reread_response_reference_values(, publish_reference_changes: bool=True [, invalidate_on_fail: bool=False]])`<br>
-  Re-reads response reference values and optionally updates values held by the parent system
-- <a id="optiSLang_Actors.IntegrationBaseActor.set_locations"></a>`set_locations(arg2: str) → bool`
+<a id="optiSLang_Actors.IntegrationBaseActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.IntegrationBaseActor.add_input"></a>
+
+#### add_input(location: str)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.IntegrationBaseActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: str)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.IntegrationBaseActor.add_output"></a>
+
+#### add_output(location: str)
+
+#### add_output(derived_variable: DerivedLocation)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.IntegrationBaseActor.add_parameter"></a>
+
+#### add_parameter(location: str)
+
+Assign location to a parameter.
+
+<a id="optiSLang_Actors.IntegrationBaseActor.add_response"></a>
+
+#### add_response(location: str)
+
+#### add_response(derived_variable: DerivedLocation)
+
+#### add_response(arg2: tuple) → str
+
+#### add_response(arg2: tuple) → str
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.IntegrationBaseActor.error_code"></a>
+
+#### *property* error_code
+
+<a id="optiSLang_Actors.IntegrationBaseActor.execution_policy"></a>
+
+#### *property* execution_policy
+
+<a id="optiSLang_Actors.IntegrationBaseActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.IntegrationBaseActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.IntegrationBaseActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.IntegrationBaseActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.IntegrationBaseActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.IntegrationBaseActor.instant_variable_update"></a>
+
+#### *property* instant_variable_update
+
+<a id="optiSLang_Actors.IntegrationBaseActor.load"></a>
+
+#### load() → bool
+
+#### load(json: str) → bool
+
+[0] Initialize integration according to specified properties
+
+[1] Initialize integration according to specified json-string content
+
+<a id="optiSLang_Actors.IntegrationBaseActor.remove_input"></a>
+
+#### remove_input(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationBaseActor.remove_internal_variable"></a>
+
+#### remove_internal_variable(arg2: str) → bool
+
+<a id="optiSLang_Actors.IntegrationBaseActor.remove_output"></a>
+
+#### remove_output(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationBaseActor.remove_parameter"></a>
+
+#### remove_parameter(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationBaseActor.remove_response"></a>
+
+#### remove_response(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationBaseActor.reread_parameter_reference_values"></a>
+
+#### reread_parameter_reference_values(, publish_reference_changes: bool=True [, invalidate_on_fail: bool=False]])
+
+Re-reads parameter reference values and optionally updates values held by the parent system
+
+<a id="optiSLang_Actors.IntegrationBaseActor.reread_response_reference_values"></a>
+
+#### reread_response_reference_values(, publish_reference_changes: bool=True [, invalidate_on_fail: bool=False]])
+
+Re-reads response reference values and optionally updates values held by the parent system
+
+<a id="optiSLang_Actors.IntegrationBaseActor.set_locations"></a>
+
+#### set_locations(arg2: str) → bool
 
 <a id="optiSLang_Actors.IntegrationDirection"></a>
 
@@ -1539,50 +4273,135 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.IntegrationDirection.DIRECTION_INPUT"></a>`DIRECTION_INPUT *= _optiSLang_Actors.IntegrationDirection.DIRECTION_INPUT*`
-- <a id="optiSLang_Actors.IntegrationDirection.DIRECTION_OUTPUT"></a>`DIRECTION_OUTPUT *= _optiSLang_Actors.IntegrationDirection.DIRECTION_OUTPUT*`
+<a id="optiSLang_Actors.IntegrationDirection.DIRECTION_INPUT"></a>
+
+#### DIRECTION_INPUT *= \_optiSLang_Actors.IntegrationDirection.DIRECTION_INPUT*
+
+<a id="optiSLang_Actors.IntegrationDirection.DIRECTION_OUTPUT"></a>
+
+#### DIRECTION_OUTPUT *= \_optiSLang_Actors.IntegrationDirection.DIRECTION_OUTPUT*
 
 <a id="optiSLang_Actors.IntegrationPluginActor"></a>
 
 ## *class* \_optiSLang_Actors.IntegrationPluginActor
 
-- <a id="optiSLang_Actors.IntegrationPluginActor.__init__"></a>`__init__(plugin: str name) → object`<br>
-  Create an integration plugin actor by name. The plugin must be loaded at runtime.
-- <a id="optiSLang_Actors.IntegrationPluginActor.add_input"></a>`add_input(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.add_internal_variable"></a>`add_internal_variable(arg2: str)`<br>
-  [1] Create a derived variable.
-- `add_internal_variable(derived: DerivedLocation variable)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.add_output"></a>`add_output(arg2: str)`<br>
-  [1] Create a derived variable and assign it to an output slot.
-- `add_output(arg2: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.add_parameter"></a>`add_parameter(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.add_response"></a>`add_response(arg2: str)`<br>
-  [1] Create a derived variable and assign it to a response.
-- `add_response(arg2: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.error_code"></a>*property* `error_code`
-- <a id="optiSLang_Actors.IntegrationPluginActor.get_internal_property_names"></a>`get_internal_property_names() → list`<br>
-  Get names of properties defined by the plugin internally
-- <a id="optiSLang_Actors.IntegrationPluginActor.get_plugin_id"></a>`get_plugin_id() → str`<br>
-  The plugin id.
-- <a id="optiSLang_Actors.IntegrationPluginActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.IntegrationPluginActor.re_register_locations_as_parameter"></a>`re_register_locations_as_parameter()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.re_register_locations_as_response"></a>`re_register_locations_as_response()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_input"></a>`register_location_as_input(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_internal_variable"></a>`register_location_as_internal_variable(arg2: str)`<br>
-  [1] Create a derived variable.
-- `register_location_as_internal_variable(derived: DerivedLocation variable)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_output"></a>`register_location_as_output(arg2: str)`<br>
-  [1] Create a derived variable and assign it to an output slot.
-- `register_location_as_output(arg2: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_parameter"></a>`register_location_as_parameter(arg2: str)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_response"></a>`register_location_as_response(arg2: str)`<br>
-  [1] Create a derived variable and assign it to a response.
-- `register_location_as_response(arg2: DerivedLocation)`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_input"></a>`register_locations_as_input()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_internal_variable"></a>`register_locations_as_internal_variable()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_output"></a>`register_locations_as_output()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_parameter"></a>`register_locations_as_parameter()`
-- <a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_response"></a>`register_locations_as_response()`
+<a id="optiSLang_Actors.IntegrationPluginActor.__init__"></a>
+
+#### \_\_init_\_(plugin: str name) → object
+
+Create an integration plugin actor by name. The plugin must be loaded at runtime.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.add_input"></a>
+
+#### add_input(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationPluginActor.add_internal_variable"></a>
+
+#### add_internal_variable(arg2: str)
+
+#### add_internal_variable(derived: DerivedLocation variable)
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.add_output"></a>
+
+#### add_output(arg2: str)
+
+#### add_output(arg2: DerivedLocation)
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.add_parameter"></a>
+
+#### add_parameter(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationPluginActor.add_response"></a>
+
+#### add_response(arg2: str)
+
+#### add_response(arg2: DerivedLocation)
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.error_code"></a>
+
+#### *property* error_code
+
+<a id="optiSLang_Actors.IntegrationPluginActor.get_internal_property_names"></a>
+
+#### get_internal_property_names() → list
+
+Get names of properties defined by the plugin internally
+
+<a id="optiSLang_Actors.IntegrationPluginActor.get_plugin_id"></a>
+
+#### get_plugin_id() → str
+
+The plugin id.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.IntegrationPluginActor.re_register_locations_as_parameter"></a>
+
+#### re_register_locations_as_parameter()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.re_register_locations_as_response"></a>
+
+#### re_register_locations_as_response()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_input"></a>
+
+#### register_location_as_input(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_internal_variable"></a>
+
+#### register_location_as_internal_variable(arg2: str)
+
+#### register_location_as_internal_variable(derived: DerivedLocation variable)
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_output"></a>
+
+#### register_location_as_output(arg2: str)
+
+#### register_location_as_output(arg2: DerivedLocation)
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_parameter"></a>
+
+#### register_location_as_parameter(arg2: str)
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_location_as_response"></a>
+
+#### register_location_as_response(arg2: str)
+
+#### register_location_as_response(arg2: DerivedLocation)
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_input"></a>
+
+#### register_locations_as_input()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_internal_variable"></a>
+
+#### register_locations_as_internal_variable()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_output"></a>
+
+#### register_locations_as_output()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_parameter"></a>
+
+#### register_locations_as_parameter()
+
+<a id="optiSLang_Actors.IntegrationPluginActor.register_locations_as_response"></a>
+
+#### register_locations_as_response()
 
 <a id="optiSLang_Actors.Invariant"></a>
 
@@ -1590,143 +4409,411 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.Invariant.INVARIANT_INV3"></a>`INVARIANT_INV3 *= _optiSLang_Actors.Invariant.INVARIANT_INV3*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MAGNITUDE"></a>`INVARIANT_MAGNITUDE *= _optiSLang_Actors.Invariant.INVARIANT_MAGNITUDE*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MAX_INPLANE_PRINCIPAL"></a>`INVARIANT_MAX_INPLANE_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_MAX_INPLANE_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MAX_PRINCIPAL"></a>`INVARIANT_MAX_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_MAX_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MID_PRINCIPAL"></a>`INVARIANT_MID_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_MID_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MIN_INPLANE_PRINCIPAL"></a>`INVARIANT_MIN_INPLANE_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_MIN_INPLANE_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MIN_PRINCIPAL"></a>`INVARIANT_MIN_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_MIN_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_MISES"></a>`INVARIANT_MISES *= _optiSLang_Actors.Invariant.INVARIANT_MISES*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_OUTOFPLANE_PRINCIPAL"></a>`INVARIANT_OUTOFPLANE_PRINCIPAL *= _optiSLang_Actors.Invariant.INVARIANT_OUTOFPLANE_PRINCIPAL*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_PRESS"></a>`INVARIANT_PRESS *= _optiSLang_Actors.Invariant.INVARIANT_PRESS*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_TRESCA"></a>`INVARIANT_TRESCA *= _optiSLang_Actors.Invariant.INVARIANT_TRESCA*`
-- <a id="optiSLang_Actors.Invariant.INVARIANT_UNDEFINED"></a>`INVARIANT_UNDEFINED *= _optiSLang_Actors.Invariant.INVARIANT_UNDEFINED*`
+<a id="optiSLang_Actors.Invariant.INVARIANT_INV3"></a>
+
+#### INVARIANT_INV3 *= \_optiSLang_Actors.Invariant.INVARIANT_INV3*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MAGNITUDE"></a>
+
+#### INVARIANT_MAGNITUDE *= \_optiSLang_Actors.Invariant.INVARIANT_MAGNITUDE*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MAX_INPLANE_PRINCIPAL"></a>
+
+#### INVARIANT_MAX_INPLANE_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_MAX_INPLANE_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MAX_PRINCIPAL"></a>
+
+#### INVARIANT_MAX_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_MAX_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MID_PRINCIPAL"></a>
+
+#### INVARIANT_MID_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_MID_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MIN_INPLANE_PRINCIPAL"></a>
+
+#### INVARIANT_MIN_INPLANE_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_MIN_INPLANE_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MIN_PRINCIPAL"></a>
+
+#### INVARIANT_MIN_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_MIN_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_MISES"></a>
+
+#### INVARIANT_MISES *= \_optiSLang_Actors.Invariant.INVARIANT_MISES*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_OUTOFPLANE_PRINCIPAL"></a>
+
+#### INVARIANT_OUTOFPLANE_PRINCIPAL *= \_optiSLang_Actors.Invariant.INVARIANT_OUTOFPLANE_PRINCIPAL*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_PRESS"></a>
+
+#### INVARIANT_PRESS *= \_optiSLang_Actors.Invariant.INVARIANT_PRESS*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_TRESCA"></a>
+
+#### INVARIANT_TRESCA *= \_optiSLang_Actors.Invariant.INVARIANT_TRESCA*
+
+<a id="optiSLang_Actors.Invariant.INVARIANT_UNDEFINED"></a>
+
+#### INVARIANT_UNDEFINED *= \_optiSLang_Actors.Invariant.INVARIANT_UNDEFINED*
 
 <a id="optiSLang_Actors.LSDYNAInputActor"></a>
 
 ## *class* \_optiSLang_Actors.LSDYNAInputActor
 
-- <a id="optiSLang_Actors.LSDYNAInputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.LSDYNAInputActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.LSDYNAInputActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
+<a id="optiSLang_Actors.LSDYNAInputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.LSDYNAInputActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.LSDYNAInputActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
 
 <a id="optiSLang_Actors.MOPActor"></a>
 
 ## *class* \_optiSLang_Actors.MOPActor
 
-- <a id="optiSLang_Actors.MOPActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.MOPActor.advanced_settings"></a>*property* `advanced_settings`<br>
-  MOP advanced settings. Assigning to this property will activate advanced mode.
-- <a id="optiSLang_Actors.MOPActor.model_complexity"></a>*property* `model_complexity`
-- <a id="optiSLang_Actors.MOPActor.mop_data"></a>*property* `mop_data`<br>
-  MOP parameter and response handling.
-- <a id="optiSLang_Actors.MOPActor.num_responses_parallel"></a>*property* `num_responses_parallel`
-- <a id="optiSLang_Actors.MOPActor.pmop_settings"></a>*property* `pmop_settings`
-- <a id="optiSLang_Actors.MOPActor.settings_type"></a>*property* `settings_type`
-- <a id="optiSLang_Actors.MOPActor.variable_reduction"></a>*property* `variable_reduction`
+<a id="optiSLang_Actors.MOPActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.MOPActor.advanced_settings"></a>
+
+#### *property* advanced_settings
+
+MOP advanced settings. Assigning to this property will activate advanced mode.
+
+<a id="optiSLang_Actors.MOPActor.model_complexity"></a>
+
+#### *property* model_complexity
+
+<a id="optiSLang_Actors.MOPActor.mop_data"></a>
+
+#### *property* mop_data
+
+MOP parameter and response handling.
+
+<a id="optiSLang_Actors.MOPActor.num_responses_parallel"></a>
+
+#### *property* num_responses_parallel
+
+<a id="optiSLang_Actors.MOPActor.pmop_settings"></a>
+
+#### *property* pmop_settings
+
+<a id="optiSLang_Actors.MOPActor.settings_type"></a>
+
+#### *property* settings_type
+
+<a id="optiSLang_Actors.MOPActor.variable_reduction"></a>
+
+#### *property* variable_reduction
 
 <a id="optiSLang_Actors.MOPAdvancedSettings"></a>
 
 ## *class* \_optiSLang_Actors.MOPAdvancedSettings
 
-- <a id="optiSLang_Actors.MOPAdvancedSettings.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.adapt_bounds"></a>*property* `adapt_bounds`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.adapt_bounds_safety_factor"></a>*property* `adapt_bounds_safety_factor`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.custom_surrogates"></a>*property* `custom_surrogates`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.cv_values_suffix"></a>*property* `cv_values_suffix`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.log_file_path"></a>*property* `log_file_path`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.log_in_file"></a>*property* `log_in_file`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.log_in_project_log"></a>*property* `log_in_project_log`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.num_parallel"></a>*property* `num_parallel`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.use_incomplete"></a>*property* `use_incomplete`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.write_cv_values"></a>*property* `write_cv_values`
-- <a id="optiSLang_Actors.MOPAdvancedSettings.write_function_string"></a>*property* `write_function_string`
+<a id="optiSLang_Actors.MOPAdvancedSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.adapt_bounds"></a>
+
+#### *property* adapt_bounds
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.adapt_bounds_safety_factor"></a>
+
+#### *property* adapt_bounds_safety_factor
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.custom_surrogates"></a>
+
+#### *property* custom_surrogates
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.cv_values_suffix"></a>
+
+#### *property* cv_values_suffix
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.log_file_path"></a>
+
+#### *property* log_file_path
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.log_in_file"></a>
+
+#### *property* log_in_file
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.log_in_project_log"></a>
+
+#### *property* log_in_project_log
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.num_parallel"></a>
+
+#### *property* num_parallel
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.use_incomplete"></a>
+
+#### *property* use_incomplete
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.write_cv_values"></a>
+
+#### *property* write_cv_values
+
+<a id="optiSLang_Actors.MOPAdvancedSettings.write_function_string"></a>
+
+#### *property* write_function_string
 
 <a id="optiSLang_Actors.MOPAlgoSettings"></a>
 
 ## *class* \_optiSLang_Actors.MOPAlgoSettings
 
-- <a id="optiSLang_Actors.MOPAlgoSettings.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_ascmo"></a>*property* `coefficient_factor_ascmo`<br>
-  Factor for minimum number of support points.
-- <a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_kriging"></a>*property* `coefficient_factor_kriging`<br>
-  Factor for minimum number of support points.
-- <a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_mls"></a>*property* `coefficient_factor_mls`<br>
-  Factor for minimum number of support points.
-- <a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_polynomial"></a>*property* `coefficient_factor_polynomial`<br>
-  Factor for minimum number of support points.
-- <a id="optiSLang_Actors.MOPAlgoSettings.correlation_input_check"></a>*property* `correlation_input_check`<br>
-  Minimum correlation value for check.
-- <a id="optiSLang_Actors.MOPAlgoSettings.get_custom_surrogate_usage"></a>`get_custom_surrogate_usage() → dict`<br>
-  Return a dictionary of available custom surrogates and their usage state.
-- <a id="optiSLang_Actors.MOPAlgoSettings.limits"></a>*property* `limits`<br>
-  Set limits as tuple of two values.
-- <a id="optiSLang_Actors.MOPAlgoSettings.max_cod"></a>*property* `max_cod`<br>
-  Maximum CoD step.
-- <a id="optiSLang_Actors.MOPAlgoSettings.max_coi"></a>*property* `max_coi`<br>
-  Maximum CoI step.
-- <a id="optiSLang_Actors.MOPAlgoSettings.max_input_correlation"></a>*property* `max_input_correlation`<br>
-  Maximum correlation (multi-dimensional) for inputs.
-- <a id="optiSLang_Actors.MOPAlgoSettings.max_order_mls"></a>*property* `max_order_mls`<br>
-  Maximum basis order.
-- <a id="optiSLang_Actors.MOPAlgoSettings.max_order_polynomial"></a>*property* `max_order_polynomial`<br>
-  Maximum basis order.
-- <a id="optiSLang_Actors.MOPAlgoSettings.min_input_correlation"></a>*property* `min_input_correlation`<br>
-  Minimum correlation (threshold) for inputs.
-- <a id="optiSLang_Actors.MOPAlgoSettings.min_significance"></a>*property* `min_significance`<br>
-  Limit for significance filter.
-- <a id="optiSLang_Actors.MOPAlgoSettings.num_correlation_steps"></a>*property* `num_correlation_steps`<br>
-  Number of steps for correlation filter combinations
-- <a id="optiSLang_Actors.MOPAlgoSettings.set_custom_surrogate"></a>`set_custom_surrogate(name: str, use: bool)`<br>
-  Set use of custom surrogate by name. Add the surrogate if not yet present.
-- <a id="optiSLang_Actors.MOPAlgoSettings.set_defaults"></a>`set_defaults()`<br>
-  Reset settings to default values.
-- <a id="optiSLang_Actors.MOPAlgoSettings.step_cod"></a>*property* `step_cod`<br>
-  Step size for CoD filter.
-- <a id="optiSLang_Actors.MOPAlgoSettings.step_coi"></a>*property* `step_coi`<br>
-  Step size for CoI filter.
-- <a id="optiSLang_Actors.MOPAlgoSettings.step_significance"></a>*property* `step_significance`<br>
-  Steps for filter reduction.
-- <a id="optiSLang_Actors.MOPAlgoSettings.testing_type"></a>*property* `testing_type`
-- <a id="optiSLang_Actors.MOPAlgoSettings.tolerance_cop_model"></a>*property* `tolerance_cop_model`
-- <a id="optiSLang_Actors.MOPAlgoSettings.tolerance_cop_variables"></a>*property* `tolerance_cop_variables`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_adjusted_cod"></a>*property* `use_adjusted_cod`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_adjusted_cop"></a>*property* `use_adjusted_cop`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_anisotropic_kernel_kriging"></a>*property* `use_anisotropic_kernel_kriging`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_anisotropic_kernel_mls"></a>*property* `use_anisotropic_kernel_mls`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_ascmo"></a>*property* `use_ascmo`<br>
-  Use ASCMO.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_boxcox"></a>*property* `use_boxcox`<br>
-  Use Box Cox.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_cod_filter"></a>*property* `use_cod_filter`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_coi_filter"></a>*property* `use_coi_filter`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_correlation_filter"></a>*property* `use_correlation_filter`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_input_correlation_filter"></a>*property* `use_input_correlation_filter`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_interpolation"></a>*property* `use_interpolation`<br>
-  Use interpolation.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_kriging"></a>*property* `use_kriging`<br>
-  Use Kriging.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_limits"></a>*property* `use_limits`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_mls"></a>*property* `use_mls`<br>
-  Use moving least squares.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_polynomials"></a>*property* `use_polynomials`<br>
-  Use polynomials.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_significance_filter"></a>*property* `use_significance_filter`
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_spearman"></a>*property* `use_spearman`<br>
-  Use Spearman.
-- <a id="optiSLang_Actors.MOPAlgoSettings.use_uniform_resample"></a>*property* `use_uniform_resample`
+<a id="optiSLang_Actors.MOPAlgoSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_ascmo"></a>
+
+#### *property* coefficient_factor_ascmo
+
+Factor for minimum number of support points.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_kriging"></a>
+
+#### *property* coefficient_factor_kriging
+
+Factor for minimum number of support points.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_mls"></a>
+
+#### *property* coefficient_factor_mls
+
+Factor for minimum number of support points.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.coefficient_factor_polynomial"></a>
+
+#### *property* coefficient_factor_polynomial
+
+Factor for minimum number of support points.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.correlation_input_check"></a>
+
+#### *property* correlation_input_check
+
+Minimum correlation value for check.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.get_custom_surrogate_usage"></a>
+
+#### get_custom_surrogate_usage() → dict
+
+Return a dictionary of available custom surrogates and their usage state.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.limits"></a>
+
+#### *property* limits
+
+Set limits as tuple of two values.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.max_cod"></a>
+
+#### *property* max_cod
+
+Maximum CoD step.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.max_coi"></a>
+
+#### *property* max_coi
+
+Maximum CoI step.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.max_input_correlation"></a>
+
+#### *property* max_input_correlation
+
+Maximum correlation (multi-dimensional) for inputs.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.max_order_mls"></a>
+
+#### *property* max_order_mls
+
+Maximum basis order.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.max_order_polynomial"></a>
+
+#### *property* max_order_polynomial
+
+Maximum basis order.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.min_input_correlation"></a>
+
+#### *property* min_input_correlation
+
+Minimum correlation (threshold) for inputs.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.min_significance"></a>
+
+#### *property* min_significance
+
+Limit for significance filter.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.num_correlation_steps"></a>
+
+#### *property* num_correlation_steps
+
+Number of steps for correlation filter combinations
+
+<a id="optiSLang_Actors.MOPAlgoSettings.set_custom_surrogate"></a>
+
+#### set_custom_surrogate(name: str, use: bool)
+
+Set use of custom surrogate by name. Add the surrogate if not yet present.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.set_defaults"></a>
+
+#### set_defaults()
+
+Reset settings to default values.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.step_cod"></a>
+
+#### *property* step_cod
+
+Step size for CoD filter.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.step_coi"></a>
+
+#### *property* step_coi
+
+Step size for CoI filter.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.step_significance"></a>
+
+#### *property* step_significance
+
+Steps for filter reduction.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.testing_type"></a>
+
+#### *property* testing_type
+
+<a id="optiSLang_Actors.MOPAlgoSettings.tolerance_cop_model"></a>
+
+#### *property* tolerance_cop_model
+
+<a id="optiSLang_Actors.MOPAlgoSettings.tolerance_cop_variables"></a>
+
+#### *property* tolerance_cop_variables
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_adjusted_cod"></a>
+
+#### *property* use_adjusted_cod
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_adjusted_cop"></a>
+
+#### *property* use_adjusted_cop
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_anisotropic_kernel_kriging"></a>
+
+#### *property* use_anisotropic_kernel_kriging
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_anisotropic_kernel_mls"></a>
+
+#### *property* use_anisotropic_kernel_mls
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_ascmo"></a>
+
+#### *property* use_ascmo
+
+Use ASCMO.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_boxcox"></a>
+
+#### *property* use_boxcox
+
+Use Box Cox.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_cod_filter"></a>
+
+#### *property* use_cod_filter
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_coi_filter"></a>
+
+#### *property* use_coi_filter
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_correlation_filter"></a>
+
+#### *property* use_correlation_filter
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_input_correlation_filter"></a>
+
+#### *property* use_input_correlation_filter
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_interpolation"></a>
+
+#### *property* use_interpolation
+
+Use interpolation.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_kriging"></a>
+
+#### *property* use_kriging
+
+Use Kriging.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_limits"></a>
+
+#### *property* use_limits
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_mls"></a>
+
+#### *property* use_mls
+
+Use moving least squares.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_polynomials"></a>
+
+#### *property* use_polynomials
+
+Use polynomials.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_significance_filter"></a>
+
+#### *property* use_significance_filter
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_spearman"></a>
+
+#### *property* use_spearman
+
+Use Spearman.
+
+<a id="optiSLang_Actors.MOPAlgoSettings.use_uniform_resample"></a>
+
+#### *property* use_uniform_resample
 
 <a id="optiSLang_Actors.MOPAutomaticSettings"></a>
 
 ## *class* \_optiSLang_Actors.MOPAutomaticSettings
 
-- <a id="optiSLang_Actors.MOPAutomaticSettings.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.MOPAutomaticSettings.model_complexity"></a>*property* `model_complexity`
-- <a id="optiSLang_Actors.MOPAutomaticSettings.num_parallel"></a>*property* `num_parallel`
-- <a id="optiSLang_Actors.MOPAutomaticSettings.variables_reduction"></a>*property* `variables_reduction`
+<a id="optiSLang_Actors.MOPAutomaticSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.MOPAutomaticSettings.model_complexity"></a>
+
+#### *property* model_complexity
+
+<a id="optiSLang_Actors.MOPAutomaticSettings.num_parallel"></a>
+
+#### *property* num_parallel
+
+<a id="optiSLang_Actors.MOPAutomaticSettings.variables_reduction"></a>
+
+#### *property* variables_reduction
 
 <a id="optiSLang_Actors.MOPData"></a>
 
@@ -1734,63 +4821,169 @@ Reliability actor that utilizes Importance Sampling Using the Design Point.
 
 Manages parameter importance and response usage for MOP.
 
-- <a id="optiSLang_Actors.MOPData.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.MOPData.parameter_importance"></a>*property* `parameter_importance`<br>
-  Set importance per parameter. The provided map may be partial, i.e. contain only the parameters that should be changed. The integer values 0 to 2 correspond to “Unimportant”, “Selectable” and “Mandatory”.
-- <a id="optiSLang_Actors.MOPData.response_usage"></a>*property* `response_usage`<br>
-  Set usage per response. Provided map may be partial.
+<a id="optiSLang_Actors.MOPData.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.MOPData.parameter_importance"></a>
+
+#### *property* parameter_importance
+
+Set importance per parameter. The provided map may be partial, i.e. contain only the parameters that should be changed. The integer values 0 to 2 correspond to “Unimportant”, “Selectable” and “Mandatory”.
+
+<a id="optiSLang_Actors.MOPData.response_usage"></a>
+
+#### *property* response_usage
+
+Set usage per response. Provided map may be partial.
 
 <a id="optiSLang_Actors.MOPSolverActor"></a>
 
 ## *class* \_optiSLang_Actors.MOPSolverActor
 
-- <a id="optiSLang_Actors.MOPSolverActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.MOPSolverActor.add_input"></a>`add_input(location: MOPSolverLocation)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.MOPSolverActor.add_internal_variable"></a>`add_internal_variable(location: MOPSolverLocation)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.MOPSolverActor.add_output"></a>`add_output(location: MOPSolverLocation)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.MOPSolverActor.add_parameter"></a>`add_parameter(location: MOPSolverLocation)`<br>
-  Assign location to a parameter.
-- <a id="optiSLang_Actors.MOPSolverActor.add_response"></a>`add_response(location: MOPSolverLocation)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.MOPSolverActor.boundary_handling"></a>*property* `boundary_handling`
-- <a id="optiSLang_Actors.MOPSolverActor.enable_multi_designs"></a>*property* `enable_multi_designs`
-- <a id="optiSLang_Actors.MOPSolverActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.MOPSolverActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.MOPSolverActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.MOPSolverActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.MOPSolverActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.MOPSolverActor.initialize_solver"></a>`initialize_solver(arg2: Path) → bool`
-- `initialize_solver(arg2: ProvidedPath) → bool`
-- <a id="optiSLang_Actors.MOPSolverActor.mdb_path"></a>*property* `mdb_path`
-- <a id="optiSLang_Actors.MOPSolverActor.multi_design_num"></a>*property* `multi_design_num`
-- <a id="optiSLang_Actors.MOPSolverActor.register_available_parameters"></a>`register_available_parameters()`
-- <a id="optiSLang_Actors.MOPSolverActor.register_available_responses"></a>`register_available_responses()`
+<a id="optiSLang_Actors.MOPSolverActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.MOPSolverActor.add_input"></a>
+
+#### add_input(location: MOPSolverLocation)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.MOPSolverActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: MOPSolverLocation)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.MOPSolverActor.add_output"></a>
+
+#### add_output(location: MOPSolverLocation)
+
+#### add_output(derived_variable: DerivedLocation)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.MOPSolverActor.add_parameter"></a>
+
+#### add_parameter(location: MOPSolverLocation)
+
+Assign location to a parameter.
+
+<a id="optiSLang_Actors.MOPSolverActor.add_response"></a>
+
+#### add_response(location: MOPSolverLocation)
+
+#### add_response(derived_variable: DerivedLocation)
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.MOPSolverActor.boundary_handling"></a>
+
+#### *property* boundary_handling
+
+<a id="optiSLang_Actors.MOPSolverActor.enable_multi_designs"></a>
+
+#### *property* enable_multi_designs
+
+<a id="optiSLang_Actors.MOPSolverActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.MOPSolverActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.MOPSolverActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.MOPSolverActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.MOPSolverActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.MOPSolverActor.initialize_solver"></a>
+
+#### initialize_solver(arg2: Path) → bool
+
+#### initialize_solver(arg2: ProvidedPath) → bool
+
+<a id="optiSLang_Actors.MOPSolverActor.mdb_path"></a>
+
+#### *property* mdb_path
+
+<a id="optiSLang_Actors.MOPSolverActor.multi_design_num"></a>
+
+#### *property* multi_design_num
+
+<a id="optiSLang_Actors.MOPSolverActor.register_available_parameters"></a>
+
+#### register_available_parameters()
+
+<a id="optiSLang_Actors.MOPSolverActor.register_available_responses"></a>
+
+#### register_available_responses()
 
 <a id="optiSLang_Actors.MOPSolverLocation"></a>
 
 ## *class* \_optiSLang_Actors.MOPSolverLocation
 
-- <a id="optiSLang_Actors.MOPSolverLocation.__init__"></a>`__init__()`<br>
-  [1] Create a MOPSolverLocation instance. [2] Create a MOPSolverLocation instance.
-- `__init__(id_base: str, direction: [IntegrationDirection](#optiSLang_Actors.IntegrationDirection), value_type: [MOPSolverLocationValueType](#optiSLang_Actors.MOPSolverLocationValueType), id_suffix: str)`
-- `__init__(id: str, direction: [IntegrationDirection](#optiSLang_Actors.IntegrationDirection), quality_usage_suffix_vector: object)`
-- <a id="optiSLang_Actors.MOPSolverLocation.direction"></a>*property* `direction`
-- <a id="optiSLang_Actors.MOPSolverLocation.id"></a>*property* `id`
-- <a id="optiSLang_Actors.MOPSolverLocation.id_base"></a>*property* `id_base`
-- <a id="optiSLang_Actors.MOPSolverLocation.id_suffix"></a>*property* `id_suffix`
-- <a id="optiSLang_Actors.MOPSolverLocation.value_type"></a>*property* `value_type`
+<a id="optiSLang_Actors.MOPSolverLocation.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(id_base: str, direction: [IntegrationDirection](#optiSLang_Actors.IntegrationDirection), value_type: [MOPSolverLocationValueType](#optiSLang_Actors.MOPSolverLocationValueType), id_suffix: str)
+
+#### \_\_init_\_(id: str, direction: [IntegrationDirection](#optiSLang_Actors.IntegrationDirection), quality_usage_suffix_vector: object)
+
+[1] Create a MOPSolverLocation instance.
+
+[2] Create a MOPSolverLocation instance.
+
+<a id="optiSLang_Actors.MOPSolverLocation.direction"></a>
+
+#### *property* direction
+
+<a id="optiSLang_Actors.MOPSolverLocation.id"></a>
+
+#### *property* id
+
+<a id="optiSLang_Actors.MOPSolverLocation.id_base"></a>
+
+#### *property* id_base
+
+<a id="optiSLang_Actors.MOPSolverLocation.id_suffix"></a>
+
+#### *property* id_suffix
+
+<a id="optiSLang_Actors.MOPSolverLocation.value_type"></a>
+
+#### *property* value_type
 
 <a id="optiSLang_Actors.MOPSolverLocationValueType"></a>
 
@@ -1798,38 +4991,78 @@ Manages parameter importance and response usage for MOP.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ABSERROR"></a>`MOP_SOLVER_LOCATION_TYPE_ABSERROR *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ABSERROR*`
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_COP"></a>`MOP_SOLVER_LOCATION_TYPE_COP *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_COP*`
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_DENSITY"></a>`MOP_SOLVER_LOCATION_TYPE_DENSITY *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_DENSITY*`
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ERROR"></a>`MOP_SOLVER_LOCATION_TYPE_ERROR *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ERROR*`
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_RMSE"></a>`MOP_SOLVER_LOCATION_TYPE_RMSE *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_RMSE*`
-- <a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_VALUE"></a>`MOP_SOLVER_LOCATION_TYPE_VALUE *= _optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_VALUE*`
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ABSERROR"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_ABSERROR *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ABSERROR*
+
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_COP"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_COP *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_COP*
+
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_DENSITY"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_DENSITY *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_DENSITY*
+
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ERROR"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_ERROR *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_ERROR*
+
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_RMSE"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_RMSE *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_RMSE*
+
+<a id="optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_VALUE"></a>
+
+#### MOP_SOLVER_LOCATION_TYPE_VALUE *= \_optiSLang_Actors.MOPSolverLocationValueType.MOP_SOLVER_LOCATION_TYPE_VALUE*
 
 <a id="optiSLang_Actors.MatlabActor"></a>
 
 ## *class* \_optiSLang_Actors.MatlabActor
 
-- <a id="optiSLang_Actors.MatlabActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.MatlabActor.get_available_versions"></a>`get_available_versions() → list`<br>
-  Return a list of tuples containing the displayed name and the value to set at the version property.
-- <a id="optiSLang_Actors.MatlabActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.MatlabActor.use_batch_mode"></a>*property* `use_batch_mode`
+<a id="optiSLang_Actors.MatlabActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.MatlabActor.get_available_versions"></a>
+
+#### get_available_versions() → list
+
+Return a list of tuples containing the displayed name and the value to set at the version property.
+
+<a id="optiSLang_Actors.MatlabActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.MatlabActor.use_batch_mode"></a>
+
+#### *property* use_batch_mode
 
 <a id="optiSLang_Actors.MemeticActor"></a>
 
 ## *class* \_optiSLang_Actors.MemeticActor
 
-- <a id="optiSLang_Actors.MemeticActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.MemeticActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.MemeticActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.MemeticActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.MonitoringActor"></a>
 
 ## *class* \_optiSLang_Actors.MonitoringActor
 
-- <a id="optiSLang_Actors.MonitoringActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="optiSLang_Actors.MonitoringActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="optiSLang_Actors.MonitoringMode"></a>
 
@@ -1837,11 +5070,25 @@ Manages parameter importance and response usage for MOP.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.MonitoringMode.APPROXIMATION"></a>`APPROXIMATION *= _optiSLang_Actors.MonitoringMode.APPROXIMATION*`
-- <a id="optiSLang_Actors.MonitoringMode.AUTOMATIC"></a>`AUTOMATIC *= _optiSLang_Actors.MonitoringMode.AUTOMATIC*`
-- <a id="optiSLang_Actors.MonitoringMode.OPTIMIZATION"></a>`OPTIMIZATION *= _optiSLang_Actors.MonitoringMode.OPTIMIZATION*`
-- <a id="optiSLang_Actors.MonitoringMode.RELIABILITY"></a>`RELIABILITY *= _optiSLang_Actors.MonitoringMode.RELIABILITY*`
-- <a id="optiSLang_Actors.MonitoringMode.STATISTICS"></a>`STATISTICS *= _optiSLang_Actors.MonitoringMode.STATISTICS*`
+<a id="optiSLang_Actors.MonitoringMode.APPROXIMATION"></a>
+
+#### APPROXIMATION *= \_optiSLang_Actors.MonitoringMode.APPROXIMATION*
+
+<a id="optiSLang_Actors.MonitoringMode.AUTOMATIC"></a>
+
+#### AUTOMATIC *= \_optiSLang_Actors.MonitoringMode.AUTOMATIC*
+
+<a id="optiSLang_Actors.MonitoringMode.OPTIMIZATION"></a>
+
+#### OPTIMIZATION *= \_optiSLang_Actors.MonitoringMode.OPTIMIZATION*
+
+<a id="optiSLang_Actors.MonitoringMode.RELIABILITY"></a>
+
+#### RELIABILITY *= \_optiSLang_Actors.MonitoringMode.RELIABILITY*
+
+<a id="optiSLang_Actors.MonitoringMode.STATISTICS"></a>
+
+#### STATISTICS *= \_optiSLang_Actors.MonitoringMode.STATISTICS*
 
 <a id="optiSLang_Actors.MonteCarloActor"></a>
 
@@ -1849,50 +5096,91 @@ Manages parameter importance and response usage for MOP.
 
 Reliability actor using Monte Carlo methods.
 
-- <a id="optiSLang_Actors.MonteCarloActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.MonteCarloActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.MonteCarloActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.MonteCarloActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.NLPQLPActor"></a>
 
 ## *class* \_optiSLang_Actors.NLPQLPActor
 
-- <a id="optiSLang_Actors.NLPQLPActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.NLPQLPActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.NLPQLPActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.NLPQLPActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.NOA2Actor"></a>
 
 ## *class* \_optiSLang_Actors.NOA2Actor
 
-- <a id="optiSLang_Actors.NOA2Actor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.NOA2Actor.algorithm_type"></a>*property* `algorithm_type`
-- <a id="optiSLang_Actors.NOA2Actor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.NOA2Actor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.NOA2Actor.algorithm_type"></a>
+
+#### *property* algorithm_type
+
+<a id="optiSLang_Actors.NOA2Actor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.NOAActor"></a>
 
 ## *class* \_optiSLang_Actors.NOAActor
 
-- <a id="optiSLang_Actors.NOAActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.NOAActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.NOAActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.NOAActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.OctaveActor"></a>
 
 ## *class* \_optiSLang_Actors.OctaveActor
 
-- <a id="optiSLang_Actors.OctaveActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.OctaveActor.max_parallel"></a>*property* `max_parallel`
+<a id="optiSLang_Actors.OctaveActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.OctaveActor.max_parallel"></a>
+
+#### *property* max_parallel
 
 <a id="optiSLang_Actors.OptimizationBaseActor"></a>
 
 ## *class* \_optiSLang_Actors.OptimizationBaseActor
 
-- <a id="optiSLang_Actors.OptimizationBaseActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.OptimizationBaseActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.OptimizationBaseActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.OptimizationBaseActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.OutputFileType"></a>
 
@@ -1900,37 +5188,57 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.OutputFileType.NUM_TYPES"></a>`NUM_TYPES *= _optiSLang_Actors.OutputFileType.NUM_TYPES*`
-- <a id="optiSLang_Actors.OutputFileType.ROBUSTNESS_OUTPUTFILE"></a>`ROBUSTNESS_OUTPUTFILE *= _optiSLang_Actors.OutputFileType.ROBUSTNESS_OUTPUTFILE*`
-- <a id="optiSLang_Actors.OutputFileType.SENSITIVITY_OUTPUTFILE"></a>`SENSITIVITY_OUTPUTFILE *= _optiSLang_Actors.OutputFileType.SENSITIVITY_OUTPUTFILE*`
+<a id="optiSLang_Actors.OutputFileType.NUM_TYPES"></a>
+
+#### NUM_TYPES *= \_optiSLang_Actors.OutputFileType.NUM_TYPES*
+
+<a id="optiSLang_Actors.OutputFileType.ROBUSTNESS_OUTPUTFILE"></a>
+
+#### ROBUSTNESS_OUTPUTFILE *= \_optiSLang_Actors.OutputFileType.ROBUSTNESS_OUTPUTFILE*
+
+<a id="optiSLang_Actors.OutputFileType.SENSITIVITY_OUTPUTFILE"></a>
+
+#### SENSITIVITY_OUTPUTFILE *= \_optiSLang_Actors.OutputFileType.SENSITIVITY_OUTPUTFILE*
 
 <a id="optiSLang_Actors.PDMActor"></a>
 
 ## *class* \_optiSLang_Actors.PDMActor
 
-- <a id="optiSLang_Actors.PDMActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PDMActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.PDMReceiveActor"></a>
 
 ## *class* \_optiSLang_Actors.PDMReceiveActor
 
-- <a id="optiSLang_Actors.PDMReceiveActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PDMReceiveActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.PDMSendActor"></a>
 
 ## *class* \_optiSLang_Actors.PDMSendActor
 
-- <a id="optiSLang_Actors.PDMSendActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PDMSendActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.PSOActor"></a>
 
 ## *class* \_optiSLang_Actors.PSOActor
 
-- <a id="optiSLang_Actors.PSOActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PSOActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ParameterMergingMode"></a>
 
@@ -1938,58 +5246,157 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.ParameterMergingMode.MERGE_FROM_SLOT"></a>`MERGE_FROM_SLOT *= _optiSLang_Actors.ParameterMergingMode.MERGE_FROM_SLOT*`
-- <a id="optiSLang_Actors.ParameterMergingMode.PREFER_PROPERTY"></a>`PREFER_PROPERTY *= _optiSLang_Actors.ParameterMergingMode.PREFER_PROPERTY*`
-- <a id="optiSLang_Actors.ParameterMergingMode.PREFER_SLOT"></a>`PREFER_SLOT *= _optiSLang_Actors.ParameterMergingMode.PREFER_SLOT*`
+<a id="optiSLang_Actors.ParameterMergingMode.MERGE_FROM_SLOT"></a>
+
+#### MERGE_FROM_SLOT *= \_optiSLang_Actors.ParameterMergingMode.MERGE_FROM_SLOT*
+
+<a id="optiSLang_Actors.ParameterMergingMode.PREFER_PROPERTY"></a>
+
+#### PREFER_PROPERTY *= \_optiSLang_Actors.ParameterMergingMode.PREFER_PROPERTY*
+
+<a id="optiSLang_Actors.ParameterMergingMode.PREFER_SLOT"></a>
+
+#### PREFER_SLOT *= \_optiSLang_Actors.ParameterMergingMode.PREFER_SLOT*
 
 <a id="optiSLang_Actors.ParametricSystemActor"></a>
 
 ## *class* \_optiSLang_Actors.ParametricSystemActor
 
-- <a id="optiSLang_Actors.ParametricSystemActor.CleanupResponses"></a>`CleanupResponses()`
-- <a id="optiSLang_Actors.ParametricSystemActor.CollectParameters"></a>`CollectParameters()`
-- <a id="optiSLang_Actors.ParametricSystemActor.GetDesignCounts"></a>`GetDesignCounts() → [DesignCounts](#optiSLang_Actors.DesignCounts)`
-- <a id="optiSLang_Actors.ParametricSystemActor.GetDesigns"></a>`GetDesigns() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)`
-- <a id="optiSLang_Actors.ParametricSystemActor.RemoveAllResponses"></a>`RemoveAllResponses(, arg2: bool])`
-- <a id="optiSLang_Actors.ParametricSystemActor.RemoveResponse"></a>`RemoveResponse(arg2: str)`
-- <a id="optiSLang_Actors.ParametricSystemActor.SetDesigns"></a>`SetDesigns(arg2: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer))`
-- <a id="optiSLang_Actors.ParametricSystemActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ParametricSystemActor.criteria"></a>*property* `criteria`
-- <a id="optiSLang_Actors.ParametricSystemActor.design_point_tolerance"></a>*property* `design_point_tolerance`
-- <a id="optiSLang_Actors.ParametricSystemActor.get_result_file_path"></a>`get_result_file_path(, hid: HID]) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)`<br>
-  Path to the OMDB file by HId. The returned path is relative to the project working directory and is empty if the OMDB file does not exist. For top-level systems the argument may be omitted.
-- <a id="optiSLang_Actors.ParametricSystemActor.manual_seed_value"></a>*property* `manual_seed_value`
-- <a id="optiSLang_Actors.ParametricSystemActor.parameter_manager"></a>*property* `parameter_manager`
-- <a id="optiSLang_Actors.ParametricSystemActor.parameter_merging_mode"></a>*property* `parameter_merging_mode`
-- <a id="optiSLang_Actors.ParametricSystemActor.prefer_criteria_from_slot"></a>*property* `prefer_criteria_from_slot`
-- <a id="optiSLang_Actors.ParametricSystemActor.register_avz_files"></a>*property* `register_avz_files`
-- <a id="optiSLang_Actors.ParametricSystemActor.register_cax_files"></a>*property* `register_cax_files`
-- <a id="optiSLang_Actors.ParametricSystemActor.register_images"></a>*property* `register_images`
-- <a id="optiSLang_Actors.ParametricSystemActor.responses"></a>*property* `responses`
-- <a id="optiSLang_Actors.ParametricSystemActor.solve_duplicated"></a>*property* `solve_duplicated`
-- <a id="optiSLang_Actors.ParametricSystemActor.solve_reference"></a>*property* `solve_reference`
-- <a id="optiSLang_Actors.ParametricSystemActor.solve_start_designs_again"></a>*property* `solve_start_designs_again`
-- <a id="optiSLang_Actors.ParametricSystemActor.solve_violated"></a>*property* `solve_violated`
-- <a id="optiSLang_Actors.ParametricSystemActor.start_designs"></a>*property* `start_designs`
-- <a id="optiSLang_Actors.ParametricSystemActor.update_result_file"></a>*property* `update_result_file`
-- <a id="optiSLang_Actors.ParametricSystemActor.use_manual_seed"></a>*property* `use_manual_seed`
-- <a id="optiSLang_Actors.ParametricSystemActor.write_osl3_bin_file_default"></a>*property* `write_osl3_bin_file_default`
+<a id="optiSLang_Actors.ParametricSystemActor.CleanupResponses"></a>
+
+#### CleanupResponses()
+
+<a id="optiSLang_Actors.ParametricSystemActor.CollectParameters"></a>
+
+#### CollectParameters()
+
+<a id="optiSLang_Actors.ParametricSystemActor.GetDesignCounts"></a>
+
+#### GetDesignCounts() → [DesignCounts](#optiSLang_Actors.DesignCounts)
+
+<a id="optiSLang_Actors.ParametricSystemActor.GetDesigns"></a>
+
+#### GetDesigns() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
+
+<a id="optiSLang_Actors.ParametricSystemActor.RemoveAllResponses"></a>
+
+#### RemoveAllResponses(, arg2: bool])
+
+<a id="optiSLang_Actors.ParametricSystemActor.RemoveResponse"></a>
+
+#### RemoveResponse(arg2: str)
+
+<a id="optiSLang_Actors.ParametricSystemActor.SetDesigns"></a>
+
+#### SetDesigns(arg2: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer))
+
+<a id="optiSLang_Actors.ParametricSystemActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ParametricSystemActor.criteria"></a>
+
+#### *property* criteria
+
+<a id="optiSLang_Actors.ParametricSystemActor.design_point_tolerance"></a>
+
+#### *property* design_point_tolerance
+
+<a id="optiSLang_Actors.ParametricSystemActor.get_result_file_path"></a>
+
+#### get_result_file_path(, hid: HID]) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
+
+Path to the OMDB file by HId. The returned path is relative to the project working directory and is empty if the OMDB file does not exist. For top-level systems the argument may be omitted.
+
+<a id="optiSLang_Actors.ParametricSystemActor.manual_seed_value"></a>
+
+#### *property* manual_seed_value
+
+<a id="optiSLang_Actors.ParametricSystemActor.parameter_manager"></a>
+
+#### *property* parameter_manager
+
+<a id="optiSLang_Actors.ParametricSystemActor.parameter_merging_mode"></a>
+
+#### *property* parameter_merging_mode
+
+<a id="optiSLang_Actors.ParametricSystemActor.prefer_criteria_from_slot"></a>
+
+#### *property* prefer_criteria_from_slot
+
+<a id="optiSLang_Actors.ParametricSystemActor.register_avz_files"></a>
+
+#### *property* register_avz_files
+
+<a id="optiSLang_Actors.ParametricSystemActor.register_cax_files"></a>
+
+#### *property* register_cax_files
+
+<a id="optiSLang_Actors.ParametricSystemActor.register_images"></a>
+
+#### *property* register_images
+
+<a id="optiSLang_Actors.ParametricSystemActor.responses"></a>
+
+#### *property* responses
+
+<a id="optiSLang_Actors.ParametricSystemActor.solve_duplicated"></a>
+
+#### *property* solve_duplicated
+
+<a id="optiSLang_Actors.ParametricSystemActor.solve_reference"></a>
+
+#### *property* solve_reference
+
+<a id="optiSLang_Actors.ParametricSystemActor.solve_start_designs_again"></a>
+
+#### *property* solve_start_designs_again
+
+<a id="optiSLang_Actors.ParametricSystemActor.solve_violated"></a>
+
+#### *property* solve_violated
+
+<a id="optiSLang_Actors.ParametricSystemActor.start_designs"></a>
+
+#### *property* start_designs
+
+<a id="optiSLang_Actors.ParametricSystemActor.update_result_file"></a>
+
+#### *property* update_result_file
+
+<a id="optiSLang_Actors.ParametricSystemActor.use_manual_seed"></a>
+
+#### *property* use_manual_seed
+
+<a id="optiSLang_Actors.ParametricSystemActor.write_osl3_bin_file_default"></a>
+
+#### *property* write_osl3_bin_file_default
 
 <a id="optiSLang_Actors.PathActor"></a>
 
 ## *class* \_optiSLang_Actors.PathActor
 
-- <a id="optiSLang_Actors.PathActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.PathActor.path"></a>*property* `path`
+<a id="optiSLang_Actors.PathActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.PathActor.path"></a>
+
+#### *property* path
 
 <a id="optiSLang_Actors.PerlScriptActor"></a>
 
 ## *class* \_optiSLang_Actors.PerlScriptActor
 
-- <a id="optiSLang_Actors.PerlScriptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PerlScriptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.Position"></a>
 
@@ -1997,42 +5404,131 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.Position.POSITION_CENTROID"></a>`POSITION_CENTROID *= _optiSLang_Actors.Position.POSITION_CENTROID*`
-- <a id="optiSLang_Actors.Position.POSITION_ELEMENT_FACE"></a>`POSITION_ELEMENT_FACE *= _optiSLang_Actors.Position.POSITION_ELEMENT_FACE*`
-- <a id="optiSLang_Actors.Position.POSITION_ELEMENT_FACE_INTEGRATION_POINT"></a>`POSITION_ELEMENT_FACE_INTEGRATION_POINT *= _optiSLang_Actors.Position.POSITION_ELEMENT_FACE_INTEGRATION_POINT*`
-- <a id="optiSLang_Actors.Position.POSITION_ELEMENT_NODAL"></a>`POSITION_ELEMENT_NODAL *= _optiSLang_Actors.Position.POSITION_ELEMENT_NODAL*`
-- <a id="optiSLang_Actors.Position.POSITION_GENERAL_PARTICLE"></a>`POSITION_GENERAL_PARTICLE *= _optiSLang_Actors.Position.POSITION_GENERAL_PARTICLE*`
-- <a id="optiSLang_Actors.Position.POSITION_INTEGRATION_POINT"></a>`POSITION_INTEGRATION_POINT *= _optiSLang_Actors.Position.POSITION_INTEGRATION_POINT*`
-- <a id="optiSLang_Actors.Position.POSITION_NODAL"></a>`POSITION_NODAL *= _optiSLang_Actors.Position.POSITION_NODAL*`
-- <a id="optiSLang_Actors.Position.POSITION_NUM_OUTPUT_POSITION"></a>`POSITION_NUM_OUTPUT_POSITION *= _optiSLang_Actors.Position.POSITION_NUM_OUTPUT_POSITION*`
-- <a id="optiSLang_Actors.Position.POSITION_SURFACE_FACET"></a>`POSITION_SURFACE_FACET *= _optiSLang_Actors.Position.POSITION_SURFACE_FACET*`
-- <a id="optiSLang_Actors.Position.POSITION_SURFACE_INTEGRATION_POINT"></a>`POSITION_SURFACE_INTEGRATION_POINT *= _optiSLang_Actors.Position.POSITION_SURFACE_INTEGRATION_POINT*`
-- <a id="optiSLang_Actors.Position.POSITION_SURFACE_NODAL"></a>`POSITION_SURFACE_NODAL *= _optiSLang_Actors.Position.POSITION_SURFACE_NODAL*`
-- <a id="optiSLang_Actors.Position.POSITION_UNDEFINED"></a>`POSITION_UNDEFINED *= _optiSLang_Actors.Position.POSITION_UNDEFINED*`
-- <a id="optiSLang_Actors.Position.POSITION_WHOLE_ELEMENT"></a>`POSITION_WHOLE_ELEMENT *= _optiSLang_Actors.Position.POSITION_WHOLE_ELEMENT*`
-- <a id="optiSLang_Actors.Position.POSITION_WHOLE_MODEL"></a>`POSITION_WHOLE_MODEL *= _optiSLang_Actors.Position.POSITION_WHOLE_MODEL*`
-- <a id="optiSLang_Actors.Position.POSITION_WHOLE_PART_INSTANCE"></a>`POSITION_WHOLE_PART_INSTANCE *= _optiSLang_Actors.Position.POSITION_WHOLE_PART_INSTANCE*`
-- <a id="optiSLang_Actors.Position.POSITION_WHOLE_REGION"></a>`POSITION_WHOLE_REGION *= _optiSLang_Actors.Position.POSITION_WHOLE_REGION*`
+<a id="optiSLang_Actors.Position.POSITION_CENTROID"></a>
+
+#### POSITION_CENTROID *= \_optiSLang_Actors.Position.POSITION_CENTROID*
+
+<a id="optiSLang_Actors.Position.POSITION_ELEMENT_FACE"></a>
+
+#### POSITION_ELEMENT_FACE *= \_optiSLang_Actors.Position.POSITION_ELEMENT_FACE*
+
+<a id="optiSLang_Actors.Position.POSITION_ELEMENT_FACE_INTEGRATION_POINT"></a>
+
+#### POSITION_ELEMENT_FACE_INTEGRATION_POINT *= \_optiSLang_Actors.Position.POSITION_ELEMENT_FACE_INTEGRATION_POINT*
+
+<a id="optiSLang_Actors.Position.POSITION_ELEMENT_NODAL"></a>
+
+#### POSITION_ELEMENT_NODAL *= \_optiSLang_Actors.Position.POSITION_ELEMENT_NODAL*
+
+<a id="optiSLang_Actors.Position.POSITION_GENERAL_PARTICLE"></a>
+
+#### POSITION_GENERAL_PARTICLE *= \_optiSLang_Actors.Position.POSITION_GENERAL_PARTICLE*
+
+<a id="optiSLang_Actors.Position.POSITION_INTEGRATION_POINT"></a>
+
+#### POSITION_INTEGRATION_POINT *= \_optiSLang_Actors.Position.POSITION_INTEGRATION_POINT*
+
+<a id="optiSLang_Actors.Position.POSITION_NODAL"></a>
+
+#### POSITION_NODAL *= \_optiSLang_Actors.Position.POSITION_NODAL*
+
+<a id="optiSLang_Actors.Position.POSITION_NUM_OUTPUT_POSITION"></a>
+
+#### POSITION_NUM_OUTPUT_POSITION *= \_optiSLang_Actors.Position.POSITION_NUM_OUTPUT_POSITION*
+
+<a id="optiSLang_Actors.Position.POSITION_SURFACE_FACET"></a>
+
+#### POSITION_SURFACE_FACET *= \_optiSLang_Actors.Position.POSITION_SURFACE_FACET*
+
+<a id="optiSLang_Actors.Position.POSITION_SURFACE_INTEGRATION_POINT"></a>
+
+#### POSITION_SURFACE_INTEGRATION_POINT *= \_optiSLang_Actors.Position.POSITION_SURFACE_INTEGRATION_POINT*
+
+<a id="optiSLang_Actors.Position.POSITION_SURFACE_NODAL"></a>
+
+#### POSITION_SURFACE_NODAL *= \_optiSLang_Actors.Position.POSITION_SURFACE_NODAL*
+
+<a id="optiSLang_Actors.Position.POSITION_UNDEFINED"></a>
+
+#### POSITION_UNDEFINED *= \_optiSLang_Actors.Position.POSITION_UNDEFINED*
+
+<a id="optiSLang_Actors.Position.POSITION_WHOLE_ELEMENT"></a>
+
+#### POSITION_WHOLE_ELEMENT *= \_optiSLang_Actors.Position.POSITION_WHOLE_ELEMENT*
+
+<a id="optiSLang_Actors.Position.POSITION_WHOLE_MODEL"></a>
+
+#### POSITION_WHOLE_MODEL *= \_optiSLang_Actors.Position.POSITION_WHOLE_MODEL*
+
+<a id="optiSLang_Actors.Position.POSITION_WHOLE_PART_INSTANCE"></a>
+
+#### POSITION_WHOLE_PART_INSTANCE *= \_optiSLang_Actors.Position.POSITION_WHOLE_PART_INSTANCE*
+
+<a id="optiSLang_Actors.Position.POSITION_WHOLE_REGION"></a>
+
+#### POSITION_WHOLE_REGION *= \_optiSLang_Actors.Position.POSITION_WHOLE_REGION*
 
 <a id="optiSLang_Actors.PostprocessingActor"></a>
 
 ## *class* \_optiSLang_Actors.PostprocessingActor
 
-- <a id="optiSLang_Actors.PostprocessingActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.PostprocessingActor.custom_script_path"></a>*property* `custom_script_path`
-- <a id="optiSLang_Actors.PostprocessingActor.force_classic"></a>*property* `force_classic`
-- <a id="optiSLang_Actors.PostprocessingActor.mdb_path"></a>*property* `mdb_path`
-- <a id="optiSLang_Actors.PostprocessingActor.monitoring_mode"></a>*property* `monitoring_mode`
-- <a id="optiSLang_Actors.PostprocessingActor.pp_mode"></a>*property* `pp_mode`
-- <a id="optiSLang_Actors.PostprocessingActor.show_pp_during_run"></a>*property* `show_pp_during_run`
-- <a id="optiSLang_Actors.PostprocessingActor.show_reduced_pp_when_avaiable"></a>*property* `show_reduced_pp_when_avaiable`
-- <a id="optiSLang_Actors.PostprocessingActor.template_file"></a>*property* `template_file`
-- <a id="optiSLang_Actors.PostprocessingActor.text_import_non_interactive"></a>*property* `text_import_non_interactive`
-- <a id="optiSLang_Actors.PostprocessingActor.text_import_settings_file"></a>*property* `text_import_settings_file`
-- <a id="optiSLang_Actors.PostprocessingActor.use_custom_script"></a>*property* `use_custom_script`
-- <a id="optiSLang_Actors.PostprocessingActor.use_template"></a>*property* `use_template`
-- <a id="optiSLang_Actors.PostprocessingActor.wait_for_pp_to_finish"></a>*property* `wait_for_pp_to_finish`
+<a id="optiSLang_Actors.PostprocessingActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.PostprocessingActor.custom_script_path"></a>
+
+#### *property* custom_script_path
+
+<a id="optiSLang_Actors.PostprocessingActor.force_classic"></a>
+
+#### *property* force_classic
+
+<a id="optiSLang_Actors.PostprocessingActor.mdb_path"></a>
+
+#### *property* mdb_path
+
+<a id="optiSLang_Actors.PostprocessingActor.monitoring_mode"></a>
+
+#### *property* monitoring_mode
+
+<a id="optiSLang_Actors.PostprocessingActor.pp_mode"></a>
+
+#### *property* pp_mode
+
+<a id="optiSLang_Actors.PostprocessingActor.show_pp_during_run"></a>
+
+#### *property* show_pp_during_run
+
+<a id="optiSLang_Actors.PostprocessingActor.show_reduced_pp_when_avaiable"></a>
+
+#### *property* show_reduced_pp_when_avaiable
+
+<a id="optiSLang_Actors.PostprocessingActor.template_file"></a>
+
+#### *property* template_file
+
+<a id="optiSLang_Actors.PostprocessingActor.text_import_non_interactive"></a>
+
+#### *property* text_import_non_interactive
+
+<a id="optiSLang_Actors.PostprocessingActor.text_import_settings_file"></a>
+
+#### *property* text_import_settings_file
+
+<a id="optiSLang_Actors.PostprocessingActor.use_custom_script"></a>
+
+#### *property* use_custom_script
+
+<a id="optiSLang_Actors.PostprocessingActor.use_template"></a>
+
+#### *property* use_template
+
+<a id="optiSLang_Actors.PostprocessingActor.wait_for_pp_to_finish"></a>
+
+#### *property* wait_for_pp_to_finish
 
 <a id="optiSLang_Actors.PostprocessingModePP3"></a>
 
@@ -2040,10 +5536,21 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.PostprocessingModePP3.PP3_APPROXIMATION"></a>`PP3_APPROXIMATION *= _optiSLang_Actors.PostprocessingModePP3.PP3_APPROXIMATION*`
-- <a id="optiSLang_Actors.PostprocessingModePP3.PP3_AUTOMATIC"></a>`PP3_AUTOMATIC *= _optiSLang_Actors.PostprocessingModePP3.PP3_AUTOMATIC*`
-- <a id="optiSLang_Actors.PostprocessingModePP3.PP3_OPTIMIZATION"></a>`PP3_OPTIMIZATION *= _optiSLang_Actors.PostprocessingModePP3.PP3_OPTIMIZATION*`
-- <a id="optiSLang_Actors.PostprocessingModePP3.PP3_STATISTICS"></a>`PP3_STATISTICS *= _optiSLang_Actors.PostprocessingModePP3.PP3_STATISTICS*`
+<a id="optiSLang_Actors.PostprocessingModePP3.PP3_APPROXIMATION"></a>
+
+#### PP3_APPROXIMATION *= \_optiSLang_Actors.PostprocessingModePP3.PP3_APPROXIMATION*
+
+<a id="optiSLang_Actors.PostprocessingModePP3.PP3_AUTOMATIC"></a>
+
+#### PP3_AUTOMATIC *= \_optiSLang_Actors.PostprocessingModePP3.PP3_AUTOMATIC*
+
+<a id="optiSLang_Actors.PostprocessingModePP3.PP3_OPTIMIZATION"></a>
+
+#### PP3_OPTIMIZATION *= \_optiSLang_Actors.PostprocessingModePP3.PP3_OPTIMIZATION*
+
+<a id="optiSLang_Actors.PostprocessingModePP3.PP3_STATISTICS"></a>
+
+#### PP3_STATISTICS *= \_optiSLang_Actors.PostprocessingModePP3.PP3_STATISTICS*
 
 <a id="optiSLang_Actors.Precision"></a>
 
@@ -2051,234 +5558,653 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.Precision.PRECISION_DOUBLE"></a>`PRECISION_DOUBLE *= _optiSLang_Actors.Precision.PRECISION_DOUBLE*`
-- <a id="optiSLang_Actors.Precision.PRECISION_SINGLE"></a>`PRECISION_SINGLE *= _optiSLang_Actors.Precision.PRECISION_SINGLE*`
+<a id="optiSLang_Actors.Precision.PRECISION_DOUBLE"></a>
+
+#### PRECISION_DOUBLE *= \_optiSLang_Actors.Precision.PRECISION_DOUBLE*
+
+<a id="optiSLang_Actors.Precision.PRECISION_SINGLE"></a>
+
+#### PRECISION_SINGLE *= \_optiSLang_Actors.Precision.PRECISION_SINGLE*
 
 <a id="optiSLang_Actors.ProEInputActor"></a>
 
 ## *class* \_optiSLang_Actors.ProEInputActor
 
-- <a id="optiSLang_Actors.ProEInputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ProEInputActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.ProEInputActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
+<a id="optiSLang_Actors.ProEInputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ProEInputActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.ProEInputActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
 
 <a id="optiSLang_Actors.ProcessActor"></a>
 
 ## *class* \_optiSLang_Actors.ProcessActor
 
-- <a id="optiSLang_Actors.ProcessActor.ArchivalMode"></a>`*class* ArchivalMode`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalCompressed"></a>`archivalCompressed *= _optiSLang_Actors.ArchivalMode.archivalCompressed*`
-- <a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalDefault"></a>`archivalDefault *= _optiSLang_Actors.ArchivalMode.archivalDefault*`
-- <a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalDelete"></a>`archivalDelete *= _optiSLang_Actors.ArchivalMode.archivalDelete*`
-- <a id="optiSLang_Actors.ProcessActor.BaseFileMapping"></a>`*class* BaseFileMapping`
-- <a id="optiSLang_Actors.ProcessActor.BaseFileMapping.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- <a id="optiSLang_Actors.ProcessActor.BaseFileMapping.archival_mode"></a>*property* `archival_mode`
-- <a id="optiSLang_Actors.ProcessActor.BaseFileMapping.slot_name"></a>*property* `slot_name`
-- <a id="optiSLang_Actors.ProcessActor.BaseFileMapping.working_file_name"></a>*property* `working_file_name`
-- <a id="optiSLang_Actors.ProcessActor.FileImportance"></a>`*class* FileImportance`<br>
-  **Enumeration**
-- <a id="optiSLang_Actors.ProcessActor.FileImportance.OPTIONAL"></a>`OPTIONAL *= _optiSLang_Actors.FileImportance.OPTIONAL*`
-- <a id="optiSLang_Actors.ProcessActor.FileImportance.REQUIRED"></a>`REQUIRED *= _optiSLang_Actors.FileImportance.REQUIRED*`
-- <a id="optiSLang_Actors.ProcessActor.FileImportance.WAIT_FAIL"></a>`WAIT_FAIL *= _optiSLang_Actors.FileImportance.WAIT_FAIL*`
-- <a id="optiSLang_Actors.ProcessActor.FileImportance.WAIT_SUCCESS"></a>`WAIT_SUCCESS *= _optiSLang_Actors.FileImportance.WAIT_SUCCESS*`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping"></a>`*class* FileMapping`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping.archival_mode"></a>*property* `archival_mode`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping.input_file_name_"></a>*property* `input_file_name_`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping.slot_name"></a>*property* `slot_name`
-- <a id="optiSLang_Actors.ProcessActor.FileMapping.working_file_name"></a>*property* `working_file_name`
-- <a id="optiSLang_Actors.ProcessActor.InputFileMapping"></a>`*class* InputFileMapping`
-- <a id="optiSLang_Actors.ProcessActor.InputFileMapping.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- <a id="optiSLang_Actors.ProcessActor.InputFileMapping.input_file_name"></a>*property* `input_file_name`
-- <a id="optiSLang_Actors.ProcessActor.InputFileMapping.input_file_name_"></a>*property* `input_file_name_`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList"></a>`*class* InputFilesList`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.append"></a>`append(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.extend"></a>`extend(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.push_back"></a>`push_back(arg2: [InputFileMapping](#optiSLang_Actors.ProcessActor.InputFileMapping))`
-- <a id="optiSLang_Actors.ProcessActor.InputFilesList.size"></a>`size() → int`
-- <a id="optiSLang_Actors.ProcessActor.OutputFileMapping"></a>`*class* OutputFileMapping`
-- <a id="optiSLang_Actors.ProcessActor.OutputFileMapping.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))`
-- <a id="optiSLang_Actors.ProcessActor.OutputFileMapping.importance"></a>*property* `importance`
-- <a id="optiSLang_Actors.ProcessActor.OutputFileMapping.remove_on_reset"></a>*property* `remove_on_reset`
-- <a id="optiSLang_Actors.ProcessActor.OutputFileMapping.working_file_regex"></a>*property* `working_file_regex`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList"></a>`*class* OutputFilesList`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.append"></a>`append(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.extend"></a>`extend(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.push_back"></a>`push_back(arg2: [OutputFileMapping](#optiSLang_Actors.ProcessActor.OutputFileMapping))`
-- <a id="optiSLang_Actors.ProcessActor.OutputFilesList.size"></a>`size() → int`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList"></a>`*class* SlotPathList`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__init__"></a>`__init__()`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__iter__"></a>`__iter__() → object`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__len__"></a>`__len__() → int`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.append"></a>`append(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.extend"></a>`extend(arg2: object)`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.push_back"></a>`push_back(arg2: [FileMapping](#optiSLang_Actors.ProcessActor.FileMapping))`
-- <a id="optiSLang_Actors.ProcessActor.SlotPathList.size"></a>`size() → int`
-- <a id="optiSLang_Actors.ProcessActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ProcessActor.arguments"></a>*property* `arguments`
-- <a id="optiSLang_Actors.ProcessActor.command"></a>*property* `command`
-- <a id="optiSLang_Actors.ProcessActor.enable_multi_design_launch"></a>*property* `enable_multi_design_launch`
-- <a id="optiSLang_Actors.ProcessActor.environment"></a>*property* `environment`
-- <a id="optiSLang_Actors.ProcessActor.ignore_exit_code"></a>*property* `ignore_exit_code`
-- <a id="optiSLang_Actors.ProcessActor.input_files"></a>*property* `input_files`
-- <a id="optiSLang_Actors.ProcessActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.ProcessActor.multi_design_launch_num"></a>*property* `multi_design_launch_num`
-- <a id="optiSLang_Actors.ProcessActor.output_files"></a>*property* `output_files`
-- <a id="optiSLang_Actors.ProcessActor.prepend_project_bin_to_path"></a>*property* `prepend_project_bin_to_path`
-- <a id="optiSLang_Actors.ProcessActor.working_dir"></a>*property* `working_dir`
+<a id="optiSLang_Actors.ProcessActor.ArchivalMode"></a>
+
+#### *class* ArchivalMode
+
+**Enumeration**
+
+<a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalCompressed"></a>
+
+#### archivalCompressed *= \_optiSLang_Actors.ArchivalMode.archivalCompressed*
+
+<a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalDefault"></a>
+
+#### archivalDefault *= \_optiSLang_Actors.ArchivalMode.archivalDefault*
+
+<a id="optiSLang_Actors.ProcessActor.ArchivalMode.archivalDelete"></a>
+
+#### archivalDelete *= \_optiSLang_Actors.ArchivalMode.archivalDelete*
+
+<a id="optiSLang_Actors.ProcessActor.BaseFileMapping"></a>
+
+#### *class* BaseFileMapping
+
+<a id="optiSLang_Actors.ProcessActor.BaseFileMapping.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+<a id="optiSLang_Actors.ProcessActor.BaseFileMapping.archival_mode"></a>
+
+#### *property* archival_mode
+
+<a id="optiSLang_Actors.ProcessActor.BaseFileMapping.slot_name"></a>
+
+#### *property* slot_name
+
+<a id="optiSLang_Actors.ProcessActor.BaseFileMapping.working_file_name"></a>
+
+#### *property* working_file_name
+
+<a id="optiSLang_Actors.ProcessActor.FileImportance"></a>
+
+#### *class* FileImportance
+
+**Enumeration**
+
+<a id="optiSLang_Actors.ProcessActor.FileImportance.OPTIONAL"></a>
+
+#### OPTIONAL *= \_optiSLang_Actors.FileImportance.OPTIONAL*
+
+<a id="optiSLang_Actors.ProcessActor.FileImportance.REQUIRED"></a>
+
+#### REQUIRED *= \_optiSLang_Actors.FileImportance.REQUIRED*
+
+<a id="optiSLang_Actors.ProcessActor.FileImportance.WAIT_FAIL"></a>
+
+#### WAIT_FAIL *= \_optiSLang_Actors.FileImportance.WAIT_FAIL*
+
+<a id="optiSLang_Actors.ProcessActor.FileImportance.WAIT_SUCCESS"></a>
+
+#### WAIT_SUCCESS *= \_optiSLang_Actors.FileImportance.WAIT_SUCCESS*
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping"></a>
+
+#### *class* FileMapping
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping.archival_mode"></a>
+
+#### *property* archival_mode
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping.input_file_name_"></a>
+
+#### *property* input_file_name_
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping.slot_name"></a>
+
+#### *property* slot_name
+
+<a id="optiSLang_Actors.ProcessActor.FileMapping.working_file_name"></a>
+
+#### *property* working_file_name
+
+<a id="optiSLang_Actors.ProcessActor.InputFileMapping"></a>
+
+#### *class* InputFileMapping
+
+<a id="optiSLang_Actors.ProcessActor.InputFileMapping.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+<a id="optiSLang_Actors.ProcessActor.InputFileMapping.input_file_name"></a>
+
+#### *property* input_file_name
+
+<a id="optiSLang_Actors.ProcessActor.InputFileMapping.input_file_name_"></a>
+
+#### *property* input_file_name_
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList"></a>
+
+#### *class* InputFilesList
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.append"></a>
+
+#### append(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.push_back"></a>
+
+#### push_back(arg2: [InputFileMapping](#optiSLang_Actors.ProcessActor.InputFileMapping))
+
+<a id="optiSLang_Actors.ProcessActor.InputFilesList.size"></a>
+
+#### size() → int
+
+<a id="optiSLang_Actors.ProcessActor.OutputFileMapping"></a>
+
+#### *class* OutputFileMapping
+
+<a id="optiSLang_Actors.ProcessActor.OutputFileMapping.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str)
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: str, arg4: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: [ArchivalMode](#optiSLang_Actors.ProcessActor.ArchivalMode))
+
+<a id="optiSLang_Actors.ProcessActor.OutputFileMapping.importance"></a>
+
+#### *property* importance
+
+<a id="optiSLang_Actors.ProcessActor.OutputFileMapping.remove_on_reset"></a>
+
+#### *property* remove_on_reset
+
+<a id="optiSLang_Actors.ProcessActor.OutputFileMapping.working_file_regex"></a>
+
+#### *property* working_file_regex
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList"></a>
+
+#### *class* OutputFilesList
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.append"></a>
+
+#### append(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.push_back"></a>
+
+#### push_back(arg2: [OutputFileMapping](#optiSLang_Actors.ProcessActor.OutputFileMapping))
+
+<a id="optiSLang_Actors.ProcessActor.OutputFilesList.size"></a>
+
+#### size() → int
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList"></a>
+
+#### *class* SlotPathList
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.append"></a>
+
+#### append(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.push_back"></a>
+
+#### push_back(arg2: [FileMapping](#optiSLang_Actors.ProcessActor.FileMapping))
+
+<a id="optiSLang_Actors.ProcessActor.SlotPathList.size"></a>
+
+#### size() → int
+
+<a id="optiSLang_Actors.ProcessActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ProcessActor.arguments"></a>
+
+#### *property* arguments
+
+<a id="optiSLang_Actors.ProcessActor.command"></a>
+
+#### *property* command
+
+<a id="optiSLang_Actors.ProcessActor.enable_multi_design_launch"></a>
+
+#### *property* enable_multi_design_launch
+
+<a id="optiSLang_Actors.ProcessActor.environment"></a>
+
+#### *property* environment
+
+<a id="optiSLang_Actors.ProcessActor.ignore_exit_code"></a>
+
+#### *property* ignore_exit_code
+
+<a id="optiSLang_Actors.ProcessActor.input_files"></a>
+
+#### *property* input_files
+
+<a id="optiSLang_Actors.ProcessActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.ProcessActor.multi_design_launch_num"></a>
+
+#### *property* multi_design_launch_num
+
+<a id="optiSLang_Actors.ProcessActor.output_files"></a>
+
+#### *property* output_files
+
+<a id="optiSLang_Actors.ProcessActor.prepend_project_bin_to_path"></a>
+
+#### *property* prepend_project_bin_to_path
+
+<a id="optiSLang_Actors.ProcessActor.working_dir"></a>
+
+#### *property* working_dir
 
 <a id="optiSLang_Actors.PythonActor"></a>
 
 ## *class* \_optiSLang_Actors.PythonActor
 
-- <a id="optiSLang_Actors.PythonActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.PythonActor.max_parallel"></a>*property* `max_parallel`
-- <a id="optiSLang_Actors.PythonActor.path"></a>*property* `path`
-- <a id="optiSLang_Actors.PythonActor.source"></a>*property* `source`
+<a id="optiSLang_Actors.PythonActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.PythonActor.max_parallel"></a>
+
+#### *property* max_parallel
+
+<a id="optiSLang_Actors.PythonActor.path"></a>
+
+#### *property* path
+
+<a id="optiSLang_Actors.PythonActor.source"></a>
+
+#### *property* source
 
 <a id="optiSLang_Actors.PythonScriptActor"></a>
 
 ## *class* \_optiSLang_Actors.PythonScriptActor
 
-- <a id="optiSLang_Actors.PythonScriptActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.PythonScriptActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.ReevaluateActor"></a>
 
 ## *class* \_optiSLang_Actors.ReevaluateActor
 
-- <a id="optiSLang_Actors.ReevaluateActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.ReevaluateActor.adapt_bounds"></a>*property* `adapt_bounds`
-- <a id="optiSLang_Actors.ReevaluateActor.design_dir_format"></a>*property* `design_dir_format`
-- <a id="optiSLang_Actors.ReevaluateActor.design_dir_path"></a>*property* `design_dir_path`
-- <a id="optiSLang_Actors.ReevaluateActor.design_numbers"></a>*property* `design_numbers`
-- <a id="optiSLang_Actors.ReevaluateActor.input_file_path"></a>*property* `input_file_path`
-- <a id="optiSLang_Actors.ReevaluateActor.merge_input_data"></a>*property* `merge_input_data`
-- <a id="optiSLang_Actors.ReevaluateActor.merge_output_data"></a>*property* `merge_output_data`
-- <a id="optiSLang_Actors.ReevaluateActor.result_file_type"></a>*property* `result_file_type`
-- <a id="optiSLang_Actors.ReevaluateActor.use_input_file"></a>*property* `use_input_file`
+<a id="optiSLang_Actors.ReevaluateActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.ReevaluateActor.adapt_bounds"></a>
+
+#### *property* adapt_bounds
+
+<a id="optiSLang_Actors.ReevaluateActor.design_dir_format"></a>
+
+#### *property* design_dir_format
+
+<a id="optiSLang_Actors.ReevaluateActor.design_dir_path"></a>
+
+#### *property* design_dir_path
+
+<a id="optiSLang_Actors.ReevaluateActor.design_numbers"></a>
+
+#### *property* design_numbers
+
+<a id="optiSLang_Actors.ReevaluateActor.input_file_path"></a>
+
+#### *property* input_file_path
+
+<a id="optiSLang_Actors.ReevaluateActor.merge_input_data"></a>
+
+#### *property* merge_input_data
+
+<a id="optiSLang_Actors.ReevaluateActor.merge_output_data"></a>
+
+#### *property* merge_output_data
+
+<a id="optiSLang_Actors.ReevaluateActor.result_file_type"></a>
+
+#### *property* result_file_type
+
+<a id="optiSLang_Actors.ReevaluateActor.use_input_file"></a>
+
+#### *property* use_input_file
 
 <a id="optiSLang_Actors.ReliabilityBaseActor"></a>
 
 ## *class* \_optiSLang_Actors.ReliabilityBaseActor
 
-- <a id="optiSLang_Actors.ReliabilityBaseActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ReliabilityBaseActor.reliability_settings"></a>*property* `reliability_settings`
+<a id="optiSLang_Actors.ReliabilityBaseActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ReliabilityBaseActor.reliability_settings"></a>
+
+#### *property* reliability_settings
 
 <a id="optiSLang_Actors.RobustnessActor"></a>
 
 ## *class* \_optiSLang_Actors.RobustnessActor
 
-- <a id="optiSLang_Actors.RobustnessActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.RobustnessActor.nominal_design_point"></a>*property* `nominal_design_point`
-- <a id="optiSLang_Actors.RobustnessActor.solve_nominal_design"></a>*property* `solve_nominal_design`
+<a id="optiSLang_Actors.RobustnessActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.RobustnessActor.nominal_design_point"></a>
+
+#### *property* nominal_design_point
+
+<a id="optiSLang_Actors.RobustnessActor.solve_nominal_design"></a>
+
+#### *property* solve_nominal_design
 
 <a id="optiSLang_Actors.RunnableSystem"></a>
 
 ## *class* \_optiSLang_Actors.RunnableSystem
 
-- <a id="optiSLang_Actors.RunnableSystem.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.RunnableSystem.get_working_directory"></a>`get_working_directory() → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)`
+<a id="optiSLang_Actors.RunnableSystem.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.RunnableSystem.get_working_directory"></a>
+
+#### get_working_directory() → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
 
 <a id="optiSLang_Actors.SDIActor"></a>
 
 ## *class* \_optiSLang_Actors.SDIActor
 
-- <a id="optiSLang_Actors.SDIActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.SDIActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.SamplingActor"></a>
 
 ## *class* \_optiSLang_Actors.SamplingActor
 
-- <a id="optiSLang_Actors.SamplingActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.SamplingActor.algorithm_settings"></a>*property* `algorithm_settings`
-- <a id="optiSLang_Actors.SamplingActor.dynamic_sampling"></a>*property* `dynamic_sampling`
-- <a id="optiSLang_Actors.SamplingActor.preserve_start_design_ids"></a>*property* `preserve_start_design_ids`
+<a id="optiSLang_Actors.SamplingActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.SamplingActor.algorithm_settings"></a>
+
+#### *property* algorithm_settings
+
+<a id="optiSLang_Actors.SamplingActor.dynamic_sampling"></a>
+
+#### *property* dynamic_sampling
+
+<a id="optiSLang_Actors.SamplingActor.preserve_start_design_ids"></a>
+
+#### *property* preserve_start_design_ids
 
 <a id="optiSLang_Actors.ScriptFileActor"></a>
 
 ## *class* \_optiSLang_Actors.ScriptFileActor
 
-- <a id="optiSLang_Actors.ScriptFileActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.ScriptFileActor.add_input"></a>`add_input(location: Parameter)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.ScriptFileActor.add_internal_variable"></a>`add_internal_variable(location: Parameter)`<br>
-  [0] Assign location to an internal variable. [1] Create a derived variable.
-- `add_internal_variable(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.ScriptFileActor.add_output"></a>`add_output(location: Parameter)`<br>
-  [0] Assign location to an output slot. [1] Create a derived variable and assign it to an output slot.
-- `add_output(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.ScriptFileActor.add_parameter"></a>`add_parameter(location: Parameter)`<br>
-  Assign location to a parameter.
-- <a id="optiSLang_Actors.ScriptFileActor.add_response"></a>`add_response(location: Parameter)`<br>
-  [0] Assign location to a response. [1] Create a derived variable and assign it to a response.
-- `add_response(derived_variable: DerivedLocation)`
-- <a id="optiSLang_Actors.ScriptFileActor.content"></a>*property* `content`
-- <a id="optiSLang_Actors.ScriptFileActor.get_internal_variables"></a>`get_internal_variables() → list`<br>
-  Get internal variables
-- <a id="optiSLang_Actors.ScriptFileActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.ScriptFileActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.ScriptFileActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.ScriptFileActor.get_registered_outputs"></a>`get_registered_outputs() → list`<br>
-  Get registered output slots
-- <a id="optiSLang_Actors.ScriptFileActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.ScriptFileActor.get_registered_responses"></a>`get_registered_responses() → list`<br>
-  Get registered responses
-- <a id="optiSLang_Actors.ScriptFileActor.register_location_as_parameter"></a>`register_location_as_parameter(arg2: str)`
-- <a id="optiSLang_Actors.ScriptFileActor.register_locations_as_parameter"></a>`register_locations_as_parameter()`
-- <a id="optiSLang_Actors.ScriptFileActor.script_path"></a>*property* `script_path`
+<a id="optiSLang_Actors.ScriptFileActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.ScriptFileActor.add_input"></a>
+
+#### add_input(location: Parameter)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.ScriptFileActor.add_internal_variable"></a>
+
+#### add_internal_variable(location: Parameter)
+
+#### add_internal_variable(derived_variable: DerivedLocation)
+
+[0] Assign location to an internal variable.
+
+[1] Create a derived variable.
+
+<a id="optiSLang_Actors.ScriptFileActor.add_output"></a>
+
+#### add_output(location: Parameter)
+
+#### add_output(derived_variable: DerivedLocation)
+
+[0] Assign location to an output slot.
+
+[1] Create a derived variable and assign it to an output slot.
+
+<a id="optiSLang_Actors.ScriptFileActor.add_parameter"></a>
+
+#### add_parameter(location: Parameter)
+
+Assign location to a parameter.
+
+<a id="optiSLang_Actors.ScriptFileActor.add_response"></a>
+
+#### add_response(location: Parameter)
+
+#### add_response(derived_variable: DerivedLocation)
+
+[0] Assign location to a response.
+
+[1] Create a derived variable and assign it to a response.
+
+<a id="optiSLang_Actors.ScriptFileActor.content"></a>
+
+#### *property* content
+
+<a id="optiSLang_Actors.ScriptFileActor.get_internal_variables"></a>
+
+#### get_internal_variables() → list
+
+Get internal variables
+
+<a id="optiSLang_Actors.ScriptFileActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.ScriptFileActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.ScriptFileActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.ScriptFileActor.get_registered_outputs"></a>
+
+#### get_registered_outputs() → list
+
+Get registered output slots
+
+<a id="optiSLang_Actors.ScriptFileActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.ScriptFileActor.get_registered_responses"></a>
+
+#### get_registered_responses() → list
+
+Get registered responses
+
+<a id="optiSLang_Actors.ScriptFileActor.register_location_as_parameter"></a>
+
+#### register_location_as_parameter(arg2: str)
+
+<a id="optiSLang_Actors.ScriptFileActor.register_locations_as_parameter"></a>
+
+#### register_locations_as_parameter()
+
+<a id="optiSLang_Actors.ScriptFileActor.script_path"></a>
+
+#### *property* script_path
 
 <a id="optiSLang_Actors.SensitivityActor"></a>
 
 ## *class* \_optiSLang_Actors.SensitivityActor
 
-- <a id="optiSLang_Actors.SensitivityActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.SensitivityActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.SetLocation"></a>
 
@@ -2286,11 +6212,25 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.SetLocation.LOCATION_CUSTOM"></a>`LOCATION_CUSTOM *= _optiSLang_Actors.SetLocation.LOCATION_CUSTOM*`
-- <a id="optiSLang_Actors.SetLocation.LOCATION_INSTANCE"></a>`LOCATION_INSTANCE *= _optiSLang_Actors.SetLocation.LOCATION_INSTANCE*`
-- <a id="optiSLang_Actors.SetLocation.LOCATION_PART"></a>`LOCATION_PART *= _optiSLang_Actors.SetLocation.LOCATION_PART*`
-- <a id="optiSLang_Actors.SetLocation.LOCATION_ROOT_ASSEMBLY"></a>`LOCATION_ROOT_ASSEMBLY *= _optiSLang_Actors.SetLocation.LOCATION_ROOT_ASSEMBLY*`
-- <a id="optiSLang_Actors.SetLocation.LOCATION_UNSUPPORTED_LOCATION"></a>`LOCATION_UNSUPPORTED_LOCATION *= _optiSLang_Actors.SetLocation.LOCATION_UNSUPPORTED_LOCATION*`
+<a id="optiSLang_Actors.SetLocation.LOCATION_CUSTOM"></a>
+
+#### LOCATION_CUSTOM *= \_optiSLang_Actors.SetLocation.LOCATION_CUSTOM*
+
+<a id="optiSLang_Actors.SetLocation.LOCATION_INSTANCE"></a>
+
+#### LOCATION_INSTANCE *= \_optiSLang_Actors.SetLocation.LOCATION_INSTANCE*
+
+<a id="optiSLang_Actors.SetLocation.LOCATION_PART"></a>
+
+#### LOCATION_PART *= \_optiSLang_Actors.SetLocation.LOCATION_PART*
+
+<a id="optiSLang_Actors.SetLocation.LOCATION_ROOT_ASSEMBLY"></a>
+
+#### LOCATION_ROOT_ASSEMBLY *= \_optiSLang_Actors.SetLocation.LOCATION_ROOT_ASSEMBLY*
+
+<a id="optiSLang_Actors.SetLocation.LOCATION_UNSUPPORTED_LOCATION"></a>
+
+#### LOCATION_UNSUPPORTED_LOCATION *= \_optiSLang_Actors.SetLocation.LOCATION_UNSUPPORTED_LOCATION*
 
 <a id="optiSLang_Actors.SetType"></a>
 
@@ -2298,136 +6238,363 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.SetType.TYPE_ELEMENT_SET"></a>`TYPE_ELEMENT_SET *= _optiSLang_Actors.SetType.TYPE_ELEMENT_SET*`
-- <a id="optiSLang_Actors.SetType.TYPE_NODE_SET"></a>`TYPE_NODE_SET *= _optiSLang_Actors.SetType.TYPE_NODE_SET*`
-- <a id="optiSLang_Actors.SetType.TYPE_SURFACE_SET"></a>`TYPE_SURFACE_SET *= _optiSLang_Actors.SetType.TYPE_SURFACE_SET*`
-- <a id="optiSLang_Actors.SetType.TYPE_UNSUPPORTED_SET_TYPE"></a>`TYPE_UNSUPPORTED_SET_TYPE *= _optiSLang_Actors.SetType.TYPE_UNSUPPORTED_SET_TYPE*`
+<a id="optiSLang_Actors.SetType.TYPE_ELEMENT_SET"></a>
+
+#### TYPE_ELEMENT_SET *= \_optiSLang_Actors.SetType.TYPE_ELEMENT_SET*
+
+<a id="optiSLang_Actors.SetType.TYPE_NODE_SET"></a>
+
+#### TYPE_NODE_SET *= \_optiSLang_Actors.SetType.TYPE_NODE_SET*
+
+<a id="optiSLang_Actors.SetType.TYPE_SURFACE_SET"></a>
+
+#### TYPE_SURFACE_SET *= \_optiSLang_Actors.SetType.TYPE_SURFACE_SET*
+
+<a id="optiSLang_Actors.SetType.TYPE_UNSUPPORTED_SET_TYPE"></a>
+
+#### TYPE_UNSUPPORTED_SET_TYPE *= \_optiSLang_Actors.SetType.TYPE_UNSUPPORTED_SET_TYPE*
 
 <a id="optiSLang_Actors.SimpackInputActor"></a>
 
 ## *class* \_optiSLang_Actors.SimpackInputActor
 
-- <a id="optiSLang_Actors.SimpackInputActor.__init__"></a>`__init__(arg2: str)`
+<a id="optiSLang_Actors.SimpackInputActor.__init__"></a>
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.SimplexActor"></a>
 
 ## *class* \_optiSLang_Actors.SimplexActor
 
-- <a id="optiSLang_Actors.SimplexActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.SimplexActor.optimizer_settings"></a>*property* `optimizer_settings`
+<a id="optiSLang_Actors.SimplexActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.SimplexActor.optimizer_settings"></a>
+
+#### *property* optimizer_settings
 
 <a id="optiSLang_Actors.SimtoolActor"></a>
 
 ## *class* \_optiSLang_Actors.SimtoolActor
 
-- <a id="optiSLang_Actors.SimtoolActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.SimtoolActor.file_path"></a>*property* `file_path`
-- <a id="optiSLang_Actors.SimtoolActor.get_available_versions"></a>`get_available_versions(arg2: bool) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="optiSLang_Actors.SimtoolActor.pre_command"></a>*property* `pre_command`
-- <a id="optiSLang_Actors.SimtoolActor.save"></a>*property* `save`
-- <a id="optiSLang_Actors.SimtoolActor.version"></a>*property* `version`
+<a id="optiSLang_Actors.SimtoolActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.SimtoolActor.file_path"></a>
+
+#### *property* file_path
+
+<a id="optiSLang_Actors.SimtoolActor.get_available_versions"></a>
+
+#### get_available_versions(arg2: bool) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="optiSLang_Actors.SimtoolActor.pre_command"></a>
+
+#### *property* pre_command
+
+<a id="optiSLang_Actors.SimtoolActor.save"></a>
+
+#### *property* save
+
+<a id="optiSLang_Actors.SimtoolActor.version"></a>
+
+#### *property* version
 
 <a id="optiSLang_Actors.SurrogateBaseActor"></a>
 
 ## *class* \_optiSLang_Actors.SurrogateBaseActor
 
-- <a id="optiSLang_Actors.SurrogateBaseActor.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="optiSLang_Actors.SurrogateBaseActor.get_parameter_from_actor"></a>`get_parameter_from_actor(arg2: [HID](id.md#id.HID), arg3: object) → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)`
-- <a id="optiSLang_Actors.SurrogateBaseActor.get_responses_from_actor"></a>`get_responses_from_actor(arg2: [HID](id.md#id.HID), arg3: object) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="optiSLang_Actors.SurrogateBaseActor.get_resulting_parameters"></a>`get_resulting_parameters() → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)`
-- <a id="optiSLang_Actors.SurrogateBaseActor.important_info"></a>*property* `important_info`
-- <a id="optiSLang_Actors.SurrogateBaseActor.is_valid"></a>`is_valid() → bool`
-- <a id="optiSLang_Actors.SurrogateBaseActor.mdb_path"></a>*property* `mdb_path`
-- <a id="optiSLang_Actors.SurrogateBaseActor.parameter_manager"></a>*property* `parameter_manager`
-- <a id="optiSLang_Actors.SurrogateBaseActor.responses"></a>*property* `responses`
-- <a id="optiSLang_Actors.SurrogateBaseActor.responses_to_be_used"></a>*property* `responses_to_be_used`
-- <a id="optiSLang_Actors.SurrogateBaseActor.show_pp_when_avaiable"></a>*property* `show_pp_when_avaiable`
-- <a id="optiSLang_Actors.SurrogateBaseActor.show_pp_when_available"></a>*property* `show_pp_when_available`
-- <a id="optiSLang_Actors.SurrogateBaseActor.use_incomplete_designs"></a>*property* `use_incomplete_designs`
+<a id="optiSLang_Actors.SurrogateBaseActor.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="optiSLang_Actors.SurrogateBaseActor.get_parameter_from_actor"></a>
+
+#### get_parameter_from_actor(arg2: [HID](id.md#id.HID), arg3: object) → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)
+
+<a id="optiSLang_Actors.SurrogateBaseActor.get_responses_from_actor"></a>
+
+#### get_responses_from_actor(arg2: [HID](id.md#id.HID), arg3: object) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="optiSLang_Actors.SurrogateBaseActor.get_resulting_parameters"></a>
+
+#### get_resulting_parameters() → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)
+
+<a id="optiSLang_Actors.SurrogateBaseActor.important_info"></a>
+
+#### *property* important_info
+
+<a id="optiSLang_Actors.SurrogateBaseActor.is_valid"></a>
+
+#### is_valid() → bool
+
+<a id="optiSLang_Actors.SurrogateBaseActor.mdb_path"></a>
+
+#### *property* mdb_path
+
+<a id="optiSLang_Actors.SurrogateBaseActor.parameter_manager"></a>
+
+#### *property* parameter_manager
+
+<a id="optiSLang_Actors.SurrogateBaseActor.responses"></a>
+
+#### *property* responses
+
+<a id="optiSLang_Actors.SurrogateBaseActor.responses_to_be_used"></a>
+
+#### *property* responses_to_be_used
+
+<a id="optiSLang_Actors.SurrogateBaseActor.show_pp_when_avaiable"></a>
+
+#### *property* show_pp_when_avaiable
+
+<a id="optiSLang_Actors.SurrogateBaseActor.show_pp_when_available"></a>
+
+#### *property* show_pp_when_available
+
+<a id="optiSLang_Actors.SurrogateBaseActor.use_incomplete_designs"></a>
+
+#### *property* use_incomplete_designs
 
 <a id="optiSLang_Actors.TaggedParameter"></a>
 
 ## *class* \_optiSLang_Actors.TaggedParameter
 
-- <a id="optiSLang_Actors.TaggedParameter.__init__"></a>`__init__()`
-- `__init__(name: str)`
-- `__init__(name: str, line: int, column: int, length: int, tagged_line: int, tagged_column: int, tagged_length: int)`
-- <a id="optiSLang_Actors.TaggedParameter.get_tagged_range"></a>`get_tagged_range(content: str) → tuple`
-- <a id="optiSLang_Actors.TaggedParameter.get_tagged_start"></a>`get_tagged_start(content: str) → int`
-- <a id="optiSLang_Actors.TaggedParameter.intersects"></a>`intersects(parameter: [TaggedParameter](#optiSLang_Actors.TaggedParameter)) → bool`
-- <a id="optiSLang_Actors.TaggedParameter.tagged_column"></a>*property* `tagged_column`
-- <a id="optiSLang_Actors.TaggedParameter.tagged_length"></a>*property* `tagged_length`
-- <a id="optiSLang_Actors.TaggedParameter.tagged_line"></a>*property* `tagged_line`
+<a id="optiSLang_Actors.TaggedParameter.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(name: str)
+
+#### \_\_init_\_(name: str, line: int, column: int, length: int, tagged_line: int, tagged_column: int, tagged_length: int)
+
+<a id="optiSLang_Actors.TaggedParameter.get_tagged_range"></a>
+
+#### get_tagged_range(content: str) → tuple
+
+<a id="optiSLang_Actors.TaggedParameter.get_tagged_start"></a>
+
+#### get_tagged_start(content: str) → int
+
+<a id="optiSLang_Actors.TaggedParameter.intersects"></a>
+
+#### intersects(parameter: [TaggedParameter](#optiSLang_Actors.TaggedParameter)) → bool
+
+<a id="optiSLang_Actors.TaggedParameter.tagged_column"></a>
+
+#### *property* tagged_column
+
+<a id="optiSLang_Actors.TaggedParameter.tagged_length"></a>
+
+#### *property* tagged_length
+
+<a id="optiSLang_Actors.TaggedParameter.tagged_line"></a>
+
+#### *property* tagged_line
 
 <a id="optiSLang_Actors.TaggedParametersActor"></a>
 
 ## *class* \_optiSLang_Actors.TaggedParametersActor
 
-- <a id="optiSLang_Actors.TaggedParametersActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.TaggedParametersActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.TaggedParametersActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.TaggedParametersActor.register_location_as_parameter"></a>`register_location_as_parameter(arg2: str)`
-- <a id="optiSLang_Actors.TaggedParametersActor.register_locations_as_parameter"></a>`register_locations_as_parameter()`
+<a id="optiSLang_Actors.TaggedParametersActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.TaggedParametersActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.TaggedParametersActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.TaggedParametersActor.register_location_as_parameter"></a>
+
+#### register_location_as_parameter(arg2: str)
+
+<a id="optiSLang_Actors.TaggedParametersActor.register_locations_as_parameter"></a>
+
+#### register_locations_as_parameter()
 
 <a id="optiSLang_Actors.TextInputActor"></a>
 
 ## *class* \_optiSLang_Actors.TextInputActor
 
-- <a id="optiSLang_Actors.TextInputActor.Parameter"></a>`*class* Parameter`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.__init__"></a>`__init__()`
-- `__init__(name: str)`
-- `__init__(name: str, line: int, column: int, length: int)`
-- `__init__(name: str, line: int, column: int, length: int, format: str)`
-- `__init__(name: str, line: int, column: int, length: int, format: str, type: [EntryType](py_os_design.md#py_os_design.EntryType))`
-- `__init__(name: str, line: int, column: int, length: int, format: str, type: [EntryType](py_os_design.md#py_os_design.EntryType), expandable: bool)`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.column"></a>*property* `column`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.end_in_line"></a>*property* `end_in_line`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.expandable"></a>*property* `expandable`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.format"></a>*property* `format`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.get_text"></a>`get_text(arg2: str, arg3: bool, arg4: int, arg5: int, arg6: int) → str`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.intersects"></a>`intersects(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter)) → bool`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.length"></a>*property* `length`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.line"></a>*property* `line`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.marker"></a>*property* `marker`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.name"></a>*property* `name`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.read"></a>`read(arg2: str, arg3: bool) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.replace"></a>`replace(arg2: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), arg3: str, arg4: int) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="optiSLang_Actors.TextInputActor.Parameter.to_string"></a>`to_string(arg2: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → str`
-- <a id="optiSLang_Actors.TextInputActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.TextInputActor.add_input"></a>`add_input(location: Parameter)`<br>
-  Assign location to an input slot.
-- <a id="optiSLang_Actors.TextInputActor.add_parameter"></a>`add_parameter(location: Parameter)`<br>
-  [0] Assign location to a parameter.
-- `add_parameter(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter))`
-- <a id="optiSLang_Actors.TextInputActor.content"></a>*property* `content`
-- <a id="optiSLang_Actors.TextInputActor.encoding"></a>*property* `encoding`
-- <a id="optiSLang_Actors.TextInputActor.file_content"></a>*property* `file_content`
-- <a id="optiSLang_Actors.TextInputActor.file_path"></a>*property* `file_path`
-- <a id="optiSLang_Actors.TextInputActor.get_locations_from_file"></a>`get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: object, arg4: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.TextInputActor.get_locations_from_string"></a>`get_locations_from_string(arg2: str, arg3: object, arg4: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool`
-- <a id="optiSLang_Actors.TextInputActor.get_registered_inputs"></a>`get_registered_inputs() → list`<br>
-  Get registered input slots
-- <a id="optiSLang_Actors.TextInputActor.get_registered_parameters"></a>`get_registered_parameters() → list`<br>
-  Get registered parameters
-- <a id="optiSLang_Actors.TextInputActor.has_parameter_location"></a>`has_parameter_location(arg2: int, arg3: int, arg4: int) → bool`
-- <a id="optiSLang_Actors.TextInputActor.registered_parameters"></a>*property* `registered_parameters`<br>
-  List of parameters in the text. Note that these represent locations in the input file. So there can be multiple of them registered to the actual input parameters.
-- <a id="optiSLang_Actors.TextInputActor.remove_parameter"></a>`remove_parameter(arg2: str)`
-- <a id="optiSLang_Actors.TextInputActor.rename_parameter"></a>`rename_parameter(arg2: str, arg3: str)`
-- <a id="optiSLang_Actors.TextInputActor.replace_parameter"></a>`replace_parameter(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter), arg3: [Parameter](#optiSLang_Actors.TextInputActor.Parameter))`
-- <a id="optiSLang_Actors.TextInputActor.set_content"></a>`set_content()`
-- <a id="optiSLang_Actors.TextInputActor.store_content"></a>*property* `store_content`
+<a id="optiSLang_Actors.TextInputActor.Parameter"></a>
+
+#### *class* Parameter
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(name: str)
+
+#### \_\_init_\_(name: str, line: int, column: int, length: int)
+
+#### \_\_init_\_(name: str, line: int, column: int, length: int, format: str)
+
+#### \_\_init_\_(name: str, line: int, column: int, length: int, format: str, type: [EntryType](py_os_design.md#py_os_design.EntryType))
+
+#### \_\_init_\_(name: str, line: int, column: int, length: int, format: str, type: [EntryType](py_os_design.md#py_os_design.EntryType), expandable: bool)
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.column"></a>
+
+#### *property* column
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.end_in_line"></a>
+
+#### *property* end_in_line
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.expandable"></a>
+
+#### *property* expandable
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.format"></a>
+
+#### *property* format
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.get_text"></a>
+
+#### get_text(arg2: str, arg3: bool, arg4: int, arg5: int, arg6: int) → str
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.intersects"></a>
+
+#### intersects(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter)) → bool
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.length"></a>
+
+#### *property* length
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.line"></a>
+
+#### *property* line
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.marker"></a>
+
+#### *property* marker
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.name"></a>
+
+#### *property* name
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.read"></a>
+
+#### read(arg2: str, arg3: bool) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.replace"></a>
+
+#### replace(arg2: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), arg3: str, arg4: int) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="optiSLang_Actors.TextInputActor.Parameter.to_string"></a>
+
+#### to_string(arg2: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → str
+
+<a id="optiSLang_Actors.TextInputActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.TextInputActor.add_input"></a>
+
+#### add_input(location: Parameter)
+
+Assign location to an input slot.
+
+<a id="optiSLang_Actors.TextInputActor.add_parameter"></a>
+
+#### add_parameter(location: Parameter)
+
+#### add_parameter(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter))
+
+[0] Assign location to a parameter.
+
+<a id="optiSLang_Actors.TextInputActor.content"></a>
+
+#### *property* content
+
+<a id="optiSLang_Actors.TextInputActor.encoding"></a>
+
+#### *property* encoding
+
+<a id="optiSLang_Actors.TextInputActor.file_content"></a>
+
+#### *property* file_content
+
+<a id="optiSLang_Actors.TextInputActor.file_path"></a>
+
+#### *property* file_path
+
+<a id="optiSLang_Actors.TextInputActor.get_locations_from_file"></a>
+
+#### get_locations_from_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: object, arg4: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.TextInputActor.get_locations_from_string"></a>
+
+#### get_locations_from_string(arg2: str, arg3: object, arg4: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+<a id="optiSLang_Actors.TextInputActor.get_registered_inputs"></a>
+
+#### get_registered_inputs() → list
+
+Get registered input slots
+
+<a id="optiSLang_Actors.TextInputActor.get_registered_parameters"></a>
+
+#### get_registered_parameters() → list
+
+Get registered parameters
+
+<a id="optiSLang_Actors.TextInputActor.has_parameter_location"></a>
+
+#### has_parameter_location(arg2: int, arg3: int, arg4: int) → bool
+
+<a id="optiSLang_Actors.TextInputActor.registered_parameters"></a>
+
+#### *property* registered_parameters
+
+List of parameters in the text. Note that these represent locations in the input file. So there can be multiple of them registered to the actual input parameters.
+
+<a id="optiSLang_Actors.TextInputActor.remove_parameter"></a>
+
+#### remove_parameter(arg2: str)
+
+<a id="optiSLang_Actors.TextInputActor.rename_parameter"></a>
+
+#### rename_parameter(arg2: str, arg3: str)
+
+<a id="optiSLang_Actors.TextInputActor.replace_parameter"></a>
+
+#### replace_parameter(arg2: [Parameter](#optiSLang_Actors.TextInputActor.Parameter), arg3: [Parameter](#optiSLang_Actors.TextInputActor.Parameter))
+
+<a id="optiSLang_Actors.TextInputActor.set_content"></a>
+
+#### set_content()
+
+<a id="optiSLang_Actors.TextInputActor.store_content"></a>
+
+#### *property* store_content
 
 <a id="optiSLang_Actors.TurboOptInputActor"></a>
 
 ## *class* \_optiSLang_Actors.TurboOptInputActor
 
-- <a id="optiSLang_Actors.TurboOptInputActor.__init__"></a>`__init__(arg2: str)`
+<a id="optiSLang_Actors.TurboOptInputActor.__init__"></a>
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.UpdateResultFileInterval"></a>
 
@@ -2435,32 +6602,55 @@ Reliability actor using Monte Carlo methods.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.UpdateResultFileInterval.AT_THE_END"></a>`AT_THE_END *= _optiSLang_Actors.UpdateResultFileInterval.AT_THE_END*`
-- <a id="optiSLang_Actors.UpdateResultFileInterval.EVERY_DESIGN"></a>`EVERY_DESIGN *= _optiSLang_Actors.UpdateResultFileInterval.EVERY_DESIGN*`
-- <a id="optiSLang_Actors.UpdateResultFileInterval.EVERY_ITERATION"></a>`EVERY_ITERATION *= _optiSLang_Actors.UpdateResultFileInterval.EVERY_ITERATION*`
-- <a id="optiSLang_Actors.UpdateResultFileInterval.NEVER"></a>`NEVER *= _optiSLang_Actors.UpdateResultFileInterval.NEVER*`
+<a id="optiSLang_Actors.UpdateResultFileInterval.AT_THE_END"></a>
+
+#### AT_THE_END *= \_optiSLang_Actors.UpdateResultFileInterval.AT_THE_END*
+
+<a id="optiSLang_Actors.UpdateResultFileInterval.EVERY_DESIGN"></a>
+
+#### EVERY_DESIGN *= \_optiSLang_Actors.UpdateResultFileInterval.EVERY_DESIGN*
+
+<a id="optiSLang_Actors.UpdateResultFileInterval.EVERY_ITERATION"></a>
+
+#### EVERY_ITERATION *= \_optiSLang_Actors.UpdateResultFileInterval.EVERY_ITERATION*
+
+<a id="optiSLang_Actors.UpdateResultFileInterval.NEVER"></a>
+
+#### NEVER *= \_optiSLang_Actors.UpdateResultFileInterval.NEVER*
 
 <a id="optiSLang_Actors.VariableActor"></a>
 
 ## *class* \_optiSLang_Actors.VariableActor
 
-- <a id="optiSLang_Actors.VariableActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="optiSLang_Actors.VariableActor.variant"></a>*property* `variant`
+<a id="optiSLang_Actors.VariableActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="optiSLang_Actors.VariableActor.variant"></a>
+
+#### *property* variant
 
 <a id="optiSLang_Actors.VariantMonitoringActor"></a>
 
 ## *class* \_optiSLang_Actors.VariantMonitoringActor
 
-- <a id="optiSLang_Actors.VariantMonitoringActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.VariantMonitoringActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.WhileActor"></a>
 
 ## *class* \_optiSLang_Actors.WhileActor
 
-- <a id="optiSLang_Actors.WhileActor.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
+<a id="optiSLang_Actors.WhileActor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
 
 <a id="optiSLang_Actors.create_custom_actor_typed"></a>
 
@@ -2486,13 +6676,33 @@ Create a Custom MOP Node by ID.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.eModelComplexityType.eBALANCED_MODEL"></a>`eBALANCED_MODEL *= _optiSLang_Actors.eModelComplexityType.eBALANCED_MODEL*`
-- <a id="optiSLang_Actors.eModelComplexityType.eCOMPLEX_MODEL"></a>`eCOMPLEX_MODEL *= _optiSLang_Actors.eModelComplexityType.eCOMPLEX_MODEL*`
-- <a id="optiSLang_Actors.eModelComplexityType.eGARS"></a>`eGARS *= _optiSLang_Actors.eModelComplexityType.eGARS*`
-- <a id="optiSLang_Actors.eModelComplexityType.eISOKRIG"></a>`eISOKRIG *= _optiSLang_Actors.eModelComplexityType.eISOKRIG*`
-- <a id="optiSLang_Actors.eModelComplexityType.eMLS"></a>`eMLS *= _optiSLang_Actors.eModelComplexityType.eMLS*`
-- <a id="optiSLang_Actors.eModelComplexityType.ePOLY_DLN"></a>`ePOLY_DLN *= _optiSLang_Actors.eModelComplexityType.ePOLY_DLN*`
-- <a id="optiSLang_Actors.eModelComplexityType.eSIMPLE_MODEL"></a>`eSIMPLE_MODEL *= _optiSLang_Actors.eModelComplexityType.eSIMPLE_MODEL*`
+<a id="optiSLang_Actors.eModelComplexityType.eBALANCED_MODEL"></a>
+
+#### eBALANCED_MODEL *= \_optiSLang_Actors.eModelComplexityType.eBALANCED_MODEL*
+
+<a id="optiSLang_Actors.eModelComplexityType.eCOMPLEX_MODEL"></a>
+
+#### eCOMPLEX_MODEL *= \_optiSLang_Actors.eModelComplexityType.eCOMPLEX_MODEL*
+
+<a id="optiSLang_Actors.eModelComplexityType.eGARS"></a>
+
+#### eGARS *= \_optiSLang_Actors.eModelComplexityType.eGARS*
+
+<a id="optiSLang_Actors.eModelComplexityType.eISOKRIG"></a>
+
+#### eISOKRIG *= \_optiSLang_Actors.eModelComplexityType.eISOKRIG*
+
+<a id="optiSLang_Actors.eModelComplexityType.eMLS"></a>
+
+#### eMLS *= \_optiSLang_Actors.eModelComplexityType.eMLS*
+
+<a id="optiSLang_Actors.eModelComplexityType.ePOLY_DLN"></a>
+
+#### ePOLY_DLN *= \_optiSLang_Actors.eModelComplexityType.ePOLY_DLN*
+
+<a id="optiSLang_Actors.eModelComplexityType.eSIMPLE_MODEL"></a>
+
+#### eSIMPLE_MODEL *= \_optiSLang_Actors.eModelComplexityType.eSIMPLE_MODEL*
 
 <a id="optiSLang_Actors.eSettingsType"></a>
 
@@ -2500,8 +6710,13 @@ Create a Custom MOP Node by ID.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.eSettingsType.eADVANCED"></a>`eADVANCED *= _optiSLang_Actors.eSettingsType.eADVANCED*`
-- <a id="optiSLang_Actors.eSettingsType.eAUTOMATIC"></a>`eAUTOMATIC *= _optiSLang_Actors.eSettingsType.eAUTOMATIC*`
+<a id="optiSLang_Actors.eSettingsType.eADVANCED"></a>
+
+#### eADVANCED *= \_optiSLang_Actors.eSettingsType.eADVANCED*
+
+<a id="optiSLang_Actors.eSettingsType.eAUTOMATIC"></a>
+
+#### eAUTOMATIC *= \_optiSLang_Actors.eSettingsType.eAUTOMATIC*
 
 <a id="optiSLang_Actors.eVariableReductionType"></a>
 
@@ -2509,10 +6724,21 @@ Create a Custom MOP Node by ID.
 
 **Enumeration**
 
-- <a id="optiSLang_Actors.eVariableReductionType.eFILTER_MINOR_IMPORTANT"></a>`eFILTER_MINOR_IMPORTANT *= _optiSLang_Actors.eVariableReductionType.eFILTER_MINOR_IMPORTANT*`
-- <a id="optiSLang_Actors.eVariableReductionType.eFILTER_UNIMPORTANT"></a>`eFILTER_UNIMPORTANT *= _optiSLang_Actors.eVariableReductionType.eFILTER_UNIMPORTANT*`
-- <a id="optiSLang_Actors.eVariableReductionType.eNO_REDUCTION"></a>`eNO_REDUCTION *= _optiSLang_Actors.eVariableReductionType.eNO_REDUCTION*`
-- <a id="optiSLang_Actors.eVariableReductionType.eUSER_DEFINED"></a>`eUSER_DEFINED *= _optiSLang_Actors.eVariableReductionType.eUSER_DEFINED*`
+<a id="optiSLang_Actors.eVariableReductionType.eFILTER_MINOR_IMPORTANT"></a>
+
+#### eFILTER_MINOR_IMPORTANT *= \_optiSLang_Actors.eVariableReductionType.eFILTER_MINOR_IMPORTANT*
+
+<a id="optiSLang_Actors.eVariableReductionType.eFILTER_UNIMPORTANT"></a>
+
+#### eFILTER_UNIMPORTANT *= \_optiSLang_Actors.eVariableReductionType.eFILTER_UNIMPORTANT*
+
+<a id="optiSLang_Actors.eVariableReductionType.eNO_REDUCTION"></a>
+
+#### eNO_REDUCTION *= \_optiSLang_Actors.eVariableReductionType.eNO_REDUCTION*
+
+<a id="optiSLang_Actors.eVariableReductionType.eUSER_DEFINED"></a>
+
+#### eUSER_DEFINED *= \_optiSLang_Actors.eVariableReductionType.eUSER_DEFINED*
 
 <a id="optiSLang_Actors.get_loaded_ci_plugins"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/_optiSLang_Kernel.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/_optiSLang_Kernel.md
@@ -6,175 +6,202 @@
 
 Base class of all actor classes
 
-
 <a id="optiSLang_Kernel.Actor.SlotType"></a>
 
-### *class* SlotType
-```python
-*class* SlotType
-```
+#### *class* SlotType
 
 **Enumeration**
 
-- <a id="optiSLang_Kernel.Actor.SlotType.BOOL"></a>`BOOL *= _optiSLang_Kernel.SlotType.BOOL*`
-- <a id="optiSLang_Kernel.Actor.SlotType.BOOL_VEC"></a>`BOOL_VEC *= _optiSLang_Kernel.SlotType.BOOL_VEC*`
-- <a id="optiSLang_Kernel.Actor.SlotType.CRITERION"></a>`CRITERION *= _optiSLang_Kernel.SlotType.CRITERION*`
-- <a id="optiSLang_Kernel.Actor.SlotType.CRITERION_SEQ"></a>`CRITERION_SEQ *= _optiSLang_Kernel.SlotType.CRITERION_SEQ*`
-- <a id="optiSLang_Kernel.Actor.SlotType.DESIGN"></a>`DESIGN *= _optiSLang_Kernel.SlotType.DESIGN*`
-- <a id="optiSLang_Kernel.Actor.SlotType.DESIGNENTRY"></a>`DESIGNENTRY *= _optiSLang_Kernel.SlotType.DESIGNENTRY*`
-- <a id="optiSLang_Kernel.Actor.SlotType.DESIGNPOINT_CONTAINER"></a>`DESIGNPOINT_CONTAINER *= _optiSLang_Kernel.SlotType.DESIGNPOINT_CONTAINER*`
-- <a id="optiSLang_Kernel.Actor.SlotType.FLOAT"></a>`FLOAT *= _optiSLang_Kernel.SlotType.FLOAT*`
-- <a id="optiSLang_Kernel.Actor.SlotType.INTEGER"></a>`INTEGER *= _optiSLang_Kernel.SlotType.INTEGER*`
-- <a id="optiSLang_Kernel.Actor.SlotType.PARAMETER"></a>`PARAMETER *= _optiSLang_Kernel.SlotType.PARAMETER*`
-- <a id="optiSLang_Kernel.Actor.SlotType.PARAMETER_MANAGER"></a>`PARAMETER_MANAGER *= _optiSLang_Kernel.SlotType.PARAMETER_MANAGER*`
-- <a id="optiSLang_Kernel.Actor.SlotType.PARAMETER_SET"></a>`PARAMETER_SET *= _optiSLang_Kernel.SlotType.PARAMETER_SET*`
-- <a id="optiSLang_Kernel.Actor.SlotType.PATH"></a>`PATH *= _optiSLang_Kernel.SlotType.PATH*`
-- <a id="optiSLang_Kernel.Actor.SlotType.RUNINFO"></a>`RUNINFO *= _optiSLang_Kernel.SlotType.RUNINFO*`
-- <a id="optiSLang_Kernel.Actor.SlotType.RUNINFO_META"></a>`RUNINFO_META *= _optiSLang_Kernel.SlotType.RUNINFO_META*`
-- <a id="optiSLang_Kernel.Actor.SlotType.SAMPLING_DESIGN"></a>`SAMPLING_DESIGN *= _optiSLang_Kernel.SlotType.SAMPLING_DESIGN*`
-- <a id="optiSLang_Kernel.Actor.SlotType.STRING"></a>`STRING *= _optiSLang_Kernel.SlotType.STRING*`
-- <a id="optiSLang_Kernel.Actor.SlotType.STRING_LIST"></a>`STRING_LIST *= _optiSLang_Kernel.SlotType.STRING_LIST*`
-- <a id="optiSLang_Kernel.Actor.SlotType.UNDEFINED"></a>`UNDEFINED *= _optiSLang_Kernel.SlotType.UNDEFINED*`
-- <a id="optiSLang_Kernel.Actor.SlotType.UNSIGNED_INTEGER"></a>`UNSIGNED_INTEGER *= _optiSLang_Kernel.SlotType.UNSIGNED_INTEGER*`
-- <a id="optiSLang_Kernel.Actor.SlotType.UNSIGNED_INTEGER_VECTOR"></a>`UNSIGNED_INTEGER_VECTOR *= _optiSLang_Kernel.SlotType.UNSIGNED_INTEGER_VECTOR*`
-- <a id="optiSLang_Kernel.Actor.SlotType.VARIANT"></a>`VARIANT *= _optiSLang_Kernel.SlotType.VARIANT*`
-- <a id="optiSLang_Kernel.Actor.SlotType.VARIANTSEQ"></a>`VARIANTSEQ *= _optiSLang_Kernel.SlotType.VARIANTSEQ*`
+<a id="optiSLang_Kernel.Actor.SlotType.BOOL"></a>
 
+#### BOOL *= \_optiSLang_Kernel.SlotType.BOOL*
+
+<a id="optiSLang_Kernel.Actor.SlotType.BOOL_VEC"></a>
+
+#### BOOL_VEC *= \_optiSLang_Kernel.SlotType.BOOL_VEC*
+
+<a id="optiSLang_Kernel.Actor.SlotType.CRITERION"></a>
+
+#### CRITERION *= \_optiSLang_Kernel.SlotType.CRITERION*
+
+<a id="optiSLang_Kernel.Actor.SlotType.CRITERION_SEQ"></a>
+
+#### CRITERION_SEQ *= \_optiSLang_Kernel.SlotType.CRITERION_SEQ*
+
+<a id="optiSLang_Kernel.Actor.SlotType.DESIGN"></a>
+
+#### DESIGN *= \_optiSLang_Kernel.SlotType.DESIGN*
+
+<a id="optiSLang_Kernel.Actor.SlotType.DESIGNENTRY"></a>
+
+#### DESIGNENTRY *= \_optiSLang_Kernel.SlotType.DESIGNENTRY*
+
+<a id="optiSLang_Kernel.Actor.SlotType.DESIGNPOINT_CONTAINER"></a>
+
+#### DESIGNPOINT_CONTAINER *= \_optiSLang_Kernel.SlotType.DESIGNPOINT_CONTAINER*
+
+<a id="optiSLang_Kernel.Actor.SlotType.FLOAT"></a>
+
+#### FLOAT *= \_optiSLang_Kernel.SlotType.FLOAT*
+
+<a id="optiSLang_Kernel.Actor.SlotType.INTEGER"></a>
+
+#### INTEGER *= \_optiSLang_Kernel.SlotType.INTEGER*
+
+<a id="optiSLang_Kernel.Actor.SlotType.PARAMETER"></a>
+
+#### PARAMETER *= \_optiSLang_Kernel.SlotType.PARAMETER*
+
+<a id="optiSLang_Kernel.Actor.SlotType.PARAMETER_MANAGER"></a>
+
+#### PARAMETER_MANAGER *= \_optiSLang_Kernel.SlotType.PARAMETER_MANAGER*
+
+<a id="optiSLang_Kernel.Actor.SlotType.PARAMETER_SET"></a>
+
+#### PARAMETER_SET *= \_optiSLang_Kernel.SlotType.PARAMETER_SET*
+
+<a id="optiSLang_Kernel.Actor.SlotType.PATH"></a>
+
+#### PATH *= \_optiSLang_Kernel.SlotType.PATH*
+
+<a id="optiSLang_Kernel.Actor.SlotType.RUNINFO"></a>
+
+#### RUNINFO *= \_optiSLang_Kernel.SlotType.RUNINFO*
+
+<a id="optiSLang_Kernel.Actor.SlotType.RUNINFO_META"></a>
+
+#### RUNINFO_META *= \_optiSLang_Kernel.SlotType.RUNINFO_META*
+
+<a id="optiSLang_Kernel.Actor.SlotType.SAMPLING_DESIGN"></a>
+
+#### SAMPLING_DESIGN *= \_optiSLang_Kernel.SlotType.SAMPLING_DESIGN*
+
+<a id="optiSLang_Kernel.Actor.SlotType.STRING"></a>
+
+#### STRING *= \_optiSLang_Kernel.SlotType.STRING*
+
+<a id="optiSLang_Kernel.Actor.SlotType.STRING_LIST"></a>
+
+#### STRING_LIST *= \_optiSLang_Kernel.SlotType.STRING_LIST*
+
+<a id="optiSLang_Kernel.Actor.SlotType.UNDEFINED"></a>
+
+#### UNDEFINED *= \_optiSLang_Kernel.SlotType.UNDEFINED*
+
+<a id="optiSLang_Kernel.Actor.SlotType.UNSIGNED_INTEGER"></a>
+
+#### UNSIGNED_INTEGER *= \_optiSLang_Kernel.SlotType.UNSIGNED_INTEGER*
+
+<a id="optiSLang_Kernel.Actor.SlotType.UNSIGNED_INTEGER_VECTOR"></a>
+
+#### UNSIGNED_INTEGER_VECTOR *= \_optiSLang_Kernel.SlotType.UNSIGNED_INTEGER_VECTOR*
+
+<a id="optiSLang_Kernel.Actor.SlotType.VARIANT"></a>
+
+#### VARIANT *= \_optiSLang_Kernel.SlotType.VARIANT*
+
+<a id="optiSLang_Kernel.Actor.SlotType.VARIANTSEQ"></a>
+
+#### VARIANTSEQ *= \_optiSLang_Kernel.SlotType.VARIANTSEQ*
 
 <a id="optiSLang_Kernel.Actor.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
+#### \_\_init_\_()
 
 Raises an exception
 This class cannot be instantiated from Python
 
-
 <a id="optiSLang_Kernel.Actor.active"></a>
 
-### *property* active
-```python
-active
-```
-
+#### *property* active
 
 <a id="optiSLang_Kernel.Actor.add_file_provider_item"></a>
 
-### add_file_provider_item
-```python
-add_file_provider_item(id: [FileProviderId](py_file_access.md#py_file_access.FileProviderId)) → bool
-```
+#### add_file_provider_item(id: [FileProviderId](py_file_access.md#py_file_access.FileProviderId)) → bool
 
 Add and use a file provider item.
 
-
 <a id="optiSLang_Kernel.Actor.add_input_slot"></a>
 
-### add_input_slot
-```python
-add_input_slot(slot_type: [SlotType](#optiSLang_Kernel.Actor.SlotType), id: str)
-```
+#### add_input_slot(slot_type: [SlotType](#optiSLang_Kernel.Actor.SlotType), id: str)
 
 Add an input slot with slot_type and id.
 
-
 <a id="optiSLang_Kernel.Actor.add_output_slot"></a>
 
-### add_output_slot
-```python
-add_output_slot(slot_type: [SlotType](#optiSLang_Kernel.Actor.SlotType), id: str)
-```
+#### add_output_slot(slot_type: [SlotType](#optiSLang_Kernel.Actor.SlotType), id: str)
 
 Add an output slot with slot_type and id.
 
-
 <a id="optiSLang_Kernel.Actor.auto_save_mode"></a>
 
-### *property* auto_save_mode
-```python
-auto_save_mode
-```
-
+#### *property* auto_save_mode
 
 <a id="optiSLang_Kernel.Actor.auto_save_on_nth_design_collected"></a>
 
-### *property* auto_save_on_nth_design_collected
-```python
-auto_save_on_nth_design_collected
-```
-
+#### *property* auto_save_on_nth_design_collected
 
 <a id="optiSLang_Kernel.Actor.connected_input_slots"></a>
 
-### *property* connected_input_slots
-```python
-connected_input_slots
-```
+#### *property* connected_input_slots
 
 Dictionary with connected input slots as keys and the slot’s sources as values. Each source is a tuple of the source actor and the source slot name.
 
-
 <a id="optiSLang_Kernel.Actor.connected_output_slots"></a>
 
-### *property* connected_output_slots
-```python
-connected_output_slots
-```
+#### *property* connected_output_slots
 
 Dictionary with connected output slots as keys and the slot’s destinations as values. Each destination is a tuple of the destination actor and the destination slot name.
 
-
 <a id="optiSLang_Kernel.Actor.get_cleaning_mode"></a>
 
-### get_cleaning_mode
-```python
-get_cleaning_mode() → int
-```
-
+#### get_cleaning_mode() → int
 
 <a id="optiSLang_Kernel.Actor.get_file_provider_items"></a>
 
-### get_file_provider_items
-```python
-get_file_provider_items() → object
-```
+#### get_file_provider_items() → object
 
 Get a list of file provider items used in this actor.
 
-
 <a id="optiSLang_Kernel.Actor.get_processed_hids"></a>
 
-### get_processed_hids
-```python
-get_processed_hids() → dict
-```
+#### get_processed_hids() → dict
 
 Dictionary with HIDs categorized by their success states.
 
-
 <a id="optiSLang_Kernel.Actor.get_property"></a>
 
-### get_property
-```python
-get_property(property_id: str, default_value: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)) → [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)
-get_property(property_id: str, default_value: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)) → [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)
-get_property(property_id: str, default_value: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)) → [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)
-get_property(property_id: str, default_value: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
-get_property(property_id: str, default_value: str) → str
-get_property(property_id: str, default_value: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)) → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)
-get_property(property_id: str, default_value: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
-get_property(property_id: str, default_value: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)
-get_property(property_id: str, default_value: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
-get_property(property_id: str, default_value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
-get_property(property_id: str, default_value: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
-get_property(property_id: str, default_value: [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)) → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)
-get_property(property_id: str, default_value: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)) → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
-get_property(property_id: str, default_value: [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)) → [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)
-get_property(property_id: str, default_value: [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)) → [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)
-get_property(property_id: str, default_value: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)) → [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)
-```
+#### get_property(property_id: str, default_value: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)) → [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)
+
+#### get_property(property_id: str, default_value: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)) → [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)
+
+#### get_property(property_id: str, default_value: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)) → [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)
+
+#### get_property(property_id: str, default_value: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
+
+#### get_property(property_id: str, default_value: str) → str
+
+#### get_property(property_id: str, default_value: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)) → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)
+
+#### get_property(property_id: str, default_value: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+#### get_property(property_id: str, default_value: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)
+
+#### get_property(property_id: str, default_value: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+#### get_property(property_id: str, default_value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+#### get_property(property_id: str, default_value: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+#### get_property(property_id: str, default_value: [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)) → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)
+
+#### get_property(property_id: str, default_value: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)) → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
+
+#### get_property(property_id: str, default_value: [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)) → [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)
+
+#### get_property(property_id: str, default_value: [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)) → [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)
+
+#### get_property(property_id: str, default_value: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)) → [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)
 
 [0] Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
 
@@ -208,214 +235,145 @@ get_property(property_id: str, default_value: [PyOSCriterionContainer](py_os_cri
 
 [15] Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
 
-
 <a id="optiSLang_Kernel.Actor.get_property_bool"></a>
 
-### get_property_bool
-```python
-get_property_bool(property_id: str, default_value: bool) → bool
-```
+#### get_property_bool(property_id: str, default_value: bool) → bool
 
 Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
-
 
 <a id="optiSLang_Kernel.Actor.get_property_float"></a>
 
-### get_property_float
-```python
-get_property_float(property_id: str, default_value: float) → float
-```
+#### get_property_float(property_id: str, default_value: float) → float
 
 Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
-
 
 <a id="optiSLang_Kernel.Actor.get_property_int"></a>
 
-### get_property_int
-```python
-get_property_int(property_id: str, default_value: int) → int
-```
+#### get_property_int(property_id: str, default_value: int) → int
 
 Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
-
 
 <a id="optiSLang_Kernel.Actor.get_property_keys"></a>
 
-### get_property_keys
-```python
-get_property_keys() → list
-```
+#### get_property_keys() → list
 
 Get all accessible property keys
 
-
 <a id="optiSLang_Kernel.Actor.get_property_raw"></a>
 
-### get_property_raw
-```python
-get_property_raw(property_id: str) → str
-```
+#### get_property_raw(property_id: str) → str
 
 Get the raw value of a property specified by property_id.
 
-
 <a id="optiSLang_Kernel.Actor.get_property_uint"></a>
 
-### get_property_uint
-```python
-get_property_uint(property_id: str, default_value: int) → int
-```
+#### get_property_uint(property_id: str, default_value: int) → int
 
 Get the value of a property specified by property_id. If no such property or datatype doesn’t match, default_value is returned.
 
-
 <a id="optiSLang_Kernel.Actor.get_slot_value"></a>
 
-### get_slot_value
-```python
-get_slot_value(slot: str name, hid: HID) → object
-```
+#### get_slot_value(slot: str name, hid: HID) → object
 
 Get the value of a slot specified by its name and HID.
 
-
 <a id="optiSLang_Kernel.Actor.goal"></a>
 
-### *property* goal
-```python
-goal
-```
-
+#### *property* goal
 
 <a id="optiSLang_Kernel.Actor.input_slots"></a>
 
-### *property* input_slots
-```python
-input_slots
-```
+#### *property* input_slots
 
 List of input slots. Items are dicts of name, type and standard.
 
-
 <a id="optiSLang_Kernel.Actor.is_finished"></a>
 
-### is_finished
-```python
-is_finished(, consider_inactive: bool=False]) → bool
-```
+#### is_finished(, consider_inactive: bool=False]) → bool
 
 Whether an actor or a system including its children have finished their computation. If consider_inactive is set, an inactive actor will return whether it’s truly finished. Otherwise it will always pretend to be finished.
 
-
 <a id="optiSLang_Kernel.Actor.is_succeeded"></a>
 
-### is_succeeded
-```python
-is_succeeded(, consider_inactive: bool=False]) → bool
-```
+#### is_succeeded(, consider_inactive: bool=False]) → bool
 
 Whether an actor or a system including its children have finished their computation successfully.
 
-
 <a id="optiSLang_Kernel.Actor.max_runtime"></a>
 
-### *property* max_runtime
-```python
-max_runtime
-```
-
+#### *property* max_runtime
 
 <a id="optiSLang_Kernel.Actor.output_slots"></a>
 
-### *property* output_slots
-```python
-output_slots
-```
+#### *property* output_slots
 
 List of output slots. Items are dicts of name, type and standard.
 
-
 <a id="optiSLang_Kernel.Actor.read_mode"></a>
 
-### *property* read_mode
-```python
-read_mode
-```
-
+#### *property* read_mode
 
 <a id="optiSLang_Kernel.Actor.remove_file_provider_item"></a>
 
-### remove_file_provider_item
-```python
-remove_file_provider_item(id: [FileProviderId](py_file_access.md#py_file_access.FileProviderId)) → bool
-```
+#### remove_file_provider_item(id: [FileProviderId](py_file_access.md#py_file_access.FileProviderId)) → bool
 
 Remove a file provider item.
 
-
 <a id="optiSLang_Kernel.Actor.result_recycling"></a>
 
-### *property* result_recycling
-```python
-result_recycling
-```
-
+#### *property* result_recycling
 
 <a id="optiSLang_Kernel.Actor.retry_count"></a>
 
-### *property* retry_count
-```python
-retry_count
-```
-
+#### *property* retry_count
 
 <a id="optiSLang_Kernel.Actor.retry_delay"></a>
 
-### *property* retry_delay
-```python
-retry_delay
-```
-
+#### *property* retry_delay
 
 <a id="optiSLang_Kernel.Actor.retry_enable"></a>
 
-### *property* retry_enable
-```python
-retry_enable
-```
-
+#### *property* retry_enable
 
 <a id="optiSLang_Kernel.Actor.set_cleaning_mode"></a>
 
-### set_cleaning_mode
-```python
-set_cleaning_mode(mode: int)
-```
+#### set_cleaning_mode(mode: int)
 
 Set clean-up mode to enable particular cleanup behavior using bitwise linked combinations of CleanupFlags
 
-
 <a id="optiSLang_Kernel.Actor.set_property"></a>
 
-### set_property
-```python
-set_property(property_id: str, value: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)) → bool
-set_property(property_id: str, value: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)) → bool
-set_property(property_id: str, value: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)) → bool
-set_property(property_id: str, value: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
-set_property(property_id: str, value: str) → bool
-set_property(property_id: str, value: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)) → bool
-set_property(property_id: str, value: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)) → bool
-set_property(property_id: str, value: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → bool
-set_property(property_id: str, value: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → bool
-set_property(property_id: str, value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → bool
-set_property(property_id: str, value: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
-set_property(property_id: str, value: [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)) → bool
-set_property(property_id: str, value: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)) → bool
-set_property(property_id: str, value: [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)) → bool
-set_property(property_id: str, value: [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)) → bool
-set_property(property_id: str, value: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)) → bool
-```
+#### set_property(property_id: str, value: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath)) → bool
+
+#### set_property(property_id: str, value: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath)) → bool
+
+#### set_property(property_id: str, value: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath)) → bool
+
+#### set_property(property_id: str, value: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
+
+#### set_property(property_id: str, value: str) → bool
+
+#### set_property(property_id: str, value: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)) → bool
+
+#### set_property(property_id: str, value: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)) → bool
+
+#### set_property(property_id: str, value: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → bool
+
+#### set_property(property_id: str, value: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → bool
+
+#### set_property(property_id: str, value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)) → bool
+
+#### set_property(property_id: str, value: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → bool
+
+#### set_property(property_id: str, value: [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)) → bool
+
+#### set_property(property_id: str, value: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)) → bool
+
+#### set_property(property_id: str, value: [boolVec](stdcpp_python_export.md#stdcpp_python_export.boolVec)) → bool
+
+#### set_property(property_id: str, value: [PyOSCriterion](py_os_criterion.md#py_os_criterion.PyOSCriterion)) → bool
+
+#### set_property(property_id: str, value: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)) → bool
 
 [0] Set the value of a property specified by property_id. Returns true if set successful.
 
@@ -449,95 +407,55 @@ set_property(property_id: str, value: [PyOSCriterionContainer](py_os_criterion.m
 
 [15] Set the value of a property specified by property_id. Returns true if set successful.
 
-
 <a id="optiSLang_Kernel.Actor.set_property_bool"></a>
 
-### set_property_bool
-```python
-set_property_bool(property_id: str, value: bool) → bool
-```
+#### set_property_bool(property_id: str, value: bool) → bool
 
 Set the value of a property specified by property_id. Returns true if set successful.
-
 
 <a id="optiSLang_Kernel.Actor.set_property_float"></a>
 
-### set_property_float
-```python
-set_property_float(property_id: str, value: float) → bool
-```
+#### set_property_float(property_id: str, value: float) → bool
 
 Set the value of a property specified by property_id. Returns true if set successful.
-
 
 <a id="optiSLang_Kernel.Actor.set_property_int"></a>
 
-### set_property_int
-```python
-set_property_int(property_id: str, value: int) → bool
-```
+#### set_property_int(property_id: str, value: int) → bool
 
 Set the value of a property specified by property_id. Returns true if set successful.
-
 
 <a id="optiSLang_Kernel.Actor.set_property_raw"></a>
 
-### set_property_raw
-```python
-set_property_raw(property_tree_json: str) → bool
-```
+#### set_property_raw(property_tree_json: str) → bool
 
 Set the value of a property. Argument has to be a json object, containing one or more properties. Returns true if set successful.
 
-
 <a id="optiSLang_Kernel.Actor.set_property_uint"></a>
 
-### set_property_uint
-```python
-set_property_uint(property_id: str, value: int) → bool
-```
+#### set_property_uint(property_id: str, value: int) → bool
 
 Set the value of a property specified by property_id. Returns true if set successful.
 
-
 <a id="optiSLang_Kernel.Actor.starting_delay"></a>
 
-### *property* starting_delay
-```python
-starting_delay
-```
-
+#### *property* starting_delay
 
 <a id="optiSLang_Kernel.Actor.starting_point"></a>
 
-### *property* starting_point
-```python
-starting_point
-```
-
+#### *property* starting_point
 
 <a id="optiSLang_Kernel.Actor.stop_after_execution"></a>
 
-### *property* stop_after_execution
-```python
-stop_after_execution
-```
-
+#### *property* stop_after_execution
 
 <a id="optiSLang_Kernel.Actor.supports_read_mode"></a>
 
-### supports_read_mode
-```python
-supports_read_mode() → bool
-```
-
+#### supports_read_mode() → bool
 
 <a id="optiSLang_Kernel.Actor.supports_recycling"></a>
 
-### supports_recycling
-```python
-supports_recycling() → bool
-```
+#### supports_recycling() → bool
 
 <a id="optiSLang_Kernel.AutoSaveMode"></a>
 
@@ -545,10 +463,21 @@ supports_recycling() → bool
 
 **Enumeration**
 
-- <a id="optiSLang_Kernel.AutoSaveMode.AS_ACTOR_FINISHED"></a>`AS_ACTOR_FINISHED *= _optiSLang_Kernel.AutoSaveMode.AS_ACTOR_FINISHED*`
-- <a id="optiSLang_Kernel.AutoSaveMode.AS_ALGO_ITERATION_FINISHED"></a>`AS_ALGO_ITERATION_FINISHED *= _optiSLang_Kernel.AutoSaveMode.AS_ALGO_ITERATION_FINISHED*`
-- <a id="optiSLang_Kernel.AutoSaveMode.AS_PSS_NTH_DESIGN_COLLECTED"></a>`AS_PSS_NTH_DESIGN_COLLECTED *= _optiSLang_Kernel.AutoSaveMode.AS_PSS_NTH_DESIGN_COLLECTED*`
-- <a id="optiSLang_Kernel.AutoSaveMode.NO_AUTO_SAVE"></a>`NO_AUTO_SAVE *= _optiSLang_Kernel.AutoSaveMode.NO_AUTO_SAVE*`
+<a id="optiSLang_Kernel.AutoSaveMode.AS_ACTOR_FINISHED"></a>
+
+#### AS_ACTOR_FINISHED *= \_optiSLang_Kernel.AutoSaveMode.AS_ACTOR_FINISHED*
+
+<a id="optiSLang_Kernel.AutoSaveMode.AS_ALGO_ITERATION_FINISHED"></a>
+
+#### AS_ALGO_ITERATION_FINISHED *= \_optiSLang_Kernel.AutoSaveMode.AS_ALGO_ITERATION_FINISHED*
+
+<a id="optiSLang_Kernel.AutoSaveMode.AS_PSS_NTH_DESIGN_COLLECTED"></a>
+
+#### AS_PSS_NTH_DESIGN_COLLECTED *= \_optiSLang_Kernel.AutoSaveMode.AS_PSS_NTH_DESIGN_COLLECTED*
+
+<a id="optiSLang_Kernel.AutoSaveMode.NO_AUTO_SAVE"></a>
+
+#### NO_AUTO_SAVE *= \_optiSLang_Kernel.AutoSaveMode.NO_AUTO_SAVE*
 
 <a id="optiSLang_Kernel.CleanupFlags"></a>
 
@@ -556,8 +485,13 @@ supports_recycling() → bool
 
 **Enumeration**
 
-- <a id="optiSLang_Kernel.CleanupFlags.CLEANUP_INTERMEDIATE_SLOT_VALUES"></a>`CLEANUP_INTERMEDIATE_SLOT_VALUES *= _optiSLang_Kernel.CleanupFlags.CLEANUP_INTERMEDIATE_SLOT_VALUES*`
-- <a id="optiSLang_Kernel.CleanupFlags.IDLE"></a>`IDLE *= _optiSLang_Kernel.CleanupFlags.IDLE*`
+<a id="optiSLang_Kernel.CleanupFlags.CLEANUP_INTERMEDIATE_SLOT_VALUES"></a>
+
+#### CLEANUP_INTERMEDIATE_SLOT_VALUES *= \_optiSLang_Kernel.CleanupFlags.CLEANUP_INTERMEDIATE_SLOT_VALUES*
+
+<a id="optiSLang_Kernel.CleanupFlags.IDLE"></a>
+
+#### IDLE *= \_optiSLang_Kernel.CleanupFlags.IDLE*
 
 <a id="optiSLang_Kernel.ReadMode"></a>
 
@@ -565,20 +499,21 @@ supports_recycling() → bool
 
 **Enumeration**
 
-- <a id="optiSLang_Kernel.ReadMode.CLASSIC_REEVALUATE_MODE"></a>`CLASSIC_REEVALUATE_MODE *= _optiSLang_Kernel.ReadMode.CLASSIC_REEVALUATE_MODE*`
-- <a id="optiSLang_Kernel.ReadMode.READ_AND_WRITE_MODE"></a>`READ_AND_WRITE_MODE *= _optiSLang_Kernel.ReadMode.READ_AND_WRITE_MODE*`
+<a id="optiSLang_Kernel.ReadMode.CLASSIC_REEVALUATE_MODE"></a>
+
+#### CLASSIC_REEVALUATE_MODE *= \_optiSLang_Kernel.ReadMode.CLASSIC_REEVALUATE_MODE*
+
+<a id="optiSLang_Kernel.ReadMode.READ_AND_WRITE_MODE"></a>
+
+#### READ_AND_WRITE_MODE *= \_optiSLang_Kernel.ReadMode.READ_AND_WRITE_MODE*
 
 <a id="optiSLang_Kernel.SequencingSystem"></a>
 
 ## *class* \_optiSLang_Kernel.SequencingSystem
 
-
 <a id="optiSLang_Kernel.SequencingSystem.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
+#### \_\_init_\_()
 
 Raises an exception
 This class cannot be instantiated from Python
@@ -587,23 +522,17 @@ This class cannot be instantiated from Python
 
 ## *class* \_optiSLang_Kernel.System
 
-
 <a id="optiSLang_Kernel.System.__init__"></a>
 
-### __init__
-```python
-__init__()
-__init__() → object
-__init__(arg2: str) → object
-```
+#### \_\_init_\_()
 
+#### \_\_init_\_() → object
+
+#### \_\_init_\_(arg2: str) → object
 
 <a id="optiSLang_Kernel.System.add_actor"></a>
 
-### add_actor
-```python
-add_actor(actor: [Actor](#optiSLang_Kernel.Actor))
-```
+#### add_actor(actor: [Actor](#optiSLang_Kernel.Actor))
 
 Add actor as child to this system.
 
@@ -612,169 +541,174 @@ param_system = actors.ParametricSystemActor("System")
 add_actor(param_system)
 ```
 
-
 <a id="optiSLang_Kernel.System.connect"></a>
 
-### connect
-```python
-connect(from_actor: Actor, from_slot: str, to_actor: Actor, to_slot: str) → bool
-connect(from_actor: str, from_slot: str, to_actor: Actor, to_slot: str) → bool
-connect(from_actor: Actor, from_slot: str, to_actor: str, to_slot: str) → bool
-connect(from_actor: str, from_slot: str, to_actor: str, to_slot: str) → bool
-```
+#### connect(from_actor: Actor, from_slot: str, to_actor: Actor, to_slot: str) → bool
+
+#### connect(from_actor: str, from_slot: str, to_actor: Actor, to_slot: str) → bool
+
+#### connect(from_actor: Actor, from_slot: str, to_actor: str, to_slot: str) → bool
+
+#### connect(from_actor: str, from_slot: str, to_actor: str, to_slot: str) → bool
 
 [0] Connect slots.
 
-**Parameters:**
-- `from_actor` - The sending actor.
-- `from_slot` - The sending slot.
-- `to_actor` - The receiving actor.
-- `to_slot` - The receiving slot.
-- `skip_rename_slot` - Whether to skip automatic slot renaming for untyped slots. False by default.
+Parameters
 
-**Returns:**
-- `bool` - True if connection succeeded c.
-- `[1] Connect slots.` - 
+from_actor
+: The sending actor.
 
-**Parameters:**
-- `from_actor` - The sending actor.
-- `from_slot` - The sending slot.
-- `to_actor` - The receiving actor.
-- `to_slot` - The receiving slot.
-- `skip_rename_slot` - Whether to skip automatic slot renaming for untyped slots. False by default.
+from_slot
+: The sending slot.
 
-**Returns:**
-- `bool` - True if connection succeeded c.
-- `[2] Connect slots.` - 
+to_actor
+: The receiving actor.
 
-**Parameters:**
-- `from_actor` - The sending actor.
-- `from_slot` - The sending slot.
-- `to_actor` - The receiving actor.
-- `to_slot` - The receiving slot.
-- `skip_rename_slot` - Whether to skip automatic slot renaming for untyped slots. False by default.
+to_slot
+: The receiving slot.
 
-**Returns:**
-- `bool` - True if connection succeeded c.
-- `[3] Connect slots.` - 
+skip_rename_slot
+: Whether to skip automatic slot renaming for untyped slots. False by default.
 
-**Parameters:**
-- `from_actor` - The sending actor.
-- `from_slot` - The sending slot.
-- `to_actor` - The receiving actor.
-- `to_slot` - The receiving slot.
-- `skip_rename_slot` - Whether to skip automatic slot renaming for untyped slots. False by default.
+Returns
 
-**Returns:**
-- `bool` - True if connection succeeded c.
+bool
+: True if connection succeeded c.
 
+[1] Connect slots.
+
+Parameters
+
+from_actor
+: The sending actor.
+
+from_slot
+: The sending slot.
+
+to_actor
+: The receiving actor.
+
+to_slot
+: The receiving slot.
+
+skip_rename_slot
+: Whether to skip automatic slot renaming for untyped slots. False by default.
+
+Returns
+
+bool
+: True if connection succeeded c.
+
+[2] Connect slots.
+
+Parameters
+
+from_actor
+: The sending actor.
+
+from_slot
+: The sending slot.
+
+to_actor
+: The receiving actor.
+
+to_slot
+: The receiving slot.
+
+skip_rename_slot
+: Whether to skip automatic slot renaming for untyped slots. False by default.
+
+Returns
+
+bool
+: True if connection succeeded c.
+
+[3] Connect slots.
+
+Parameters
+
+from_actor
+: The sending actor.
+
+from_slot
+: The sending slot.
+
+to_actor
+: The receiving actor.
+
+to_slot
+: The receiving slot.
+
+skip_rename_slot
+: Whether to skip automatic slot renaming for untyped slots. False by default.
+
+Returns
+
+bool
+: True if connection succeeded c.
 
 <a id="optiSLang_Kernel.System.connected_inner_input_slots"></a>
 
-### *property* connected_inner_input_slots
-```python
-connected_inner_input_slots
-```
+#### *property* connected_inner_input_slots
 
 Dictionary with connected inner input slots as keys and the slot’s sources as values. Each source is a tuple of the source actor and the source slot name.
 
-
 <a id="optiSLang_Kernel.System.connected_inner_output_slots"></a>
 
-### *property* connected_inner_output_slots
-```python
-connected_inner_output_slots
-```
+#### *property* connected_inner_output_slots
 
 Dictionary with connected inner output slots as keys and the slot’s destinations as values. Each destination is a tuple of the destination actor and the destination slot name.
 
-
 <a id="optiSLang_Kernel.System.disconnect"></a>
 
-### disconnect
-```python
-disconnect(from_actor: [Actor](#optiSLang_Kernel.Actor), from_slot: str, to_actor: [Actor](#optiSLang_Kernel.Actor), to_slot: str) → bool
-disconnect(from_actor: str, from_slot: str, to_actor: [Actor](#optiSLang_Kernel.Actor), to_slot: str) → bool
-disconnect(from_actor: [Actor](#optiSLang_Kernel.Actor), from_slot: str, to_actor: str, to_slot: str) → bool
-disconnect(from_actor: str, from_slot: str, to_actor: str, to_slot: str) → bool
-```
+#### disconnect(from_actor: [Actor](#optiSLang_Kernel.Actor), from_slot: str, to_actor: [Actor](#optiSLang_Kernel.Actor), to_slot: str) → bool
 
+#### disconnect(from_actor: str, from_slot: str, to_actor: [Actor](#optiSLang_Kernel.Actor), to_slot: str) → bool
+
+#### disconnect(from_actor: [Actor](#optiSLang_Kernel.Actor), from_slot: str, to_actor: str, to_slot: str) → bool
+
+#### disconnect(from_actor: str, from_slot: str, to_actor: str, to_slot: str) → bool
 
 <a id="optiSLang_Kernel.System.dot_graph"></a>
 
-### *property* dot_graph
-```python
-dot_graph
-```
-
+#### *property* dot_graph
 
 <a id="optiSLang_Kernel.System.find_actor"></a>
 
-### find_actor
-```python
-find_actor(name: str) → object
-```
-
+#### find_actor(name: str) → object
 
 <a id="optiSLang_Kernel.System.get_children"></a>
 
-### get_children
-```python
-get_children() → dict
-```
+#### get_children() → dict
 
 Return all descending actors in a dictionary.
 
-
 <a id="optiSLang_Kernel.System.get_dot_graph"></a>
 
-### get_dot_graph
-```python
-get_dot_graph() → str
-```
-
+#### get_dot_graph() → str
 
 <a id="optiSLang_Kernel.System.get_working_directory"></a>
 
-### get_working_directory
-```python
-get_working_directory(hid: [HID](id.md#id.HID)) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
-```
-
+#### get_working_directory(hid: [HID](id.md#id.HID)) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
 
 <a id="optiSLang_Kernel.System.inner_input_slots"></a>
 
-### *property* inner_input_slots
-```python
-inner_input_slots
-```
+#### *property* inner_input_slots
 
 List of inner input slots. Items are dicts of name, type and standard.
 
-
 <a id="optiSLang_Kernel.System.inner_output_slots"></a>
 
-### *property* inner_output_slots
-```python
-inner_output_slots
-```
+#### *property* inner_output_slots
 
 List of inner output slots. Items are dicts of name, type and standard.
 
-
 <a id="optiSLang_Kernel.System.remove_actor"></a>
 
-### remove_actor
-```python
-remove_actor(arg2: [Actor](#optiSLang_Kernel.Actor))
-```
-
+#### remove_actor(arg2: [Actor](#optiSLang_Kernel.Actor))
 
 <a id="optiSLang_Kernel.System.reset_complete"></a>
 
-### reset_complete
-```python
-reset_complete()
-```
+#### reset_complete()
 
 Reset system’s status, working directory and runtime data. Attempts to shrink database.

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/amop.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/amop.md
@@ -4,85 +4,297 @@
 
 ## *class* amop.AMop
 
-- <a id="amop.AMop.__init__"></a>`__init__(arg2: [AMopSettings](#amop.AMopSettings))`
-- <a id="amop.AMop.adapt"></a>`adapt()`
-- <a id="amop.AMop.appraise"></a>`appraise()`
-- <a id="amop.AMop.finalize"></a>`finalize()`
-- <a id="amop.AMop.get_criteria_success_info"></a>`get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)`
-- <a id="amop.AMop.get_equalities"></a>`get_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.get_inequalities"></a>`get_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.get_inputs"></a>`get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.get_next_designs"></a>`get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.get_num_awaiting_designs"></a>`get_num_awaiting_designs() → int`
-- <a id="amop.AMop.get_objectives"></a>`get_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.get_responses"></a>`get_responses() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="amop.AMop.initialize"></a>`initialize(arg2: [AMopSettings](#amop.AMopSettings))`
-- <a id="amop.AMop.is_converged"></a>`is_converged() → bool`
-- <a id="amop.AMop.is_terminated"></a>`is_terminated() → bool`
-- <a id="amop.AMop.set_criteria_success_info"></a>`set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))`
-- <a id="amop.AMop.set_equalities"></a>`set_equalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_inequalities"></a>`set_inequalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_inputs"></a>`set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_objectives"></a>`set_objectives(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_responses"></a>`set_responses(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_start_designs"></a>`set_start_designs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- <a id="amop.AMop.set_terminated"></a>`set_terminated()`
+<a id="amop.AMop.__init__"></a>
+
+#### \_\_init_\_(arg2: [AMopSettings](#amop.AMopSettings))
+
+<a id="amop.AMop.adapt"></a>
+
+#### adapt()
+
+<a id="amop.AMop.appraise"></a>
+
+#### appraise()
+
+<a id="amop.AMop.finalize"></a>
+
+#### finalize()
+
+<a id="amop.AMop.get_criteria_success_info"></a>
+
+#### get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)
+
+<a id="amop.AMop.get_equalities"></a>
+
+#### get_equalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.get_inequalities"></a>
+
+#### get_inequalities() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.get_inputs"></a>
+
+#### get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.get_next_designs"></a>
+
+#### get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.get_num_awaiting_designs"></a>
+
+#### get_num_awaiting_designs() → int
+
+<a id="amop.AMop.get_objectives"></a>
+
+#### get_objectives() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.get_responses"></a>
+
+#### get_responses() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="amop.AMop.initialize"></a>
+
+#### initialize(arg2: [AMopSettings](#amop.AMopSettings))
+
+<a id="amop.AMop.is_converged"></a>
+
+#### is_converged() → bool
+
+<a id="amop.AMop.is_terminated"></a>
+
+#### is_terminated() → bool
+
+<a id="amop.AMop.set_criteria_success_info"></a>
+
+#### set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))
+
+<a id="amop.AMop.set_equalities"></a>
+
+#### set_equalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_inequalities"></a>
+
+#### set_inequalities(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_inputs"></a>
+
+#### set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_objectives"></a>
+
+#### set_objectives(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_responses"></a>
+
+#### set_responses(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_start_designs"></a>
+
+#### set_start_designs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+<a id="amop.AMop.set_terminated"></a>
+
+#### set_terminated()
 
 <a id="amop.AMopSettings"></a>
 
 ## *class* amop.AMopSettings
 
-- <a id="amop.AMopSettings.__init__"></a>`__init__()`
-- <a id="amop.AMopSettings.get_consider_failed_designs"></a>`get_consider_failed_designs() → bool`
-- <a id="amop.AMopSettings.get_max_iteration"></a>`get_max_iteration() → int`
-- <a id="amop.AMopSettings.get_min_cop"></a>`get_min_cop() → float`
-- <a id="amop.AMopSettings.get_num_designs"></a>`get_num_designs() → int`
-- <a id="amop.AMopSettings.get_num_designs_max"></a>`get_num_designs_max() → int`
-- <a id="amop.AMopSettings.get_num_discretization_adapt"></a>`get_num_discretization_adapt() → int`<br>
-  Return AMOP discretization number for refinement settings
-- <a id="amop.AMopSettings.get_num_discretization_init"></a>`get_num_discretization_init() → int`<br>
-  Return AMOP discretization number for start iteration settings
-- <a id="amop.AMopSettings.get_num_equalities"></a>`get_num_equalities() → int`
-- <a id="amop.AMopSettings.get_num_inequalities"></a>`get_num_inequalities() → int`
-- <a id="amop.AMopSettings.get_num_inputs"></a>`get_num_inputs() → int`
-- <a id="amop.AMopSettings.get_num_objectives"></a>`get_num_objectives() → int`
-- <a id="amop.AMopSettings.get_num_responses"></a>`get_num_responses() → int`
-- <a id="amop.AMopSettings.get_refinement_type"></a>`get_refinement_type() → [RefinementType](#amop.RefinementType)`
-- <a id="amop.AMopSettings.get_sampling_type_adapt"></a>`get_sampling_type_adapt() → [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES)`
-- <a id="amop.AMopSettings.get_sampling_type_init"></a>`get_sampling_type_init() → [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES)`
-- <a id="amop.AMopSettings.get_stagnation_iterations"></a>`get_stagnation_iterations() → int`
-- <a id="amop.AMopSettings.get_use_incomplete_designs"></a>`get_use_incomplete_designs() → bool`
-- <a id="amop.AMopSettings.get_use_pareto_refinement"></a>`get_use_pareto_refinement() → bool`
-- <a id="amop.AMopSettings.get_use_start_designs_only"></a>`get_use_start_designs_only() → bool`
-- <a id="amop.AMopSettings.get_weight_criteria"></a>`get_weight_criteria() → float`
-- <a id="amop.AMopSettings.get_weight_density"></a>`get_weight_density() → float`
-- <a id="amop.AMopSettings.get_weight_localCoP"></a>`get_weight_localCoP() → float`
-- <a id="amop.AMopSettings.set_consider_failed_designs"></a>`set_consider_failed_designs(arg2: bool)`
-- <a id="amop.AMopSettings.set_defaults"></a>`set_defaults()`
-- <a id="amop.AMopSettings.set_lower_bounds"></a>`set_lower_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="amop.AMopSettings.set_max_iteration"></a>`set_max_iteration(arg2: int)`
-- <a id="amop.AMopSettings.set_min_cop"></a>`set_min_cop(arg2: float)`
-- <a id="amop.AMopSettings.set_num_designs_max"></a>`set_num_designs_max(arg2: int)`
-- <a id="amop.AMopSettings.set_num_discretization_adapt"></a>`set_num_discretization_adapt(num_discretization: int)`<br>
-  Set AMOP discretization number for refinement
-- <a id="amop.AMopSettings.set_num_discretization_init"></a>`set_num_discretization_init(num_discretization: int)`<br>
-  Set AMOP discretization number for start iteration
-- <a id="amop.AMopSettings.set_num_equalities"></a>`set_num_equalities(arg2: int)`
-- <a id="amop.AMopSettings.set_num_inequalities"></a>`set_num_inequalities(arg2: int)`
-- <a id="amop.AMopSettings.set_num_inputs"></a>`set_num_inputs(arg2: int)`
-- <a id="amop.AMopSettings.set_num_objectives"></a>`set_num_objectives(arg2: int)`
-- <a id="amop.AMopSettings.set_num_responses"></a>`set_num_responses(arg2: int)`
-- <a id="amop.AMopSettings.set_refinement_type"></a>`set_refinement_type(arg2: [RefinementType](#amop.RefinementType))`
-- <a id="amop.AMopSettings.set_sampling_type_adapt"></a>`set_sampling_type_adapt(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))`
-- <a id="amop.AMopSettings.set_sampling_type_init"></a>`set_sampling_type_init(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))`
-- <a id="amop.AMopSettings.set_stagnation_iterations"></a>`set_stagnation_iterations(arg2: int)`
-- <a id="amop.AMopSettings.set_upper_bounds"></a>`set_upper_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="amop.AMopSettings.set_use_incomplete_designs"></a>`set_use_incomplete_designs(arg2: bool)`
-- <a id="amop.AMopSettings.set_use_pareto_refinement"></a>`set_use_pareto_refinement(arg2: bool)`
-- <a id="amop.AMopSettings.set_use_start_designs_only"></a>`set_use_start_designs_only(arg2: bool)`
-- <a id="amop.AMopSettings.set_weight_criteria"></a>`set_weight_criteria(arg2: float)`
-- <a id="amop.AMopSettings.set_weight_density"></a>`set_weight_density(arg2: float)`
-- <a id="amop.AMopSettings.set_weight_localCoP"></a>`set_weight_localCoP(arg2: float)`
+<a id="amop.AMopSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="amop.AMopSettings.get_consider_failed_designs"></a>
+
+#### get_consider_failed_designs() → bool
+
+<a id="amop.AMopSettings.get_max_iteration"></a>
+
+#### get_max_iteration() → int
+
+<a id="amop.AMopSettings.get_min_cop"></a>
+
+#### get_min_cop() → float
+
+<a id="amop.AMopSettings.get_num_designs"></a>
+
+#### get_num_designs() → int
+
+<a id="amop.AMopSettings.get_num_designs_max"></a>
+
+#### get_num_designs_max() → int
+
+<a id="amop.AMopSettings.get_num_discretization_adapt"></a>
+
+#### get_num_discretization_adapt() → int
+
+Return AMOP discretization number for refinement settings
+
+<a id="amop.AMopSettings.get_num_discretization_init"></a>
+
+#### get_num_discretization_init() → int
+
+Return AMOP discretization number for start iteration settings
+
+<a id="amop.AMopSettings.get_num_equalities"></a>
+
+#### get_num_equalities() → int
+
+<a id="amop.AMopSettings.get_num_inequalities"></a>
+
+#### get_num_inequalities() → int
+
+<a id="amop.AMopSettings.get_num_inputs"></a>
+
+#### get_num_inputs() → int
+
+<a id="amop.AMopSettings.get_num_objectives"></a>
+
+#### get_num_objectives() → int
+
+<a id="amop.AMopSettings.get_num_responses"></a>
+
+#### get_num_responses() → int
+
+<a id="amop.AMopSettings.get_refinement_type"></a>
+
+#### get_refinement_type() → [RefinementType](#amop.RefinementType)
+
+<a id="amop.AMopSettings.get_sampling_type_adapt"></a>
+
+#### get_sampling_type_adapt() → [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES)
+
+<a id="amop.AMopSettings.get_sampling_type_init"></a>
+
+#### get_sampling_type_init() → [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES)
+
+<a id="amop.AMopSettings.get_stagnation_iterations"></a>
+
+#### get_stagnation_iterations() → int
+
+<a id="amop.AMopSettings.get_use_incomplete_designs"></a>
+
+#### get_use_incomplete_designs() → bool
+
+<a id="amop.AMopSettings.get_use_pareto_refinement"></a>
+
+#### get_use_pareto_refinement() → bool
+
+<a id="amop.AMopSettings.get_use_start_designs_only"></a>
+
+#### get_use_start_designs_only() → bool
+
+<a id="amop.AMopSettings.get_weight_criteria"></a>
+
+#### get_weight_criteria() → float
+
+<a id="amop.AMopSettings.get_weight_density"></a>
+
+#### get_weight_density() → float
+
+<a id="amop.AMopSettings.get_weight_localCoP"></a>
+
+#### get_weight_localCoP() → float
+
+<a id="amop.AMopSettings.set_consider_failed_designs"></a>
+
+#### set_consider_failed_designs(arg2: bool)
+
+<a id="amop.AMopSettings.set_defaults"></a>
+
+#### set_defaults()
+
+<a id="amop.AMopSettings.set_lower_bounds"></a>
+
+#### set_lower_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+<a id="amop.AMopSettings.set_max_iteration"></a>
+
+#### set_max_iteration(arg2: int)
+
+<a id="amop.AMopSettings.set_min_cop"></a>
+
+#### set_min_cop(arg2: float)
+
+<a id="amop.AMopSettings.set_num_designs_max"></a>
+
+#### set_num_designs_max(arg2: int)
+
+<a id="amop.AMopSettings.set_num_discretization_adapt"></a>
+
+#### set_num_discretization_adapt(num_discretization: int)
+
+Set AMOP discretization number for refinement
+
+<a id="amop.AMopSettings.set_num_discretization_init"></a>
+
+#### set_num_discretization_init(num_discretization: int)
+
+Set AMOP discretization number for start iteration
+
+<a id="amop.AMopSettings.set_num_equalities"></a>
+
+#### set_num_equalities(arg2: int)
+
+<a id="amop.AMopSettings.set_num_inequalities"></a>
+
+#### set_num_inequalities(arg2: int)
+
+<a id="amop.AMopSettings.set_num_inputs"></a>
+
+#### set_num_inputs(arg2: int)
+
+<a id="amop.AMopSettings.set_num_objectives"></a>
+
+#### set_num_objectives(arg2: int)
+
+<a id="amop.AMopSettings.set_num_responses"></a>
+
+#### set_num_responses(arg2: int)
+
+<a id="amop.AMopSettings.set_refinement_type"></a>
+
+#### set_refinement_type(arg2: [RefinementType](#amop.RefinementType))
+
+<a id="amop.AMopSettings.set_sampling_type_adapt"></a>
+
+#### set_sampling_type_adapt(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))
+
+<a id="amop.AMopSettings.set_sampling_type_init"></a>
+
+#### set_sampling_type_init(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))
+
+<a id="amop.AMopSettings.set_stagnation_iterations"></a>
+
+#### set_stagnation_iterations(arg2: int)
+
+<a id="amop.AMopSettings.set_upper_bounds"></a>
+
+#### set_upper_bounds(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+<a id="amop.AMopSettings.set_use_incomplete_designs"></a>
+
+#### set_use_incomplete_designs(arg2: bool)
+
+<a id="amop.AMopSettings.set_use_pareto_refinement"></a>
+
+#### set_use_pareto_refinement(arg2: bool)
+
+<a id="amop.AMopSettings.set_use_start_designs_only"></a>
+
+#### set_use_start_designs_only(arg2: bool)
+
+<a id="amop.AMopSettings.set_weight_criteria"></a>
+
+#### set_weight_criteria(arg2: float)
+
+<a id="amop.AMopSettings.set_weight_density"></a>
+
+#### set_weight_density(arg2: float)
+
+<a id="amop.AMopSettings.set_weight_localCoP"></a>
+
+#### set_weight_localCoP(arg2: float)
 
 <a id="amop.RefinementType"></a>
 
@@ -90,6 +302,14 @@
 
 **Enumeration**
 
-- <a id="amop.RefinementType.CRITERIA_REFINEMENT"></a>`CRITERIA_REFINEMENT *= amop.RefinementType.CRITERIA_REFINEMENT*`
-- <a id="amop.RefinementType.GLOBAL_REFINEMENT"></a>`GLOBAL_REFINEMENT *= amop.RefinementType.GLOBAL_REFINEMENT*`
-- <a id="amop.RefinementType.LOCAL_REFINEMENT"></a>`LOCAL_REFINEMENT *= amop.RefinementType.LOCAL_REFINEMENT*`
+<a id="amop.RefinementType.CRITERIA_REFINEMENT"></a>
+
+#### CRITERIA_REFINEMENT *= amop.RefinementType.CRITERIA_REFINEMENT*
+
+<a id="amop.RefinementType.GLOBAL_REFINEMENT"></a>
+
+#### GLOBAL_REFINEMENT *= amop.RefinementType.GLOBAL_REFINEMENT*
+
+<a id="amop.RefinementType.LOCAL_REFINEMENT"></a>
+
+#### LOCAL_REFINEMENT *= amop.RefinementType.LOCAL_REFINEMENT*

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/custom_types.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/custom_types.md
@@ -6,35 +6,83 @@
 
 An aggregate of input arguments per hid.
 
-- <a id="custom_types.HidSpecificInputData.__init__"></a>`__init__()`
-- <a id="custom_types.HidSpecificInputData.hid"></a>*property* `hid`<br>
-  Hierarchical  ID of a design variation, for example, [0.99.4]
-- <a id="custom_types.HidSpecificInputData.input_file"></a>*property* `input_file`<br>
-  Input file.
-- <a id="custom_types.HidSpecificInputData.input_file_encoding"></a>*property* `input_file_encoding`<br>
-  Input file encoding.
-- <a id="custom_types.HidSpecificInputData.input_slot_values"></a>*property* `input_slot_values`<br>
-  A dict where slot names are keys and items are the slot values.
-- <a id="custom_types.HidSpecificInputData.osl_variables"></a>*property* `osl_variables`<br>
-  A dict where the keys are optiSLang application specific variables names and items their respective values.
-- <a id="custom_types.HidSpecificInputData.reference_file"></a>*property* `reference_file`<br>
-  Reference file.
-- <a id="custom_types.HidSpecificInputData.reference_file_encoding"></a>*property* `reference_file_encoding`<br>
-  Reference file encoding.
-- <a id="custom_types.HidSpecificInputData.reference_file_is_relative_to_working_directory"></a>*property* `reference_file_is_relative_to_working_directory`<br>
-  Whether “reference_file” is specified relative to working directory.
-- <a id="custom_types.HidSpecificInputData.working_dir_hierarchy"></a>*property* `working_dir_hierarchy`<br>
-  The nodes working directory hierarchy.
-- <a id="custom_types.HidSpecificInputData.working_directory"></a>*property* `working_directory`<br>
-  String. The nodes working directory.
+<a id="custom_types.HidSpecificInputData.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="custom_types.HidSpecificInputData.hid"></a>
+
+#### *property* hid
+
+Hierarchical  ID of a design variation, for example, [0.99.4]
+
+<a id="custom_types.HidSpecificInputData.input_file"></a>
+
+#### *property* input_file
+
+Input file.
+
+<a id="custom_types.HidSpecificInputData.input_file_encoding"></a>
+
+#### *property* input_file_encoding
+
+Input file encoding.
+
+<a id="custom_types.HidSpecificInputData.input_slot_values"></a>
+
+#### *property* input_slot_values
+
+A dict where slot names are keys and items are the slot values.
+
+<a id="custom_types.HidSpecificInputData.osl_variables"></a>
+
+#### *property* osl_variables
+
+A dict where the keys are optiSLang application specific variables names and items their respective values.
+
+<a id="custom_types.HidSpecificInputData.reference_file"></a>
+
+#### *property* reference_file
+
+Reference file.
+
+<a id="custom_types.HidSpecificInputData.reference_file_encoding"></a>
+
+#### *property* reference_file_encoding
+
+Reference file encoding.
+
+<a id="custom_types.HidSpecificInputData.reference_file_is_relative_to_working_directory"></a>
+
+#### *property* reference_file_is_relative_to_working_directory
+
+Whether “reference_file” is specified relative to working directory.
+
+<a id="custom_types.HidSpecificInputData.working_dir_hierarchy"></a>
+
+#### *property* working_dir_hierarchy
+
+The nodes working directory hierarchy.
+
+<a id="custom_types.HidSpecificInputData.working_directory"></a>
+
+#### *property* working_directory
+
+String. The nodes working directory.
 
 <a id="custom_types.HidSpecificInputDataIntegrations"></a>
 
 ## *class* custom_types.HidSpecificInputDataIntegrations
 
-- <a id="custom_types.HidSpecificInputDataIntegrations.__init__"></a>`__init__()`
-- <a id="custom_types.HidSpecificInputDataIntegrations.parameter_values"></a>*property* `parameter_values`<br>
-  Parameter values of a specific HId.
+<a id="custom_types.HidSpecificInputDataIntegrations.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="custom_types.HidSpecificInputDataIntegrations.parameter_values"></a>
+
+#### *property* parameter_values
+
+Parameter values of a specific HId.
 
 <a id="custom_types.HidSpecificOutputData"></a>
 
@@ -42,20 +90,43 @@ An aggregate of input arguments per hid.
 
 An aggregate of output arguments per hid.
 
-- <a id="custom_types.HidSpecificOutputData.__init__"></a>`__init__()`<br>
-  [5] Create a HidSpecificOutputData instance. [6] Create a HidSpecificOutputData instance.
-- `__init__(arg2: [HID](id.md#id.HID))`
-- `__init__(arg2: [HID](id.md#id.HID), arg3: [RunStatus](#custom_types.RunStatus))`
-- `__init__(arg2: [HidSpecificInputData](#custom_types.HidSpecificInputData))`
-- `__init__(arg2: [HidSpecificInputData](#custom_types.HidSpecificInputData), arg3: [RunStatus](#custom_types.RunStatus))`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- <a id="custom_types.HidSpecificOutputData.hid"></a>*property* `hid`<br>
-  Hierarchical  ID of a design variation, for example, [0.99.4]
-- <a id="custom_types.HidSpecificOutputData.output_slot_values"></a>*property* `output_slot_values`<br>
-  A dict where keys are the output slot names and items are the output slot values.
-- <a id="custom_types.HidSpecificOutputData.status"></a>*property* `status`<br>
-  RunStatus object.
+<a id="custom_types.HidSpecificOutputData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [HID](id.md#id.HID))
+
+#### \_\_init_\_(arg2: [HID](id.md#id.HID), arg3: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(arg2: [HidSpecificInputData](#custom_types.HidSpecificInputData))
+
+#### \_\_init_\_(arg2: [HidSpecificInputData](#custom_types.HidSpecificInputData), arg3: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+[5] Create a HidSpecificOutputData instance.
+
+[6] Create a HidSpecificOutputData instance.
+
+<a id="custom_types.HidSpecificOutputData.hid"></a>
+
+#### *property* hid
+
+Hierarchical  ID of a design variation, for example, [0.99.4]
+
+<a id="custom_types.HidSpecificOutputData.output_slot_values"></a>
+
+#### *property* output_slot_values
+
+A dict where keys are the output slot names and items are the output slot values.
+
+<a id="custom_types.HidSpecificOutputData.status"></a>
+
+#### *property* status
+
+RunStatus object.
 
 <a id="custom_types.HidSpecificOutputDataIntegrations"></a>
 
@@ -63,20 +134,53 @@ An aggregate of output arguments per hid.
 
 An aggregate of output arguments per hid. Specialization for integration node.
 
-- <a id="custom_types.HidSpecificOutputDataIntegrations.__init__"></a>`__init__()`<br>
-  [1] Create a HidSpecificOutputDataIntegrations instance. [2] Create a HidSpecificOutputDataIntegrations instance. [3] Create a HidSpecificOutputDataIntegrations instance. [4] Create a HidSpecificOutputDataIntegrations instance. [5] Create a HidSpecificOutputDataIntegrations instance. [6] Create a HidSpecificOutputDataIntegrations instance. [7] Create a HidSpecificOutputDataIntegrations instance. [8] Create a HidSpecificOutputDataIntegrations instance.
-- `__init__(hid: [HID](id.md#id.HID))`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus))`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData))`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus))`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, response_values: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → object`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, response_values: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → object`
-- <a id="custom_types.HidSpecificOutputDataIntegrations.adapted_parameter_values"></a>*property* `adapted_parameter_values`<br>
-  Adapted parameter values of a specific HId.
-- <a id="custom_types.HidSpecificOutputDataIntegrations.responses"></a>*property* `responses`<br>
-  Response values of a specific HId.
+<a id="custom_types.HidSpecificOutputDataIntegrations.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID))
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData))
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, response_values: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → object
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, response_values: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)) → object
+
+[1] Create a HidSpecificOutputDataIntegrations instance.
+
+[2] Create a HidSpecificOutputDataIntegrations instance.
+
+[3] Create a HidSpecificOutputDataIntegrations instance.
+
+[4] Create a HidSpecificOutputDataIntegrations instance.
+
+[5] Create a HidSpecificOutputDataIntegrations instance.
+
+[6] Create a HidSpecificOutputDataIntegrations instance.
+
+[7] Create a HidSpecificOutputDataIntegrations instance.
+
+[8] Create a HidSpecificOutputDataIntegrations instance.
+
+<a id="custom_types.HidSpecificOutputDataIntegrations.adapted_parameter_values"></a>
+
+#### *property* adapted_parameter_values
+
+Adapted parameter values of a specific HId.
+
+<a id="custom_types.HidSpecificOutputDataIntegrations.responses"></a>
+
+#### *property* responses
+
+Response values of a specific HId.
 
 <a id="custom_types.HidSpecificOutputDataMop"></a>
 
@@ -84,18 +188,47 @@ An aggregate of output arguments per hid. Specialization for integration node.
 
 An aggregate of output arguments per hid. Specialization for MOP node.
 
-- <a id="custom_types.HidSpecificOutputDataMop.__init__"></a>`__init__()`<br>
-  [1] Create a HidSpecificOutputDataMop instance. [2] Create a HidSpecificOutputDataMop instance. [3] Create a HidSpecificOutputDataMop instance. [4] Create a HidSpecificOutputDataMop instance. [5] Create a HidSpecificOutputDataMop instance. [6] Create a HidSpecificOutputDataMop instance. [7] Create a HidSpecificOutputDataMop instance. [8] Create a HidSpecificOutputDataMop instance.
-- `__init__(hid: [HID](id.md#id.HID))`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus))`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData))`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus))`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- `__init__(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, resulting_parameter_manager: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → object`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object`
-- `__init__(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, resulting_parameter_manager: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → object`
-- <a id="custom_types.HidSpecificOutputDataMop.resulting_parameter_manager"></a>*property* `resulting_parameter_manager`<br>
-  A class for managing parameters.
+<a id="custom_types.HidSpecificOutputDataMop.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID))
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData))
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus))
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+#### \_\_init_\_(hid: [HID](id.md#id.HID), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, resulting_parameter_manager: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → object
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict) → object
+
+#### \_\_init_\_(input_data: [HidSpecificInputData](#custom_types.HidSpecificInputData), run_status: [RunStatus](#custom_types.RunStatus), output_slot_values: dict, resulting_parameter_manager: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)) → object
+
+[1] Create a HidSpecificOutputDataMop instance.
+
+[2] Create a HidSpecificOutputDataMop instance.
+
+[3] Create a HidSpecificOutputDataMop instance.
+
+[4] Create a HidSpecificOutputDataMop instance.
+
+[5] Create a HidSpecificOutputDataMop instance.
+
+[6] Create a HidSpecificOutputDataMop instance.
+
+[7] Create a HidSpecificOutputDataMop instance.
+
+[8] Create a HidSpecificOutputDataMop instance.
+
+<a id="custom_types.HidSpecificOutputDataMop.resulting_parameter_manager"></a>
+
+#### *property* resulting_parameter_manager
+
+A class for managing parameters.
 
 <a id="custom_types.InputDefinition"></a>
 
@@ -103,20 +236,47 @@ An aggregate of output arguments per hid. Specialization for MOP node.
 
 Defining the inputs.
 
-- <a id="custom_types.InputDefinition.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`
-- <a id="custom_types.InputDefinition.discrete_states"></a>*property* `discrete_states`<br>
-  None or a list of design entries.
-- <a id="custom_types.InputDefinition.lower_bound"></a>*property* `lower_bound`<br>
-  The lower bound or None.
-- <a id="custom_types.InputDefinition.mean"></a>*property* `mean`<br>
-  The value’s mean or None.
-- <a id="custom_types.InputDefinition.random_variable_type"></a>*property* `random_variable_type`<br>
-  The random variable’s type or None.
-- <a id="custom_types.InputDefinition.standard_deviation"></a>*property* `standard_deviation`<br>
-  The standard deviation or None.
-- <a id="custom_types.InputDefinition.upper_bound"></a>*property* `upper_bound`<br>
-  The upper bound or None.
+<a id="custom_types.InputDefinition.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
+
+<a id="custom_types.InputDefinition.discrete_states"></a>
+
+#### *property* discrete_states
+
+None or a list of design entries.
+
+<a id="custom_types.InputDefinition.lower_bound"></a>
+
+#### *property* lower_bound
+
+The lower bound or None.
+
+<a id="custom_types.InputDefinition.mean"></a>
+
+#### *property* mean
+
+The value’s mean or None.
+
+<a id="custom_types.InputDefinition.random_variable_type"></a>
+
+#### *property* random_variable_type
+
+The random variable’s type or None.
+
+<a id="custom_types.InputDefinition.standard_deviation"></a>
+
+#### *property* standard_deviation
+
+The standard deviation or None.
+
+<a id="custom_types.InputDefinition.upper_bound"></a>
+
+#### *property* upper_bound
+
+The upper bound or None.
 
 <a id="custom_types.OutputDefinition"></a>
 
@@ -124,9 +284,13 @@ Defining the inputs.
 
 Defining the outputs.
 
-- <a id="custom_types.OutputDefinition.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`
+<a id="custom_types.OutputDefinition.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
 
 <a id="custom_types.RunStatus"></a>
 
@@ -134,13 +298,25 @@ Defining the outputs.
 
 An object for documenting success and loggin purpose.
 
-- <a id="custom_types.RunStatus.__init__"></a>`__init__()`
-- `__init__(arg2: bool)`
-- `__init__(arg2: bool, arg3: str)`
-- <a id="custom_types.RunStatus.message"></a>*property* `message`<br>
-  Message for logging purpose.
-- <a id="custom_types.RunStatus.success"></a>*property* `success`<br>
-  Flag for documenting success.
+<a id="custom_types.RunStatus.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: bool)
+
+#### \_\_init_\_(arg2: bool, arg3: str)
+
+<a id="custom_types.RunStatus.message"></a>
+
+#### *property* message
+
+Message for logging purpose.
+
+<a id="custom_types.RunStatus.success"></a>
+
+#### *property* success
+
+Flag for documenting success.
 
 <a id="custom_types.ValueDefinition"></a>
 
@@ -148,9 +324,23 @@ An object for documenting success and loggin purpose.
 
 Common base for InputValueDefintion and OutputDefinition
 
-- <a id="custom_types.ValueDefinition.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="custom_types.ValueDefinition.additional_data"></a>*property* `additional_data`<br>
-  Extend the list view of detected inputs and outputs by additional columns                                                                                   where “key” is the column headers and “item” is the corresponding field value.                                                                                   A tree structure for grouping the data can be build here as well:                                                                                   Providing “”entry_n” : “ANodeLabel””, where n can be 1-9, the current ValueDefinition is                                                                                   assigned to the specified group.
-- <a id="custom_types.ValueDefinition.name"></a>*property* `name`
-- <a id="custom_types.ValueDefinition.value"></a>*property* `value`
+<a id="custom_types.ValueDefinition.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="custom_types.ValueDefinition.additional_data"></a>
+
+#### *property* additional_data
+
+Extend the list view of detected inputs and outputs by additional columns                                                                                   where “key” is the column headers and “item” is the corresponding field value.                                                                                   A tree structure for grouping the data can be build here as well:                                                                                   Providing “”entry_n” : “ANodeLabel””, where n can be 1-9, the current ValueDefinition is                                                                                   assigned to the specified group.
+
+<a id="custom_types.ValueDefinition.name"></a>
+
+#### *property* name
+
+<a id="custom_types.ValueDefinition.value"></a>
+
+#### *property* value

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/dynardo_py_algorithms.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/dynardo_py_algorithms.md
@@ -6,28 +6,93 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.DOETYPES.ADVANCEDLATINHYPER"></a>`ADVANCEDLATINHYPER *= dynardo_py_algorithms.DOETYPES.ADVANCEDLATINHYPER*`
-- <a id="dynardo_py_algorithms.DOETYPES.AXIAL"></a>`AXIAL *= dynardo_py_algorithms.DOETYPES.AXIAL*`
-- <a id="dynardo_py_algorithms.DOETYPES.BOXBEHNKEN"></a>`BOXBEHNKEN *= dynardo_py_algorithms.DOETYPES.BOXBEHNKEN*`
-- <a id="dynardo_py_algorithms.DOETYPES.CENTERPOINT"></a>`CENTERPOINT *= dynardo_py_algorithms.DOETYPES.CENTERPOINT*`
-- <a id="dynardo_py_algorithms.DOETYPES.CENTRALCOMPOSITE"></a>`CENTRALCOMPOSITE *= dynardo_py_algorithms.DOETYPES.CENTRALCOMPOSITE*`
-- <a id="dynardo_py_algorithms.DOETYPES.DOPTIMAL"></a>`DOPTIMAL *= dynardo_py_algorithms.DOETYPES.DOPTIMAL*`
-- <a id="dynardo_py_algorithms.DOETYPES.DOPTIMALLINEAR"></a>`DOPTIMALLINEAR *= dynardo_py_algorithms.DOETYPES.DOPTIMALLINEAR*`
-- <a id="dynardo_py_algorithms.DOETYPES.DOPTIMALQUADRATIC"></a>`DOPTIMALQUADRATIC *= dynardo_py_algorithms.DOETYPES.DOPTIMALQUADRATIC*`
-- <a id="dynardo_py_algorithms.DOETYPES.FEKETE"></a>`FEKETE *= dynardo_py_algorithms.DOETYPES.FEKETE*`
-- <a id="dynardo_py_algorithms.DOETYPES.FULLCOMBINATORIAL"></a>`FULLCOMBINATORIAL *= dynardo_py_algorithms.DOETYPES.FULLCOMBINATORIAL*`
-- <a id="dynardo_py_algorithms.DOETYPES.FULLFACTORIAL"></a>`FULLFACTORIAL *= dynardo_py_algorithms.DOETYPES.FULLFACTORIAL*`
-- <a id="dynardo_py_algorithms.DOETYPES.KOSHAL"></a>`KOSHAL *= dynardo_py_algorithms.DOETYPES.KOSHAL*`
-- <a id="dynardo_py_algorithms.DOETYPES.KOSHALLINEAR"></a>`KOSHALLINEAR *= dynardo_py_algorithms.DOETYPES.KOSHALLINEAR*`
-- <a id="dynardo_py_algorithms.DOETYPES.KOSHALQUADRATIC"></a>`KOSHALQUADRATIC *= dynardo_py_algorithms.DOETYPES.KOSHALQUADRATIC*`
-- <a id="dynardo_py_algorithms.DOETYPES.LATINHYPER"></a>`LATINHYPER *= dynardo_py_algorithms.DOETYPES.LATINHYPER*`
-- <a id="dynardo_py_algorithms.DOETYPES.LATINHYPERDETERMINISTIC"></a>`LATINHYPERDETERMINISTIC *= dynardo_py_algorithms.DOETYPES.LATINHYPERDETERMINISTIC*`
-- <a id="dynardo_py_algorithms.DOETYPES.MIXEDTERMS"></a>`MIXEDTERMS *= dynardo_py_algorithms.DOETYPES.MIXEDTERMS*`
-- <a id="dynardo_py_algorithms.DOETYPES.ORTHOLATINHYPERDETERMINISTIC"></a>`ORTHOLATINHYPERDETERMINISTIC *= dynardo_py_algorithms.DOETYPES.ORTHOLATINHYPERDETERMINISTIC*`
-- <a id="dynardo_py_algorithms.DOETYPES.PLAINMONTECARLO"></a>`PLAINMONTECARLO *= dynardo_py_algorithms.DOETYPES.PLAINMONTECARLO*`
-- <a id="dynardo_py_algorithms.DOETYPES.SOBOL"></a>`SOBOL *= dynardo_py_algorithms.DOETYPES.SOBOL*`
-- <a id="dynardo_py_algorithms.DOETYPES.SPACEFILLINGLATINHYPER"></a>`SPACEFILLINGLATINHYPER *= dynardo_py_algorithms.DOETYPES.SPACEFILLINGLATINHYPER*`
-- <a id="dynardo_py_algorithms.DOETYPES.STARPOINTS"></a>`STARPOINTS *= dynardo_py_algorithms.DOETYPES.STARPOINTS*`
+<a id="dynardo_py_algorithms.DOETYPES.ADVANCEDLATINHYPER"></a>
+
+#### ADVANCEDLATINHYPER *= dynardo_py_algorithms.DOETYPES.ADVANCEDLATINHYPER*
+
+<a id="dynardo_py_algorithms.DOETYPES.AXIAL"></a>
+
+#### AXIAL *= dynardo_py_algorithms.DOETYPES.AXIAL*
+
+<a id="dynardo_py_algorithms.DOETYPES.BOXBEHNKEN"></a>
+
+#### BOXBEHNKEN *= dynardo_py_algorithms.DOETYPES.BOXBEHNKEN*
+
+<a id="dynardo_py_algorithms.DOETYPES.CENTERPOINT"></a>
+
+#### CENTERPOINT *= dynardo_py_algorithms.DOETYPES.CENTERPOINT*
+
+<a id="dynardo_py_algorithms.DOETYPES.CENTRALCOMPOSITE"></a>
+
+#### CENTRALCOMPOSITE *= dynardo_py_algorithms.DOETYPES.CENTRALCOMPOSITE*
+
+<a id="dynardo_py_algorithms.DOETYPES.DOPTIMAL"></a>
+
+#### DOPTIMAL *= dynardo_py_algorithms.DOETYPES.DOPTIMAL*
+
+<a id="dynardo_py_algorithms.DOETYPES.DOPTIMALLINEAR"></a>
+
+#### DOPTIMALLINEAR *= dynardo_py_algorithms.DOETYPES.DOPTIMALLINEAR*
+
+<a id="dynardo_py_algorithms.DOETYPES.DOPTIMALQUADRATIC"></a>
+
+#### DOPTIMALQUADRATIC *= dynardo_py_algorithms.DOETYPES.DOPTIMALQUADRATIC*
+
+<a id="dynardo_py_algorithms.DOETYPES.FEKETE"></a>
+
+#### FEKETE *= dynardo_py_algorithms.DOETYPES.FEKETE*
+
+<a id="dynardo_py_algorithms.DOETYPES.FULLCOMBINATORIAL"></a>
+
+#### FULLCOMBINATORIAL *= dynardo_py_algorithms.DOETYPES.FULLCOMBINATORIAL*
+
+<a id="dynardo_py_algorithms.DOETYPES.FULLFACTORIAL"></a>
+
+#### FULLFACTORIAL *= dynardo_py_algorithms.DOETYPES.FULLFACTORIAL*
+
+<a id="dynardo_py_algorithms.DOETYPES.KOSHAL"></a>
+
+#### KOSHAL *= dynardo_py_algorithms.DOETYPES.KOSHAL*
+
+<a id="dynardo_py_algorithms.DOETYPES.KOSHALLINEAR"></a>
+
+#### KOSHALLINEAR *= dynardo_py_algorithms.DOETYPES.KOSHALLINEAR*
+
+<a id="dynardo_py_algorithms.DOETYPES.KOSHALQUADRATIC"></a>
+
+#### KOSHALQUADRATIC *= dynardo_py_algorithms.DOETYPES.KOSHALQUADRATIC*
+
+<a id="dynardo_py_algorithms.DOETYPES.LATINHYPER"></a>
+
+#### LATINHYPER *= dynardo_py_algorithms.DOETYPES.LATINHYPER*
+
+<a id="dynardo_py_algorithms.DOETYPES.LATINHYPERDETERMINISTIC"></a>
+
+#### LATINHYPERDETERMINISTIC *= dynardo_py_algorithms.DOETYPES.LATINHYPERDETERMINISTIC*
+
+<a id="dynardo_py_algorithms.DOETYPES.MIXEDTERMS"></a>
+
+#### MIXEDTERMS *= dynardo_py_algorithms.DOETYPES.MIXEDTERMS*
+
+<a id="dynardo_py_algorithms.DOETYPES.ORTHOLATINHYPERDETERMINISTIC"></a>
+
+#### ORTHOLATINHYPERDETERMINISTIC *= dynardo_py_algorithms.DOETYPES.ORTHOLATINHYPERDETERMINISTIC*
+
+<a id="dynardo_py_algorithms.DOETYPES.PLAINMONTECARLO"></a>
+
+#### PLAINMONTECARLO *= dynardo_py_algorithms.DOETYPES.PLAINMONTECARLO*
+
+<a id="dynardo_py_algorithms.DOETYPES.SOBOL"></a>
+
+#### SOBOL *= dynardo_py_algorithms.DOETYPES.SOBOL*
+
+<a id="dynardo_py_algorithms.DOETYPES.SPACEFILLINGLATINHYPER"></a>
+
+#### SPACEFILLINGLATINHYPER *= dynardo_py_algorithms.DOETYPES.SPACEFILLINGLATINHYPER*
+
+<a id="dynardo_py_algorithms.DOETYPES.STARPOINTS"></a>
+
+#### STARPOINTS *= dynardo_py_algorithms.DOETYPES.STARPOINTS*
 
 <a id="dynardo_py_algorithms.DesignTypes"></a>
 
@@ -35,12 +100,29 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.DesignTypes.eGRADIENT"></a>`eGRADIENT *= dynardo_py_algorithms.DesignTypes.eGRADIENT*`
-- <a id="dynardo_py_algorithms.DesignTypes.eITERATION_BEST"></a>`eITERATION_BEST *= dynardo_py_algorithms.DesignTypes.eITERATION_BEST*`
-- <a id="dynardo_py_algorithms.DesignTypes.eNEW_POP"></a>`eNEW_POP *= dynardo_py_algorithms.DesignTypes.eNEW_POP*`
-- <a id="dynardo_py_algorithms.DesignTypes.eNONE"></a>`eNONE *= dynardo_py_algorithms.DesignTypes.eNONE*`
-- <a id="dynardo_py_algorithms.DesignTypes.eOBJECTIVE"></a>`eOBJECTIVE *= dynardo_py_algorithms.DesignTypes.eOBJECTIVE*`
-- <a id="dynardo_py_algorithms.DesignTypes.eSUPPORT_POINT"></a>`eSUPPORT_POINT *= dynardo_py_algorithms.DesignTypes.eSUPPORT_POINT*`
+<a id="dynardo_py_algorithms.DesignTypes.eGRADIENT"></a>
+
+#### eGRADIENT *= dynardo_py_algorithms.DesignTypes.eGRADIENT*
+
+<a id="dynardo_py_algorithms.DesignTypes.eITERATION_BEST"></a>
+
+#### eITERATION_BEST *= dynardo_py_algorithms.DesignTypes.eITERATION_BEST*
+
+<a id="dynardo_py_algorithms.DesignTypes.eNEW_POP"></a>
+
+#### eNEW_POP *= dynardo_py_algorithms.DesignTypes.eNEW_POP*
+
+<a id="dynardo_py_algorithms.DesignTypes.eNONE"></a>
+
+#### eNONE *= dynardo_py_algorithms.DesignTypes.eNONE*
+
+<a id="dynardo_py_algorithms.DesignTypes.eOBJECTIVE"></a>
+
+#### eOBJECTIVE *= dynardo_py_algorithms.DesignTypes.eOBJECTIVE*
+
+<a id="dynardo_py_algorithms.DesignTypes.eSUPPORT_POINT"></a>
+
+#### eSUPPORT_POINT *= dynardo_py_algorithms.DesignTypes.eSUPPORT_POINT*
 
 <a id="dynardo_py_algorithms.DeterministicType"></a>
 
@@ -48,26 +130,69 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.DeterministicType.CONTINUOUS"></a>`CONTINUOUS *= dynardo_py_algorithms.DeterministicType.CONTINUOUS*`
-- <a id="dynardo_py_algorithms.DeterministicType.NOMINALDISCRETE"></a>`NOMINALDISCRETE *= dynardo_py_algorithms.DeterministicType.NOMINALDISCRETE*`
-- <a id="dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_INDEX"></a>`ORDINALDISCRETE_INDEX *= dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_INDEX*`
-- <a id="dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_VALUE"></a>`ORDINALDISCRETE_VALUE *= dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_VALUE*`
+<a id="dynardo_py_algorithms.DeterministicType.CONTINUOUS"></a>
+
+#### CONTINUOUS *= dynardo_py_algorithms.DeterministicType.CONTINUOUS*
+
+<a id="dynardo_py_algorithms.DeterministicType.NOMINALDISCRETE"></a>
+
+#### NOMINALDISCRETE *= dynardo_py_algorithms.DeterministicType.NOMINALDISCRETE*
+
+<a id="dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_INDEX"></a>
+
+#### ORDINALDISCRETE_INDEX *= dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_INDEX*
+
+<a id="dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_VALUE"></a>
+
+#### ORDINALDISCRETE_VALUE *= dynardo_py_algorithms.DeterministicType.ORDINALDISCRETE_VALUE*
 
 <a id="dynardo_py_algorithms.DeterministicTypeVec"></a>
 
 ## *class* dynardo_py_algorithms.DeterministicTypeVec
 
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__init__"></a>`__init__()`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__iter__"></a>`__iter__() → object`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__len__"></a>`__len__() → int`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.append"></a>`append(arg2: object)`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.extend"></a>`extend(arg2: object)`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.push_back"></a>`push_back(arg2: [DeterministicType](#dynardo_py_algorithms.DeterministicType))`
-- <a id="dynardo_py_algorithms.DeterministicTypeVec.size"></a>`size() → int`
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.push_back"></a>
+
+#### push_back(arg2: [DeterministicType](#dynardo_py_algorithms.DeterministicType))
+
+<a id="dynardo_py_algorithms.DeterministicTypeVec.size"></a>
+
+#### size() → int
 
 <a id="dynardo_py_algorithms.DeterministicType_list_to_vec"></a>
 
@@ -81,10 +206,21 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.ParameterType.DEPENDENT"></a>`DEPENDENT *= dynardo_py_algorithms.ParameterType.DEPENDENT*`
-- <a id="dynardo_py_algorithms.ParameterType.DETERMINISTIC"></a>`DETERMINISTIC *= dynardo_py_algorithms.ParameterType.DETERMINISTIC*`
-- <a id="dynardo_py_algorithms.ParameterType.MIXED"></a>`MIXED *= dynardo_py_algorithms.ParameterType.MIXED*`
-- <a id="dynardo_py_algorithms.ParameterType.STOCHASTIC"></a>`STOCHASTIC *= dynardo_py_algorithms.ParameterType.STOCHASTIC*`
+<a id="dynardo_py_algorithms.ParameterType.DEPENDENT"></a>
+
+#### DEPENDENT *= dynardo_py_algorithms.ParameterType.DEPENDENT*
+
+<a id="dynardo_py_algorithms.ParameterType.DETERMINISTIC"></a>
+
+#### DETERMINISTIC *= dynardo_py_algorithms.ParameterType.DETERMINISTIC*
+
+<a id="dynardo_py_algorithms.ParameterType.MIXED"></a>
+
+#### MIXED *= dynardo_py_algorithms.ParameterType.MIXED*
+
+<a id="dynardo_py_algorithms.ParameterType.STOCHASTIC"></a>
+
+#### STOCHASTIC *= dynardo_py_algorithms.ParameterType.STOCHASTIC*
 
 <a id="dynardo_py_algorithms.RandomVariableKind"></a>
 
@@ -92,10 +228,21 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.RandomVariableKind.DETERMINISTIC"></a>`DETERMINISTIC *= dynardo_py_algorithms.RandomVariableKind.DETERMINISTIC*`
-- <a id="dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_CONTINUOUS"></a>`EMPIRICAL_CONTINUOUS *= dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_CONTINUOUS*`
-- <a id="dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_DISCRETE"></a>`EMPIRICAL_DISCRETE *= dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_DISCRETE*`
-- <a id="dynardo_py_algorithms.RandomVariableKind.MARGINALDISTRIBUTION"></a>`MARGINALDISTRIBUTION *= dynardo_py_algorithms.RandomVariableKind.MARGINALDISTRIBUTION*`
+<a id="dynardo_py_algorithms.RandomVariableKind.DETERMINISTIC"></a>
+
+#### DETERMINISTIC *= dynardo_py_algorithms.RandomVariableKind.DETERMINISTIC*
+
+<a id="dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_CONTINUOUS"></a>
+
+#### EMPIRICAL_CONTINUOUS *= dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_CONTINUOUS*
+
+<a id="dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_DISCRETE"></a>
+
+#### EMPIRICAL_DISCRETE *= dynardo_py_algorithms.RandomVariableKind.EMPIRICAL_DISCRETE*
+
+<a id="dynardo_py_algorithms.RandomVariableKind.MARGINALDISTRIBUTION"></a>
+
+#### MARGINALDISTRIBUTION *= dynardo_py_algorithms.RandomVariableKind.MARGINALDISTRIBUTION*
 
 <a id="dynardo_py_algorithms.RandomVariableType"></a>
 
@@ -103,69 +250,239 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.RandomVariableType.BERNOULLI"></a>`BERNOULLI *= dynardo_py_algorithms.RandomVariableType.BERNOULLI*`
-- <a id="dynardo_py_algorithms.RandomVariableType.BETA"></a>`BETA *= dynardo_py_algorithms.RandomVariableType.BETA*`
-- <a id="dynardo_py_algorithms.RandomVariableType.CHI_SQUARE"></a>`CHI_SQUARE *= dynardo_py_algorithms.RandomVariableType.CHI_SQUARE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.ERLANG"></a>`ERLANG *= dynardo_py_algorithms.RandomVariableType.ERLANG*`
-- <a id="dynardo_py_algorithms.RandomVariableType.EXPONENTIAL"></a>`EXPONENTIAL *= dynardo_py_algorithms.RandomVariableType.EXPONENTIAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.EXTERNAL"></a>`EXTERNAL *= dynardo_py_algorithms.RandomVariableType.EXTERNAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.EXTERNALCOHERENCE"></a>`EXTERNALCOHERENCE *= dynardo_py_algorithms.RandomVariableType.EXTERNALCOHERENCE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.EXTREME_VALUE"></a>`EXTREME_VALUE *= dynardo_py_algorithms.RandomVariableType.EXTREME_VALUE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.FISHER_F"></a>`FISHER_F *= dynardo_py_algorithms.RandomVariableType.FISHER_F*`
-- <a id="dynardo_py_algorithms.RandomVariableType.FISHER_TIPPETT"></a>`FISHER_TIPPETT *= dynardo_py_algorithms.RandomVariableType.FISHER_TIPPETT*`
-- <a id="dynardo_py_algorithms.RandomVariableType.FISHER_Z"></a>`FISHER_Z *= dynardo_py_algorithms.RandomVariableType.FISHER_Z*`
-- <a id="dynardo_py_algorithms.RandomVariableType.FRECHET"></a>`FRECHET *= dynardo_py_algorithms.RandomVariableType.FRECHET*`
-- <a id="dynardo_py_algorithms.RandomVariableType.GAMMA"></a>`GAMMA *= dynardo_py_algorithms.RandomVariableType.GAMMA*`
-- <a id="dynardo_py_algorithms.RandomVariableType.GENERAL_DISCRETE"></a>`GENERAL_DISCRETE *= dynardo_py_algorithms.RandomVariableType.GENERAL_DISCRETE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.GUMBEL"></a>`GUMBEL *= dynardo_py_algorithms.RandomVariableType.GUMBEL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.INVERSE_NORMAL"></a>`INVERSE_NORMAL *= dynardo_py_algorithms.RandomVariableType.INVERSE_NORMAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.KERNEL"></a>`KERNEL *= dynardo_py_algorithms.RandomVariableType.KERNEL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LAMBDA"></a>`LAMBDA *= dynardo_py_algorithms.RandomVariableType.LAMBDA*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LAPLACE"></a>`LAPLACE *= dynardo_py_algorithms.RandomVariableType.LAPLACE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LARGE_I"></a>`LARGE_I *= dynardo_py_algorithms.RandomVariableType.LARGE_I*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LARGE_II"></a>`LARGE_II *= dynardo_py_algorithms.RandomVariableType.LARGE_II*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LARGE_III"></a>`LARGE_III *= dynardo_py_algorithms.RandomVariableType.LARGE_III*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LEVY"></a>`LEVY *= dynardo_py_algorithms.RandomVariableType.LEVY*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LOGISTIC"></a>`LOGISTIC *= dynardo_py_algorithms.RandomVariableType.LOGISTIC*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LOGNORMAL"></a>`LOGNORMAL *= dynardo_py_algorithms.RandomVariableType.LOGNORMAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LOGUNIFORM"></a>`LOGUNIFORM *= dynardo_py_algorithms.RandomVariableType.LOGUNIFORM*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LOG_GAMMA"></a>`LOG_GAMMA *= dynardo_py_algorithms.RandomVariableType.LOG_GAMMA*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LOG_NORMAL"></a>`LOG_NORMAL *= dynardo_py_algorithms.RandomVariableType.LOG_NORMAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.LORENTZ"></a>`LORENTZ *= dynardo_py_algorithms.RandomVariableType.LORENTZ*`
-- <a id="dynardo_py_algorithms.RandomVariableType.MAX_TYPE"></a>`MAX_TYPE *= dynardo_py_algorithms.RandomVariableType.MAX_TYPE*`
-- <a id="dynardo_py_algorithms.RandomVariableType.MULTIUNIFORM"></a>`MULTIUNIFORM *= dynardo_py_algorithms.RandomVariableType.MULTIUNIFORM*`
-- <a id="dynardo_py_algorithms.RandomVariableType.NORMAL"></a>`NORMAL *= dynardo_py_algorithms.RandomVariableType.NORMAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.PARETO"></a>`PARETO *= dynardo_py_algorithms.RandomVariableType.PARETO*`
-- <a id="dynardo_py_algorithms.RandomVariableType.POISSON"></a>`POISSON *= dynardo_py_algorithms.RandomVariableType.POISSON*`
-- <a id="dynardo_py_algorithms.RandomVariableType.POLYMAP"></a>`POLYMAP *= dynardo_py_algorithms.RandomVariableType.POLYMAP*`
-- <a id="dynardo_py_algorithms.RandomVariableType.RAYLEIGH"></a>`RAYLEIGH *= dynardo_py_algorithms.RandomVariableType.RAYLEIGH*`
-- <a id="dynardo_py_algorithms.RandomVariableType.ROSSI"></a>`ROSSI *= dynardo_py_algorithms.RandomVariableType.ROSSI*`
-- <a id="dynardo_py_algorithms.RandomVariableType.SMALL_I"></a>`SMALL_I *= dynardo_py_algorithms.RandomVariableType.SMALL_I*`
-- <a id="dynardo_py_algorithms.RandomVariableType.SMALL_II"></a>`SMALL_II *= dynardo_py_algorithms.RandomVariableType.SMALL_II*`
-- <a id="dynardo_py_algorithms.RandomVariableType.SMALL_III"></a>`SMALL_III *= dynardo_py_algorithms.RandomVariableType.SMALL_III*`
-- <a id="dynardo_py_algorithms.RandomVariableType.STUDENTS_T"></a>`STUDENTS_T *= dynardo_py_algorithms.RandomVariableType.STUDENTS_T*`
-- <a id="dynardo_py_algorithms.RandomVariableType.TRIANGULAR"></a>`TRIANGULAR *= dynardo_py_algorithms.RandomVariableType.TRIANGULAR*`
-- <a id="dynardo_py_algorithms.RandomVariableType.TRUNCATEDNORMAL"></a>`TRUNCATEDNORMAL *= dynardo_py_algorithms.RandomVariableType.TRUNCATEDNORMAL*`
-- <a id="dynardo_py_algorithms.RandomVariableType.UNIFORM"></a>`UNIFORM *= dynardo_py_algorithms.RandomVariableType.UNIFORM*`
-- <a id="dynardo_py_algorithms.RandomVariableType.UNTYPED"></a>`UNTYPED *= dynardo_py_algorithms.RandomVariableType.UNTYPED*`
-- <a id="dynardo_py_algorithms.RandomVariableType.WEIBULL"></a>`WEIBULL *= dynardo_py_algorithms.RandomVariableType.WEIBULL*`
+<a id="dynardo_py_algorithms.RandomVariableType.BERNOULLI"></a>
+
+#### BERNOULLI *= dynardo_py_algorithms.RandomVariableType.BERNOULLI*
+
+<a id="dynardo_py_algorithms.RandomVariableType.BETA"></a>
+
+#### BETA *= dynardo_py_algorithms.RandomVariableType.BETA*
+
+<a id="dynardo_py_algorithms.RandomVariableType.CHI_SQUARE"></a>
+
+#### CHI_SQUARE *= dynardo_py_algorithms.RandomVariableType.CHI_SQUARE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.ERLANG"></a>
+
+#### ERLANG *= dynardo_py_algorithms.RandomVariableType.ERLANG*
+
+<a id="dynardo_py_algorithms.RandomVariableType.EXPONENTIAL"></a>
+
+#### EXPONENTIAL *= dynardo_py_algorithms.RandomVariableType.EXPONENTIAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.EXTERNAL"></a>
+
+#### EXTERNAL *= dynardo_py_algorithms.RandomVariableType.EXTERNAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.EXTERNALCOHERENCE"></a>
+
+#### EXTERNALCOHERENCE *= dynardo_py_algorithms.RandomVariableType.EXTERNALCOHERENCE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.EXTREME_VALUE"></a>
+
+#### EXTREME_VALUE *= dynardo_py_algorithms.RandomVariableType.EXTREME_VALUE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.FISHER_F"></a>
+
+#### FISHER_F *= dynardo_py_algorithms.RandomVariableType.FISHER_F*
+
+<a id="dynardo_py_algorithms.RandomVariableType.FISHER_TIPPETT"></a>
+
+#### FISHER_TIPPETT *= dynardo_py_algorithms.RandomVariableType.FISHER_TIPPETT*
+
+<a id="dynardo_py_algorithms.RandomVariableType.FISHER_Z"></a>
+
+#### FISHER_Z *= dynardo_py_algorithms.RandomVariableType.FISHER_Z*
+
+<a id="dynardo_py_algorithms.RandomVariableType.FRECHET"></a>
+
+#### FRECHET *= dynardo_py_algorithms.RandomVariableType.FRECHET*
+
+<a id="dynardo_py_algorithms.RandomVariableType.GAMMA"></a>
+
+#### GAMMA *= dynardo_py_algorithms.RandomVariableType.GAMMA*
+
+<a id="dynardo_py_algorithms.RandomVariableType.GENERAL_DISCRETE"></a>
+
+#### GENERAL_DISCRETE *= dynardo_py_algorithms.RandomVariableType.GENERAL_DISCRETE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.GUMBEL"></a>
+
+#### GUMBEL *= dynardo_py_algorithms.RandomVariableType.GUMBEL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.INVERSE_NORMAL"></a>
+
+#### INVERSE_NORMAL *= dynardo_py_algorithms.RandomVariableType.INVERSE_NORMAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.KERNEL"></a>
+
+#### KERNEL *= dynardo_py_algorithms.RandomVariableType.KERNEL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LAMBDA"></a>
+
+#### LAMBDA *= dynardo_py_algorithms.RandomVariableType.LAMBDA*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LAPLACE"></a>
+
+#### LAPLACE *= dynardo_py_algorithms.RandomVariableType.LAPLACE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LARGE_I"></a>
+
+#### LARGE_I *= dynardo_py_algorithms.RandomVariableType.LARGE_I*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LARGE_II"></a>
+
+#### LARGE_II *= dynardo_py_algorithms.RandomVariableType.LARGE_II*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LARGE_III"></a>
+
+#### LARGE_III *= dynardo_py_algorithms.RandomVariableType.LARGE_III*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LEVY"></a>
+
+#### LEVY *= dynardo_py_algorithms.RandomVariableType.LEVY*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LOGISTIC"></a>
+
+#### LOGISTIC *= dynardo_py_algorithms.RandomVariableType.LOGISTIC*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LOGNORMAL"></a>
+
+#### LOGNORMAL *= dynardo_py_algorithms.RandomVariableType.LOGNORMAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LOGUNIFORM"></a>
+
+#### LOGUNIFORM *= dynardo_py_algorithms.RandomVariableType.LOGUNIFORM*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LOG_GAMMA"></a>
+
+#### LOG_GAMMA *= dynardo_py_algorithms.RandomVariableType.LOG_GAMMA*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LOG_NORMAL"></a>
+
+#### LOG_NORMAL *= dynardo_py_algorithms.RandomVariableType.LOG_NORMAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.LORENTZ"></a>
+
+#### LORENTZ *= dynardo_py_algorithms.RandomVariableType.LORENTZ*
+
+<a id="dynardo_py_algorithms.RandomVariableType.MAX_TYPE"></a>
+
+#### MAX_TYPE *= dynardo_py_algorithms.RandomVariableType.MAX_TYPE*
+
+<a id="dynardo_py_algorithms.RandomVariableType.MULTIUNIFORM"></a>
+
+#### MULTIUNIFORM *= dynardo_py_algorithms.RandomVariableType.MULTIUNIFORM*
+
+<a id="dynardo_py_algorithms.RandomVariableType.NORMAL"></a>
+
+#### NORMAL *= dynardo_py_algorithms.RandomVariableType.NORMAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.PARETO"></a>
+
+#### PARETO *= dynardo_py_algorithms.RandomVariableType.PARETO*
+
+<a id="dynardo_py_algorithms.RandomVariableType.POISSON"></a>
+
+#### POISSON *= dynardo_py_algorithms.RandomVariableType.POISSON*
+
+<a id="dynardo_py_algorithms.RandomVariableType.POLYMAP"></a>
+
+#### POLYMAP *= dynardo_py_algorithms.RandomVariableType.POLYMAP*
+
+<a id="dynardo_py_algorithms.RandomVariableType.RAYLEIGH"></a>
+
+#### RAYLEIGH *= dynardo_py_algorithms.RandomVariableType.RAYLEIGH*
+
+<a id="dynardo_py_algorithms.RandomVariableType.ROSSI"></a>
+
+#### ROSSI *= dynardo_py_algorithms.RandomVariableType.ROSSI*
+
+<a id="dynardo_py_algorithms.RandomVariableType.SMALL_I"></a>
+
+#### SMALL_I *= dynardo_py_algorithms.RandomVariableType.SMALL_I*
+
+<a id="dynardo_py_algorithms.RandomVariableType.SMALL_II"></a>
+
+#### SMALL_II *= dynardo_py_algorithms.RandomVariableType.SMALL_II*
+
+<a id="dynardo_py_algorithms.RandomVariableType.SMALL_III"></a>
+
+#### SMALL_III *= dynardo_py_algorithms.RandomVariableType.SMALL_III*
+
+<a id="dynardo_py_algorithms.RandomVariableType.STUDENTS_T"></a>
+
+#### STUDENTS_T *= dynardo_py_algorithms.RandomVariableType.STUDENTS_T*
+
+<a id="dynardo_py_algorithms.RandomVariableType.TRIANGULAR"></a>
+
+#### TRIANGULAR *= dynardo_py_algorithms.RandomVariableType.TRIANGULAR*
+
+<a id="dynardo_py_algorithms.RandomVariableType.TRUNCATEDNORMAL"></a>
+
+#### TRUNCATEDNORMAL *= dynardo_py_algorithms.RandomVariableType.TRUNCATEDNORMAL*
+
+<a id="dynardo_py_algorithms.RandomVariableType.UNIFORM"></a>
+
+#### UNIFORM *= dynardo_py_algorithms.RandomVariableType.UNIFORM*
+
+<a id="dynardo_py_algorithms.RandomVariableType.UNTYPED"></a>
+
+#### UNTYPED *= dynardo_py_algorithms.RandomVariableType.UNTYPED*
+
+<a id="dynardo_py_algorithms.RandomVariableType.WEIBULL"></a>
+
+#### WEIBULL *= dynardo_py_algorithms.RandomVariableType.WEIBULL*
 
 <a id="dynardo_py_algorithms.RandomVariableTypeVec"></a>
 
 ## *class* dynardo_py_algorithms.RandomVariableTypeVec
 
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__init__"></a>`__init__()`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__len__"></a>`__len__() → int`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.append"></a>`append(arg2: object)`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.extend"></a>`extend(arg2: object)`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.push_back"></a>`push_back(arg2: [RandomVariableType](#dynardo_py_algorithms.RandomVariableType))`
-- <a id="dynardo_py_algorithms.RandomVariableTypeVec.size"></a>`size() → int`
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.push_back"></a>
+
+#### push_back(arg2: [RandomVariableType](#dynardo_py_algorithms.RandomVariableType))
+
+<a id="dynardo_py_algorithms.RandomVariableTypeVec.size"></a>
+
+#### size() → int
 
 <a id="dynardo_py_algorithms.SupportedAlgorithms"></a>
 
@@ -173,38 +490,117 @@
 
 **Enumeration**
 
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.APPROXIMATION"></a>`APPROXIMATION *= dynardo_py_algorithms.SupportedAlgorithms.APPROXIMATION*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.ARSM"></a>`ARSM *= dynardo_py_algorithms.SupportedAlgorithms.ARSM*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.CMA"></a>`CMA *= dynardo_py_algorithms.SupportedAlgorithms.CMA*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_OPTIMIZATION"></a>`CUSTOM_OPTIMIZATION *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_OPTIMIZATION*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_SAMPLING"></a>`CUSTOM_SAMPLING *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_SAMPLING*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_STOCHASTIC"></a>`CUSTOM_STOCHASTIC *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_STOCHASTIC*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.EA"></a>`EA *= dynardo_py_algorithms.SupportedAlgorithms.EA*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.IMPORTED"></a>`IMPORTED *= dynardo_py_algorithms.SupportedAlgorithms.IMPORTED*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.MEMETIC"></a>`MEMETIC *= dynardo_py_algorithms.SupportedAlgorithms.MEMETIC*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.MOP3"></a>`MOP3 *= dynardo_py_algorithms.SupportedAlgorithms.MOP3*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.NLPQL"></a>`NLPQL *= dynardo_py_algorithms.SupportedAlgorithms.NLPQL*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.PARAMETRIC_SERVICE"></a>`PARAMETRIC_SERVICE *= dynardo_py_algorithms.SupportedAlgorithms.PARAMETRIC_SERVICE*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.PSO"></a>`PSO *= dynardo_py_algorithms.SupportedAlgorithms.PSO*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RDO"></a>`RDO *= dynardo_py_algorithms.SupportedAlgorithms.RDO*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELIABILITY"></a>`RELIABILITY *= dynardo_py_algorithms.SupportedAlgorithms.RELIABILITY*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_AS"></a>`RELI_AS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_AS*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_DS"></a>`RELI_DS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_DS*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_DS_ARSM"></a>`RELI_DS_ARSM *= dynardo_py_algorithms.SupportedAlgorithms.RELI_DS_ARSM*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_FORM"></a>`RELI_FORM *= dynardo_py_algorithms.SupportedAlgorithms.RELI_FORM*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_ISPUD"></a>`RELI_ISPUD *= dynardo_py_algorithms.SupportedAlgorithms.RELI_ISPUD*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_MCS"></a>`RELI_MCS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_MCS*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.ROBUSTNESS"></a>`ROBUSTNESS *= dynardo_py_algorithms.SupportedAlgorithms.ROBUSTNESS*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.SDI"></a>`SDI *= dynardo_py_algorithms.SupportedAlgorithms.SDI*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.SENSITIVITY"></a>`SENSITIVITY *= dynardo_py_algorithms.SupportedAlgorithms.SENSITIVITY*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.SIMPLEX"></a>`SIMPLEX *= dynardo_py_algorithms.SupportedAlgorithms.SIMPLEX*`
-- <a id="dynardo_py_algorithms.SupportedAlgorithms.UNKNOWN"></a>`UNKNOWN *= dynardo_py_algorithms.SupportedAlgorithms.UNKNOWN*`
+<a id="dynardo_py_algorithms.SupportedAlgorithms.APPROXIMATION"></a>
+
+#### APPROXIMATION *= dynardo_py_algorithms.SupportedAlgorithms.APPROXIMATION*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.ARSM"></a>
+
+#### ARSM *= dynardo_py_algorithms.SupportedAlgorithms.ARSM*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.CMA"></a>
+
+#### CMA *= dynardo_py_algorithms.SupportedAlgorithms.CMA*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_OPTIMIZATION"></a>
+
+#### CUSTOM_OPTIMIZATION *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_OPTIMIZATION*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_SAMPLING"></a>
+
+#### CUSTOM_SAMPLING *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_SAMPLING*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_STOCHASTIC"></a>
+
+#### CUSTOM_STOCHASTIC *= dynardo_py_algorithms.SupportedAlgorithms.CUSTOM_STOCHASTIC*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.EA"></a>
+
+#### EA *= dynardo_py_algorithms.SupportedAlgorithms.EA*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.IMPORTED"></a>
+
+#### IMPORTED *= dynardo_py_algorithms.SupportedAlgorithms.IMPORTED*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.MEMETIC"></a>
+
+#### MEMETIC *= dynardo_py_algorithms.SupportedAlgorithms.MEMETIC*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.MOP3"></a>
+
+#### MOP3 *= dynardo_py_algorithms.SupportedAlgorithms.MOP3*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.NLPQL"></a>
+
+#### NLPQL *= dynardo_py_algorithms.SupportedAlgorithms.NLPQL*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.PARAMETRIC_SERVICE"></a>
+
+#### PARAMETRIC_SERVICE *= dynardo_py_algorithms.SupportedAlgorithms.PARAMETRIC_SERVICE*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.PSO"></a>
+
+#### PSO *= dynardo_py_algorithms.SupportedAlgorithms.PSO*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RDO"></a>
+
+#### RDO *= dynardo_py_algorithms.SupportedAlgorithms.RDO*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELIABILITY"></a>
+
+#### RELIABILITY *= dynardo_py_algorithms.SupportedAlgorithms.RELIABILITY*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_AS"></a>
+
+#### RELI_AS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_AS*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_DS"></a>
+
+#### RELI_DS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_DS*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_DS_ARSM"></a>
+
+#### RELI_DS_ARSM *= dynardo_py_algorithms.SupportedAlgorithms.RELI_DS_ARSM*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_FORM"></a>
+
+#### RELI_FORM *= dynardo_py_algorithms.SupportedAlgorithms.RELI_FORM*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_ISPUD"></a>
+
+#### RELI_ISPUD *= dynardo_py_algorithms.SupportedAlgorithms.RELI_ISPUD*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.RELI_MCS"></a>
+
+#### RELI_MCS *= dynardo_py_algorithms.SupportedAlgorithms.RELI_MCS*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.ROBUSTNESS"></a>
+
+#### ROBUSTNESS *= dynardo_py_algorithms.SupportedAlgorithms.ROBUSTNESS*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.SDI"></a>
+
+#### SDI *= dynardo_py_algorithms.SupportedAlgorithms.SDI*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.SENSITIVITY"></a>
+
+#### SENSITIVITY *= dynardo_py_algorithms.SupportedAlgorithms.SENSITIVITY*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.SIMPLEX"></a>
+
+#### SIMPLEX *= dynardo_py_algorithms.SupportedAlgorithms.SIMPLEX*
+
+<a id="dynardo_py_algorithms.SupportedAlgorithms.UNKNOWN"></a>
+
+#### UNKNOWN *= dynardo_py_algorithms.SupportedAlgorithms.UNKNOWN*
 
 <a id="dynardo_py_algorithms.bitset_type"></a>
 
 ## *class* dynardo_py_algorithms.bitset_type
 
-- <a id="dynardo_py_algorithms.bitset_type.__init__"></a>`__init__()`
+<a id="dynardo_py_algorithms.bitset_type.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="dynardo_py_algorithms.bool_list_to_bitset"></a>
 
@@ -240,11 +636,25 @@ Create a vector from a list.
 
 Exposes optiSLang’s internal matrix representation.
 
-- <a id="dynardo_py_algorithms.matrix_type.__call__"></a>`__call__(arg2: int, arg3: int) → float`
-- <a id="dynardo_py_algorithms.matrix_type.__init__"></a>`__init__(arg2: int, arg3: int)`
-- <a id="dynardo_py_algorithms.matrix_type.cols"></a>`cols() → int`
-- <a id="dynardo_py_algorithms.matrix_type.rows"></a>`rows() → int`
-- <a id="dynardo_py_algorithms.matrix_type.size"></a>`size() → int`
+<a id="dynardo_py_algorithms.matrix_type.__call__"></a>
+
+#### \_\_call_\_(arg2: int, arg3: int) → float
+
+<a id="dynardo_py_algorithms.matrix_type.__init__"></a>
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="dynardo_py_algorithms.matrix_type.cols"></a>
+
+#### cols() → int
+
+<a id="dynardo_py_algorithms.matrix_type.rows"></a>
+
+#### rows() → int
+
+<a id="dynardo_py_algorithms.matrix_type.size"></a>
+
+#### size() → int
 
 <a id="dynardo_py_algorithms.vector_type"></a>
 
@@ -252,8 +662,22 @@ Exposes optiSLang’s internal matrix representation.
 
 Exposes optiSLang’s internal vector representation.
 
-- <a id="dynardo_py_algorithms.vector_type.__call__"></a>`__call__(arg2: int) → float`
-- <a id="dynardo_py_algorithms.vector_type.__init__"></a>`__init__(arg2: int)`
-- <a id="dynardo_py_algorithms.vector_type.cols"></a>`cols() → int`
-- <a id="dynardo_py_algorithms.vector_type.rows"></a>`rows() → int`
-- <a id="dynardo_py_algorithms.vector_type.size"></a>`size() → int`
+<a id="dynardo_py_algorithms.vector_type.__call__"></a>
+
+#### \_\_call_\_(arg2: int) → float
+
+<a id="dynardo_py_algorithms.vector_type.__init__"></a>
+
+#### \_\_init_\_(arg2: int)
+
+<a id="dynardo_py_algorithms.vector_type.cols"></a>
+
+#### cols() → int
+
+<a id="dynardo_py_algorithms.vector_type.rows"></a>
+
+#### rows() → int
+
+<a id="dynardo_py_algorithms.vector_type.size"></a>
+
+#### size() → int

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/id.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/id.md
@@ -4,30 +4,97 @@
 
 ## *class* id.HID
 
-- <a id="id.HID.FromString"></a>`*static* FromString() → [HID](#id.HID)`
-- <a id="id.HID.GetChild"></a>`GetChild() → [HID](#id.HID)`
-- <a id="id.HID.GetDepth"></a>`GetDepth() → int`
-- <a id="id.HID.GetLeaf"></a>`GetLeaf() → [HID](#id.HID)`
-- <a id="id.HID.GetNumber"></a>`GetNumber() → int`
-- <a id="id.HID.HasChild"></a>`HasChild() → bool`
-- <a id="id.HID.RemoveUndermostChild"></a>`RemoveUndermostChild() → [HID](#id.HID)`
-- <a id="id.HID.ToString"></a>`ToString() → str`
-- <a id="id.HID.__div__"></a>`__div__(arg2: int) → [HID](#id.HID)`
-- <a id="id.HID.__iadd__"></a>`__iadd__(arg2: int) → int`
-- <a id="id.HID.__idiv__"></a>`__idiv__(arg2: int) → [HID](#id.HID)`
-- <a id="id.HID.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- `__init__(arg2: str) → object`
-- <a id="id.HID.__isub__"></a>`__isub__(arg2: int) → int`
-- <a id="id.HID.__str__"></a>`__str__() → str`
-- <a id="id.HID.from_string"></a>`*static* from_string() → [HID](#id.HID)`
-- <a id="id.HID.get_child"></a>`get_child() → [HID](#id.HID)`
-- <a id="id.HID.get_depth"></a>`get_depth() → int`
-- <a id="id.HID.get_leaf"></a>`get_leaf() → [HID](#id.HID)`
-- <a id="id.HID.get_number"></a>`get_number() → int`
-- <a id="id.HID.has_child"></a>`has_child() → bool`
-- <a id="id.HID.remove_undermost_child"></a>`remove_undermost_child() → [HID](#id.HID)`
-- <a id="id.HID.to_string"></a>`to_string() → str`
+<a id="id.HID.FromString"></a>
+
+#### *static* FromString() → [HID](#id.HID)
+
+<a id="id.HID.GetChild"></a>
+
+#### GetChild() → [HID](#id.HID)
+
+<a id="id.HID.GetDepth"></a>
+
+#### GetDepth() → int
+
+<a id="id.HID.GetLeaf"></a>
+
+#### GetLeaf() → [HID](#id.HID)
+
+<a id="id.HID.GetNumber"></a>
+
+#### GetNumber() → int
+
+<a id="id.HID.HasChild"></a>
+
+#### HasChild() → bool
+
+<a id="id.HID.RemoveUndermostChild"></a>
+
+#### RemoveUndermostChild() → [HID](#id.HID)
+
+<a id="id.HID.ToString"></a>
+
+#### ToString() → str
+
+<a id="id.HID.__div__"></a>
+
+#### \_\_div_\_(arg2: int) → [HID](#id.HID)
+
+<a id="id.HID.__iadd__"></a>
+
+#### \_\_iadd_\_(arg2: int) → int
+
+<a id="id.HID.__idiv__"></a>
+
+#### \_\_idiv_\_(arg2: int) → [HID](#id.HID)
+
+<a id="id.HID.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+#### \_\_init_\_(arg2: str) → object
+
+<a id="id.HID.__isub__"></a>
+
+#### \_\_isub_\_(arg2: int) → int
+
+<a id="id.HID.__str__"></a>
+
+#### \_\_str_\_() → str
+
+<a id="id.HID.from_string"></a>
+
+#### *static* from_string() → [HID](#id.HID)
+
+<a id="id.HID.get_child"></a>
+
+#### get_child() → [HID](#id.HID)
+
+<a id="id.HID.get_depth"></a>
+
+#### get_depth() → int
+
+<a id="id.HID.get_leaf"></a>
+
+#### get_leaf() → [HID](#id.HID)
+
+<a id="id.HID.get_number"></a>
+
+#### get_number() → int
+
+<a id="id.HID.has_child"></a>
+
+#### has_child() → bool
+
+<a id="id.HID.remove_undermost_child"></a>
+
+#### remove_undermost_child() → [HID](#id.HID)
+
+<a id="id.HID.to_string"></a>
+
+#### to_string() → str
 
 <a id="id.HIDSet"></a>
 
@@ -35,51 +102,125 @@
 
 A mutable set.
 
-- <a id="id.HIDSet.__and__"></a>`__and__(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return the intersection of this set and other.
-- <a id="id.HIDSet.__contains__"></a>`__contains__(arg2: [HID](#id.HID)) → bool`
-- <a id="id.HIDSet.__delitem__"></a>`__delitem__(arg2: [HID](#id.HID))`
-- <a id="id.HIDSet.__hash__"></a>`__hash__()`
-- <a id="id.HIDSet.__init__"></a>`__init__()`
-- <a id="id.HIDSet.__iter__"></a>`__iter__() → object`
-- <a id="id.HIDSet.__len__"></a>`__len__() → int`
-- <a id="id.HIDSet.__or__"></a>`__or__(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return the union of this set and other.
-- <a id="id.HIDSet.__sub__"></a>`__sub__(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="id.HIDSet.__xor__"></a>`__xor__(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="id.HIDSet.add"></a>`add(element: [HID](#id.HID))`<br>
-  Add element.
-- <a id="id.HIDSet.difference"></a>`difference(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="id.HIDSet.intersection"></a>`intersection(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return the intersection of this set and other.
-- <a id="id.HIDSet.remove"></a>`remove(element: [HID](#id.HID))`<br>
-  Remove element.
-- <a id="id.HIDSet.symmetric_difference"></a>`symmetric_difference(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="id.HIDSet.union"></a>`union(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)`<br>
-  Return the union of this set and other.
+<a id="id.HIDSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return the intersection of this set and other.
+
+<a id="id.HIDSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [HID](#id.HID)) → bool
+
+<a id="id.HIDSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [HID](#id.HID))
+
+<a id="id.HIDSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="id.HIDSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="id.HIDSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="id.HIDSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="id.HIDSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return the union of this set and other.
+
+<a id="id.HIDSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return elements of this set that are not in other.
+
+<a id="id.HIDSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="id.HIDSet.add"></a>
+
+#### add(element: [HID](#id.HID))
+
+Add element.
+
+<a id="id.HIDSet.difference"></a>
+
+#### difference(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return elements of this set that are not in other.
+
+<a id="id.HIDSet.intersection"></a>
+
+#### intersection(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return the intersection of this set and other.
+
+<a id="id.HIDSet.remove"></a>
+
+#### remove(element: [HID](#id.HID))
+
+Remove element.
+
+<a id="id.HIDSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="id.HIDSet.union"></a>
+
+#### union(other: [HIDSet](#id.HIDSet)) → [HIDSet](#id.HIDSet)
+
+Return the union of this set and other.
 
 <a id="id.Id"></a>
 
 ## *class* id.Id
 
-- <a id="id.Id.__init__"></a>`__init__()`
-- <a id="id.Id.name"></a>*property* `name`
+<a id="id.Id.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="id.Id.name"></a>
+
+#### *property* name
 
 <a id="id.Tag"></a>
 
 ## *class* id.Tag
 
-- <a id="id.Tag.__init__"></a>`__init__()`
-- <a id="id.Tag.uuid"></a>*property* `uuid`
+<a id="id.Tag.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="id.Tag.uuid"></a>
+
+#### *property* uuid
 
 <a id="id.UUID"></a>
 
 ## *class* id.UUID
 
-- <a id="id.UUID.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="id.UUID.__str__"></a>`__str__() → str`
+<a id="id.UUID.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="id.UUID.__str__"></a>
+
+#### \_\_str_\_() → str

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/os_doe_py_export.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/os_doe_py_export.md
@@ -4,35 +4,108 @@
 
 ## *class* os_doe_py_export.DOE
 
-- <a id="os_doe_py_export.DOE.__init__"></a>`__init__(arg2: int, arg3: int)`
-- <a id="os_doe_py_export.DOE.append"></a>`append(arg2: [DOE](#os_doe_py_export.DOE))`
-- <a id="os_doe_py_export.DOE.build"></a>`build(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES), arg3: int, arg4: bool)`
-- <a id="os_doe_py_export.DOE.get_center"></a>`get_center() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="os_doe_py_export.DOE.get_designs"></a>`get_designs() → [doubleVecVec](stdcpp_python_export.md#stdcpp_python_export.doubleVecVec)`
-- <a id="os_doe_py_export.DOE.get_lower_bounds"></a>`get_lower_bounds() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="os_doe_py_export.DOE.get_matrix"></a>`get_matrix() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="os_doe_py_export.DOE.get_upper_bounds"></a>`get_upper_bounds() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="os_doe_py_export.DOE.move"></a>`move(arg2: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="os_doe_py_export.DOE.scale"></a>`scale(arg2: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="os_doe_py_export.DOE.sort"></a>`sort()`
-- <a id="os_doe_py_export.DOE.unique"></a>`unique()`
+<a id="os_doe_py_export.DOE.__init__"></a>
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="os_doe_py_export.DOE.append"></a>
+
+#### append(arg2: [DOE](#os_doe_py_export.DOE))
+
+<a id="os_doe_py_export.DOE.build"></a>
+
+#### build(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES), arg3: int, arg4: bool)
+
+<a id="os_doe_py_export.DOE.get_center"></a>
+
+#### get_center() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="os_doe_py_export.DOE.get_designs"></a>
+
+#### get_designs() → [doubleVecVec](stdcpp_python_export.md#stdcpp_python_export.doubleVecVec)
+
+<a id="os_doe_py_export.DOE.get_lower_bounds"></a>
+
+#### get_lower_bounds() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="os_doe_py_export.DOE.get_matrix"></a>
+
+#### get_matrix() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="os_doe_py_export.DOE.get_upper_bounds"></a>
+
+#### get_upper_bounds() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="os_doe_py_export.DOE.move"></a>
+
+#### move(arg2: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="os_doe_py_export.DOE.scale"></a>
+
+#### scale(arg2: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="os_doe_py_export.DOE.sort"></a>
+
+#### sort()
+
+<a id="os_doe_py_export.DOE.unique"></a>
+
+#### unique()
 
 <a id="os_doe_py_export.OSDOE"></a>
 
 ## *class* os_doe_py_export.OSDOE
 
-- <a id="os_doe_py_export.OSDOE.__init__"></a>`__init__()`
-- `__init__(arg2: int)`
-- <a id="os_doe_py_export.OSDOE.build_robustness"></a>`build_robustness(Parameters: PyParameterManager to be used, Reference: PyOSDesignPoint/Nominal design point, DOE: DOETYPES method, Number: int of discretization)`<br>
-  Builds designs on unit hypercube at the design point given and transforms them to desired domain space.
-- <a id="os_doe_py_export.OSDOE.build_sensitivity"></a>`build_sensitivity(Parameters: PyParameterManager to be used, DOE: DOETYPES method, Number: int of discretization)`<br>
-  Builds designs on unit hypercube and transforms them to the desired domain space.
-- <a id="os_doe_py_export.OSDOE.get_design"></a>`get_design(arg2: int) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="os_doe_py_export.OSDOE.get_designs"></a>`get_designs() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)`
-- <a id="os_doe_py_export.OSDOE.get_lower_bounds"></a>`get_lower_bounds() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="os_doe_py_export.OSDOE.get_num_designs"></a>`get_num_designs() → int`
-- <a id="os_doe_py_export.OSDOE.get_upper_bounds"></a>`get_upper_bounds() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="os_doe_py_export.OSDOE.set_seed"></a>`set_seed(arg2: int) → int`
-- <a id="os_doe_py_export.OSDOE.size"></a>`size() → int`
-- <a id="os_doe_py_export.OSDOE.sort"></a>`sort() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)`
-- <a id="os_doe_py_export.OSDOE.unique"></a>`unique() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)`
+<a id="os_doe_py_export.OSDOE.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: int)
+
+<a id="os_doe_py_export.OSDOE.build_robustness"></a>
+
+#### build_robustness(Parameters: PyParameterManager to be used, Reference: PyOSDesignPoint/Nominal design point, DOE: DOETYPES method, Number: int of discretization)
+
+Builds designs on unit hypercube at the design point given and transforms them to desired domain space.
+
+<a id="os_doe_py_export.OSDOE.build_sensitivity"></a>
+
+#### build_sensitivity(Parameters: PyParameterManager to be used, DOE: DOETYPES method, Number: int of discretization)
+
+Builds designs on unit hypercube and transforms them to the desired domain space.
+
+<a id="os_doe_py_export.OSDOE.get_design"></a>
+
+#### get_design(arg2: int) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="os_doe_py_export.OSDOE.get_designs"></a>
+
+#### get_designs() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)
+
+<a id="os_doe_py_export.OSDOE.get_lower_bounds"></a>
+
+#### get_lower_bounds() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="os_doe_py_export.OSDOE.get_num_designs"></a>
+
+#### get_num_designs() → int
+
+<a id="os_doe_py_export.OSDOE.get_upper_bounds"></a>
+
+#### get_upper_bounds() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="os_doe_py_export.OSDOE.set_seed"></a>
+
+#### set_seed(arg2: int) → int
+
+<a id="os_doe_py_export.OSDOE.size"></a>
+
+#### size() → int
+
+<a id="os_doe_py_export.OSDOE.sort"></a>
+
+#### sort() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)
+
+<a id="os_doe_py_export.OSDOE.unique"></a>
+
+#### unique() → [PyOSDesignPointContainer](py_os_design.md#py_os_design.PyOSDesignPointContainer)

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_algorithm_info.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_algorithm_info.md
@@ -4,81 +4,201 @@
 
 ## *class* py_algorithm_info.AlgorithmInfo
 
-- <a id="py_algorithm_info.AlgorithmInfo.__init__"></a>`__init__(arg2: [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms))`
-- <a id="py_algorithm_info.AlgorithmInfo.add_signal_info"></a>`add_signal_info(signal: str name, abscissa: list)`<br>
-  Add new signal info by name and abscissa values. Skip if signal info is already present.
-- <a id="py_algorithm_info.AlgorithmInfo.add_signal_info_y_data"></a>`add_signal_info_y_data(signal: str name, channel: str name, data: str name, data: str part name, channel: list values)`<br>
-  Add new channel values to an existing signal info.
-- <a id="py_algorithm_info.AlgorithmInfo.clear_signal_info"></a>`clear_signal_info()`<br>
-  Clear all existing signal information.
-- <a id="py_algorithm_info.AlgorithmInfo.get_mop3_info"></a>`get_mop3_info() → [MOP3Info](#py_algorithm_info.MOP3Info)`<br>
-  Returns detailed MOP3 info if present.
-- <a id="py_algorithm_info.AlgorithmInfo.get_mop_info"></a>`get_mop_info() → [MOPInfo](#py_algorithm_info.MOPInfo)`<br>
-  Returns detailed MOP info if present.
-- <a id="py_algorithm_info.AlgorithmInfo.get_seed_value"></a>`get_seed_value() → int`<br>
-  Returns the given seed value for the processed algorithm.
-- <a id="py_algorithm_info.AlgorithmInfo.get_signal_info_channel_names"></a>`get_signal_info_channel_names(signal: str name) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get a list of channel names for given signal info name
-- <a id="py_algorithm_info.AlgorithmInfo.get_signal_info_data_names"></a>`get_signal_info_data_names(signal: str name, channel: str name) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get a list of data names for given signal info name and channel name
-- <a id="py_algorithm_info.AlgorithmInfo.get_signal_info_signal_names"></a>`get_signal_info_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get a list of signal info names
-- <a id="py_algorithm_info.AlgorithmInfo.get_type"></a>`get_type() → [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms)`<br>
-  Returns the algorithm type.
-- <a id="py_algorithm_info.AlgorithmInfo.has_best_design_infos"></a>`has_best_design_infos() → bool`<br>
-  Returns whether the detailed info has iteration best design infos.
-- <a id="py_algorithm_info.AlgorithmInfo.is_adaptive_mop_info"></a>`is_adaptive_mop_info() → bool`<br>
-  Returns whether the detailed info is of type AdaptiveMOP info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_deterministic_sampling"></a>`is_deterministic_sampling() → bool`<br>
-  Returns whether the deterministic parameters were varied in this algorithm.
-- <a id="py_algorithm_info.AlgorithmInfo.is_mop3_info"></a>`is_mop3_info() → bool`<br>
-  Returns whether the detailed info is of type MOP3 info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_mop_info"></a>`is_mop_info() → bool`<br>
-  Returns whether the detailed info is of type MOP info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_optimization_info"></a>`is_optimization_info() → bool`<br>
-  Returns whether the detailed info is of type Optimization info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_reliability_info"></a>`is_reliability_info() → bool`<br>
-  Returns whether the detailed info is of type Reliability info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_robustness_info"></a>`is_robustness_info() → bool`<br>
-  Returns whether the detailed info is of type Robustness info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_sensitivity_info"></a>`is_sensitivity_info() → bool`<br>
-  Returns whether the detailed info is of type Sensitivity info.
-- <a id="py_algorithm_info.AlgorithmInfo.is_stochastic_sampling"></a>`is_stochastic_sampling() → bool`<br>
-  Returns whether the stochastic parameters were varied in this algorithm.
+<a id="py_algorithm_info.AlgorithmInfo.__init__"></a>
+
+#### \_\_init_\_(arg2: [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms))
+
+<a id="py_algorithm_info.AlgorithmInfo.add_signal_info"></a>
+
+#### add_signal_info(signal: str name, abscissa: list)
+
+Add new signal info by name and abscissa values. Skip if signal info is already present.
+
+<a id="py_algorithm_info.AlgorithmInfo.add_signal_info_y_data"></a>
+
+#### add_signal_info_y_data(signal: str name, channel: str name, data: str name, data: str part name, channel: list values)
+
+Add new channel values to an existing signal info.
+
+<a id="py_algorithm_info.AlgorithmInfo.clear_signal_info"></a>
+
+#### clear_signal_info()
+
+Clear all existing signal information.
+
+<a id="py_algorithm_info.AlgorithmInfo.get_mop3_info"></a>
+
+#### get_mop3_info() → [MOP3Info](#py_algorithm_info.MOP3Info)
+
+Returns detailed MOP3 info if present.
+
+<a id="py_algorithm_info.AlgorithmInfo.get_mop_info"></a>
+
+#### get_mop_info() → [MOPInfo](#py_algorithm_info.MOPInfo)
+
+Returns detailed MOP info if present.
+
+<a id="py_algorithm_info.AlgorithmInfo.get_seed_value"></a>
+
+#### get_seed_value() → int
+
+Returns the given seed value for the processed algorithm.
+
+<a id="py_algorithm_info.AlgorithmInfo.get_signal_info_channel_names"></a>
+
+#### get_signal_info_channel_names(signal: str name) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get a list of channel names for given signal info name
+
+<a id="py_algorithm_info.AlgorithmInfo.get_signal_info_data_names"></a>
+
+#### get_signal_info_data_names(signal: str name, channel: str name) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get a list of data names for given signal info name and channel name
+
+<a id="py_algorithm_info.AlgorithmInfo.get_signal_info_signal_names"></a>
+
+#### get_signal_info_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get a list of signal info names
+
+<a id="py_algorithm_info.AlgorithmInfo.get_type"></a>
+
+#### get_type() → [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms)
+
+Returns the algorithm type.
+
+<a id="py_algorithm_info.AlgorithmInfo.has_best_design_infos"></a>
+
+#### has_best_design_infos() → bool
+
+Returns whether the detailed info has iteration best design infos.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_adaptive_mop_info"></a>
+
+#### is_adaptive_mop_info() → bool
+
+Returns whether the detailed info is of type AdaptiveMOP info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_deterministic_sampling"></a>
+
+#### is_deterministic_sampling() → bool
+
+Returns whether the deterministic parameters were varied in this algorithm.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_mop3_info"></a>
+
+#### is_mop3_info() → bool
+
+Returns whether the detailed info is of type MOP3 info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_mop_info"></a>
+
+#### is_mop_info() → bool
+
+Returns whether the detailed info is of type MOP info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_optimization_info"></a>
+
+#### is_optimization_info() → bool
+
+Returns whether the detailed info is of type Optimization info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_reliability_info"></a>
+
+#### is_reliability_info() → bool
+
+Returns whether the detailed info is of type Reliability info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_robustness_info"></a>
+
+#### is_robustness_info() → bool
+
+Returns whether the detailed info is of type Robustness info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_sensitivity_info"></a>
+
+#### is_sensitivity_info() → bool
+
+Returns whether the detailed info is of type Sensitivity info.
+
+<a id="py_algorithm_info.AlgorithmInfo.is_stochastic_sampling"></a>
+
+#### is_stochastic_sampling() → bool
+
+Returns whether the stochastic parameters were varied in this algorithm.
 
 <a id="py_algorithm_info.DetailedAlgorithmInfo"></a>
 
 ## *class* py_algorithm_info.DetailedAlgorithmInfo
 
-- <a id="py_algorithm_info.DetailedAlgorithmInfo.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="py_algorithm_info.DetailedAlgorithmInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="py_algorithm_info.MOP3Info"></a>
 
 ## *class* py_algorithm_info.MOP3Info
 
-- <a id="py_algorithm_info.MOP3Info.__init__"></a>`__init__()`
-- <a id="py_algorithm_info.MOP3Info.mop3_configuration"></a>*property* `mop3_configuration`<br>
-  Configuration file (string) for MOP3.
-- <a id="py_algorithm_info.MOP3Info.mop3_design_ids"></a>*property* `mop3_design_ids`<br>
-  Design IDs (string list/id vector) for MOP3.
-- <a id="py_algorithm_info.MOP3Info.mop3_parameter_manager"></a>*property* `mop3_parameter_manager`<br>
-  Parameter Manager (parameter_manager) for MOP3.
-- <a id="py_algorithm_info.MOP3Info.mop3_responses"></a>*property* `mop3_responses`<br>
-  Response Matrix (tmath::Matrix/Eigen::Matrix) for MOP3.
-- <a id="py_algorithm_info.MOP3Info.mop3_sdb"></a>*property* `mop3_sdb`<br>
-  Sdb file (string) for MOP3.
-- <a id="py_algorithm_info.MOP3Info.mop3_support_points"></a>*property* `mop3_support_points`<br>
-  Support Point Matrix (tmath::Matrix/Eigen::Matrix) for MOP3.
+<a id="py_algorithm_info.MOP3Info.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_algorithm_info.MOP3Info.mop3_configuration"></a>
+
+#### *property* mop3_configuration
+
+Configuration file (string) for MOP3.
+
+<a id="py_algorithm_info.MOP3Info.mop3_design_ids"></a>
+
+#### *property* mop3_design_ids
+
+Design IDs (string list/id vector) for MOP3.
+
+<a id="py_algorithm_info.MOP3Info.mop3_parameter_manager"></a>
+
+#### *property* mop3_parameter_manager
+
+Parameter Manager (parameter_manager) for MOP3.
+
+<a id="py_algorithm_info.MOP3Info.mop3_responses"></a>
+
+#### *property* mop3_responses
+
+Response Matrix (tmath::Matrix/Eigen::Matrix) for MOP3.
+
+<a id="py_algorithm_info.MOP3Info.mop3_sdb"></a>
+
+#### *property* mop3_sdb
+
+Sdb file (string) for MOP3.
+
+<a id="py_algorithm_info.MOP3Info.mop3_support_points"></a>
+
+#### *property* mop3_support_points
+
+Support Point Matrix (tmath::Matrix/Eigen::Matrix) for MOP3.
 
 <a id="py_algorithm_info.MOPInfo"></a>
 
 ## *class* py_algorithm_info.MOPInfo
 
-- <a id="py_algorithm_info.MOPInfo.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_algorithm_info.MOPInfo.has_cv_values"></a>`has_cv_values() → bool`<br>
-  Returns whether cross validation values are present.
+<a id="py_algorithm_info.MOPInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_algorithm_info.MOPInfo.has_cv_values"></a>
+
+#### has_cv_values() → bool
+
+Returns whether cross validation values are present.
 
 <a id="py_algorithm_info.PyAlgorithmInfo"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_doe_settings.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_doe_settings.md
@@ -4,10 +4,30 @@
 
 ## *class* py_doe_settings.DOESettings
 
-- <a id="py_doe_settings.DOESettings.__init__"></a>`__init__()`
-- <a id="py_doe_settings.DOESettings.num_dimensions"></a>*property* `num_dimensions`
-- <a id="py_doe_settings.DOESettings.num_discretization"></a>*property* `num_discretization`
-- <a id="py_doe_settings.DOESettings.num_points"></a>*property* `num_points`
-- <a id="py_doe_settings.DOESettings.sampling_method"></a>*property* `sampling_method`
-- <a id="py_doe_settings.DOESettings.seed"></a>*property* `seed`
-- <a id="py_doe_settings.DOESettings.set_default"></a>`set_default(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))`
+<a id="py_doe_settings.DOESettings.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_doe_settings.DOESettings.num_dimensions"></a>
+
+#### *property* num_dimensions
+
+<a id="py_doe_settings.DOESettings.num_discretization"></a>
+
+#### *property* num_discretization
+
+<a id="py_doe_settings.DOESettings.num_points"></a>
+
+#### *property* num_points
+
+<a id="py_doe_settings.DOESettings.sampling_method"></a>
+
+#### *property* sampling_method
+
+<a id="py_doe_settings.DOESettings.seed"></a>
+
+#### *property* seed
+
+<a id="py_doe_settings.DOESettings.set_default"></a>
+
+#### set_default(arg2: [DOETYPES](dynardo_py_algorithms.md#dynardo_py_algorithms.DOETYPES))

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_file_access.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_file_access.md
@@ -4,113 +4,333 @@
 
 ## *class* py_file_access.FileProvider
 
-- <a id="py_file_access.FileProvider.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_file_access.FileProvider.__iter__"></a>`__iter__() → object`
-- <a id="py_file_access.FileProvider.__len__"></a>`__len__() → int`
-- <a id="py_file_access.FileProvider.file_access_types"></a>*property* `file_access_types`<br>
-  List available types of file access.
-- <a id="py_file_access.FileProvider.get_item"></a>`get_item(arg2: [FileProviderId](#py_file_access.FileProviderId)) → [FileProviderItem](#py_file_access.FileProviderItem)`<br>
-  Get item by ID.
-- <a id="py_file_access.FileProvider.set_item"></a>`set_item(arg2: [FileProviderItem](#py_file_access.FileProviderItem)) → bool`<br>
-  Set item.
+<a id="py_file_access.FileProvider.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_file_access.FileProvider.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_file_access.FileProvider.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_file_access.FileProvider.file_access_types"></a>
+
+#### *property* file_access_types
+
+List available types of file access.
+
+<a id="py_file_access.FileProvider.get_item"></a>
+
+#### get_item(arg2: [FileProviderId](#py_file_access.FileProviderId)) → [FileProviderItem](#py_file_access.FileProviderItem)
+
+Get item by ID.
+
+<a id="py_file_access.FileProvider.set_item"></a>
+
+#### set_item(arg2: [FileProviderItem](#py_file_access.FileProviderItem)) → bool
+
+Set item.
 
 <a id="py_file_access.FileProviderId"></a>
 
 ## *class* py_file_access.FileProviderId
 
-- <a id="py_file_access.FileProviderId.__init__"></a>`__init__()`
-- <a id="py_file_access.FileProviderId.__str__"></a>`__str__() → str`
-- <a id="py_file_access.FileProviderId.name"></a>*property* `name`<br>
-  Name
+<a id="py_file_access.FileProviderId.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_file_access.FileProviderId.__str__"></a>
+
+#### \_\_str_\_() → str
+
+<a id="py_file_access.FileProviderId.name"></a>
+
+#### *property* name
+
+Name
 
 <a id="py_file_access.FileProviderItem"></a>
 
 ## *class* py_file_access.FileProviderItem
 
-- <a id="py_file_access.FileProviderItem.Action"></a>`*class* Action`<br>
-  **Enumeration** Enumerates possible FileProviderItem action types.
-- <a id="py_file_access.FileProviderItem.Action.LOCAL_COMPRESS_GZ"></a>`LOCAL_COMPRESS_GZ *= py_file_access.Action.LOCAL_COMPRESS_GZ*`
-- <a id="py_file_access.FileProviderItem.Action.LOCAL_REMOVE"></a>`LOCAL_REMOVE *= py_file_access.Action.LOCAL_REMOVE*`
-- <a id="py_file_access.FileProviderItem.Action.NONE"></a>`NONE *= py_file_access.Action.NONE*`
-- <a id="py_file_access.FileProviderItem.Action.RECEIVE"></a>`RECEIVE *= py_file_access.Action.RECEIVE*`
-- <a id="py_file_access.FileProviderItem.Action.SEND"></a>`SEND *= py_file_access.Action.SEND*`
-- <a id="py_file_access.FileProviderItem.ActionPoint"></a>`*class* ActionPoint`<br>
-  **Enumeration** Enumerates possible FileProviderItem action points.
-- <a id="py_file_access.FileProviderItem.ActionPoint.CLOSE"></a>`CLOSE *= py_file_access.ActionPoint.CLOSE*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.LOAD"></a>`LOAD *= py_file_access.ActionPoint.LOAD*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.NODE_FAILED"></a>`NODE_FAILED *= py_file_access.ActionPoint.NODE_FAILED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.NODE_FINISHED"></a>`NODE_FINISHED *= py_file_access.ActionPoint.NODE_FINISHED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.NODE_STARTED"></a>`NODE_STARTED *= py_file_access.ActionPoint.NODE_STARTED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.NODE_SUCCEEDED"></a>`NODE_SUCCEEDED *= py_file_access.ActionPoint.NODE_SUCCEEDED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.NONE"></a>`NONE *= py_file_access.ActionPoint.NONE*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.RUN_FINISHED"></a>`RUN_FINISHED *= py_file_access.ActionPoint.RUN_FINISHED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.RUN_STARTED"></a>`RUN_STARTED *= py_file_access.ActionPoint.RUN_STARTED*`
-- <a id="py_file_access.FileProviderItem.ActionPoint.SAVE"></a>`SAVE *= py_file_access.ActionPoint.SAVE*`
-- <a id="py_file_access.FileProviderItem.Existence"></a>`*class* Existence`<br>
-  **Enumeration** Enumerates possible FileProviderItem file existence options.
-- <a id="py_file_access.FileProviderItem.Existence.DONT_CARE"></a>`DONT_CARE *= py_file_access.Existence.DONT_CARE*`
-- <a id="py_file_access.FileProviderItem.Existence.INDICATES_FAILURE"></a>`INDICATES_FAILURE *= py_file_access.Existence.INDICATES_FAILURE*`
-- <a id="py_file_access.FileProviderItem.Existence.REQUIRED_FOR_SUCCESS"></a>`REQUIRED_FOR_SUCCESS *= py_file_access.Existence.REQUIRED_FOR_SUCCESS*`
-- <a id="py_file_access.FileProviderItem.Usage"></a>`*class* Usage`<br>
-  **Enumeration** Enumerates possible FileProviderItem usage types.
-- <a id="py_file_access.FileProviderItem.Usage.INPUT_FILE"></a>`INPUT_FILE *= py_file_access.Usage.INPUT_FILE*`
-- <a id="py_file_access.FileProviderItem.Usage.INTERMEDIATE_RESULT"></a>`INTERMEDIATE_RESULT *= py_file_access.Usage.INTERMEDIATE_RESULT*`
-- <a id="py_file_access.FileProviderItem.Usage.OUTPUT_FILE"></a>`OUTPUT_FILE *= py_file_access.Usage.OUTPUT_FILE*`
-- <a id="py_file_access.FileProviderItem.Usage.UNDETERMINED"></a>`UNDETERMINED *= py_file_access.Usage.UNDETERMINED*`
-- <a id="py_file_access.FileProviderItem.__init__"></a>`__init__()`
-- <a id="py_file_access.FileProviderItem.action"></a>*property* `action`<br>
-  Action to be performed
-- <a id="py_file_access.FileProviderItem.action_point"></a>*property* `action_point`<br>
-  Point in time for the action to be performed
-- <a id="py_file_access.FileProviderItem.auto_generated"></a>*property* `auto_generated`<br>
-  Whether file is auto-generated
-- <a id="py_file_access.FileProviderItem.comment"></a>*property* `comment`<br>
-  Free text for comments
-- <a id="py_file_access.FileProviderItem.existence"></a>*property* `existence`<br>
-  Option controlling whether the local file existence is required
-- <a id="py_file_access.FileProviderItem.filename_regex"></a>*property* `filename_regex`<br>
-  Option controlling the regular expression for filename matching
-- <a id="py_file_access.FileProviderItem.id"></a>*property* `id`<br>
-  ID
-- <a id="py_file_access.FileProviderItem.local_path"></a>*property* `local_path`<br>
-  RelativeSplittedPath on the local system
-- <a id="py_file_access.FileProviderItem.name"></a>*property* `name`<br>
-  Item name
-- <a id="py_file_access.FileProviderItem.remove_on_reset"></a>*property* `remove_on_reset`<br>
-  Whether file should be removed when associated node is reset
-- <a id="py_file_access.FileProviderItem.revision"></a>*property* `revision`<br>
-  Revision
-- <a id="py_file_access.FileProviderItem.save_location"></a>*property* `save_location`<br>
-  Save location
-- <a id="py_file_access.FileProviderItem.store_in_project"></a>*property* `store_in_project`<br>
-  Whether to store file in project
-- <a id="py_file_access.FileProviderItem.type"></a>*property* `type`<br>
-  Access type
-- <a id="py_file_access.FileProviderItem.usage"></a>*property* `usage`<br>
-  File usage
-- <a id="py_file_access.FileProviderItem.use_regex_for_filename"></a>*property* `use_regex_for_filename`<br>
-  Whether to match filenames against a regular expression when checking for local files existence
-- <a id="py_file_access.FileProviderItem.wait_for_file"></a>*property* `wait_for_file`<br>
-  Whether to wait for the file after the node finished execution
+<a id="py_file_access.FileProviderItem.Action"></a>
+
+#### *class* Action
+
+**Enumeration**
+
+Enumerates possible FileProviderItem action types.
+
+<a id="py_file_access.FileProviderItem.Action.LOCAL_COMPRESS_GZ"></a>
+
+#### LOCAL_COMPRESS_GZ *= py_file_access.Action.LOCAL_COMPRESS_GZ*
+
+<a id="py_file_access.FileProviderItem.Action.LOCAL_REMOVE"></a>
+
+#### LOCAL_REMOVE *= py_file_access.Action.LOCAL_REMOVE*
+
+<a id="py_file_access.FileProviderItem.Action.NONE"></a>
+
+#### NONE *= py_file_access.Action.NONE*
+
+<a id="py_file_access.FileProviderItem.Action.RECEIVE"></a>
+
+#### RECEIVE *= py_file_access.Action.RECEIVE*
+
+<a id="py_file_access.FileProviderItem.Action.SEND"></a>
+
+#### SEND *= py_file_access.Action.SEND*
+
+<a id="py_file_access.FileProviderItem.ActionPoint"></a>
+
+#### *class* ActionPoint
+
+**Enumeration**
+
+Enumerates possible FileProviderItem action points.
+
+<a id="py_file_access.FileProviderItem.ActionPoint.CLOSE"></a>
+
+#### CLOSE *= py_file_access.ActionPoint.CLOSE*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.LOAD"></a>
+
+#### LOAD *= py_file_access.ActionPoint.LOAD*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.NODE_FAILED"></a>
+
+#### NODE_FAILED *= py_file_access.ActionPoint.NODE_FAILED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.NODE_FINISHED"></a>
+
+#### NODE_FINISHED *= py_file_access.ActionPoint.NODE_FINISHED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.NODE_STARTED"></a>
+
+#### NODE_STARTED *= py_file_access.ActionPoint.NODE_STARTED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.NODE_SUCCEEDED"></a>
+
+#### NODE_SUCCEEDED *= py_file_access.ActionPoint.NODE_SUCCEEDED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.NONE"></a>
+
+#### NONE *= py_file_access.ActionPoint.NONE*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.RUN_FINISHED"></a>
+
+#### RUN_FINISHED *= py_file_access.ActionPoint.RUN_FINISHED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.RUN_STARTED"></a>
+
+#### RUN_STARTED *= py_file_access.ActionPoint.RUN_STARTED*
+
+<a id="py_file_access.FileProviderItem.ActionPoint.SAVE"></a>
+
+#### SAVE *= py_file_access.ActionPoint.SAVE*
+
+<a id="py_file_access.FileProviderItem.Existence"></a>
+
+#### *class* Existence
+
+**Enumeration**
+
+Enumerates possible FileProviderItem file existence options.
+
+<a id="py_file_access.FileProviderItem.Existence.DONT_CARE"></a>
+
+#### DONT_CARE *= py_file_access.Existence.DONT_CARE*
+
+<a id="py_file_access.FileProviderItem.Existence.INDICATES_FAILURE"></a>
+
+#### INDICATES_FAILURE *= py_file_access.Existence.INDICATES_FAILURE*
+
+<a id="py_file_access.FileProviderItem.Existence.REQUIRED_FOR_SUCCESS"></a>
+
+#### REQUIRED_FOR_SUCCESS *= py_file_access.Existence.REQUIRED_FOR_SUCCESS*
+
+<a id="py_file_access.FileProviderItem.Usage"></a>
+
+#### *class* Usage
+
+**Enumeration**
+
+Enumerates possible FileProviderItem usage types.
+
+<a id="py_file_access.FileProviderItem.Usage.INPUT_FILE"></a>
+
+#### INPUT_FILE *= py_file_access.Usage.INPUT_FILE*
+
+<a id="py_file_access.FileProviderItem.Usage.INTERMEDIATE_RESULT"></a>
+
+#### INTERMEDIATE_RESULT *= py_file_access.Usage.INTERMEDIATE_RESULT*
+
+<a id="py_file_access.FileProviderItem.Usage.OUTPUT_FILE"></a>
+
+#### OUTPUT_FILE *= py_file_access.Usage.OUTPUT_FILE*
+
+<a id="py_file_access.FileProviderItem.Usage.UNDETERMINED"></a>
+
+#### UNDETERMINED *= py_file_access.Usage.UNDETERMINED*
+
+<a id="py_file_access.FileProviderItem.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_file_access.FileProviderItem.action"></a>
+
+#### *property* action
+
+Action to be performed
+
+<a id="py_file_access.FileProviderItem.action_point"></a>
+
+#### *property* action_point
+
+Point in time for the action to be performed
+
+<a id="py_file_access.FileProviderItem.auto_generated"></a>
+
+#### *property* auto_generated
+
+Whether file is auto-generated
+
+<a id="py_file_access.FileProviderItem.comment"></a>
+
+#### *property* comment
+
+Free text for comments
+
+<a id="py_file_access.FileProviderItem.existence"></a>
+
+#### *property* existence
+
+Option controlling whether the local file existence is required
+
+<a id="py_file_access.FileProviderItem.filename_regex"></a>
+
+#### *property* filename_regex
+
+Option controlling the regular expression for filename matching
+
+<a id="py_file_access.FileProviderItem.id"></a>
+
+#### *property* id
+
+ID
+
+<a id="py_file_access.FileProviderItem.local_path"></a>
+
+#### *property* local_path
+
+RelativeSplittedPath on the local system
+
+<a id="py_file_access.FileProviderItem.name"></a>
+
+#### *property* name
+
+Item name
+
+<a id="py_file_access.FileProviderItem.remove_on_reset"></a>
+
+#### *property* remove_on_reset
+
+Whether file should be removed when associated node is reset
+
+<a id="py_file_access.FileProviderItem.revision"></a>
+
+#### *property* revision
+
+Revision
+
+<a id="py_file_access.FileProviderItem.save_location"></a>
+
+#### *property* save_location
+
+Save location
+
+<a id="py_file_access.FileProviderItem.store_in_project"></a>
+
+#### *property* store_in_project
+
+Whether to store file in project
+
+<a id="py_file_access.FileProviderItem.type"></a>
+
+#### *property* type
+
+Access type
+
+<a id="py_file_access.FileProviderItem.usage"></a>
+
+#### *property* usage
+
+File usage
+
+<a id="py_file_access.FileProviderItem.use_regex_for_filename"></a>
+
+#### *property* use_regex_for_filename
+
+Whether to match filenames against a regular expression when checking for local files existence
+
+<a id="py_file_access.FileProviderItem.wait_for_file"></a>
+
+#### *property* wait_for_file
+
+Whether to wait for the file after the node finished execution
 
 <a id="py_file_access.ProvidedPath"></a>
 
 ## *class* py_file_access.ProvidedPath
 
-- <a id="py_file_access.ProvidedPath.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath))`
-- `__init__(arg2: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath))`
-- `__init__(arg2: [FileProviderId](#py_file_access.FileProviderId))`
-- <a id="py_file_access.ProvidedPath.__str__"></a>`__str__() → str`
-- <a id="py_file_access.ProvidedPath.actual_relative_split_path"></a>*property* `actual_relative_split_path`<br>
-  Actual RelativeSplittedPath. Takes central file registration into account.
-- <a id="py_file_access.ProvidedPath.empty"></a>*property* `empty`<br>
-  True if ProvidedPath is empty
-- <a id="py_file_access.ProvidedPath.file_provider_id"></a>*property* `file_provider_id`<br>
-  A FileProviderId in case a FileProviderId is contained, or None otherwise.
-- <a id="py_file_access.ProvidedPath.get_actual_path"></a>`get_actual_path(file_provider: FileProvider) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)`<br>
-  Return the actual file path. Takes central file registration into account.
-- <a id="py_file_access.ProvidedPath.relative_split_path"></a>*property* `relative_split_path`<br>
-  A RelativeSplittedPath in case a RelativeSplittedPath is contained, or None otherwise.
+<a id="py_file_access.ProvidedPath.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [SplittedPath](stdcpp_python_export.md#stdcpp_python_export.SplittedPath))
+
+#### \_\_init_\_(arg2: [RelativeSplittedPath](stdcpp_python_export.md#stdcpp_python_export.RelativeSplittedPath))
+
+#### \_\_init_\_(arg2: [FileProviderId](#py_file_access.FileProviderId))
+
+<a id="py_file_access.ProvidedPath.__str__"></a>
+
+#### \_\_str_\_() → str
+
+<a id="py_file_access.ProvidedPath.actual_relative_split_path"></a>
+
+#### *property* actual_relative_split_path
+
+Actual RelativeSplittedPath. Takes central file registration into account.
+
+<a id="py_file_access.ProvidedPath.empty"></a>
+
+#### *property* empty
+
+True if ProvidedPath is empty
+
+<a id="py_file_access.ProvidedPath.file_provider_id"></a>
+
+#### *property* file_provider_id
+
+A FileProviderId in case a FileProviderId is contained, or None otherwise.
+
+<a id="py_file_access.ProvidedPath.get_actual_path"></a>
+
+#### get_actual_path(file_provider: FileProvider) → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
+
+Return the actual file path. Takes central file registration into account.
+
+<a id="py_file_access.ProvidedPath.relative_split_path"></a>
+
+#### *property* relative_split_path
+
+A RelativeSplittedPath in case a RelativeSplittedPath is contained, or None otherwise.

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_monitoring_gui.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_monitoring_gui.md
@@ -6,9 +6,17 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.Interactions"></a>`Interactions *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.Interactions*`
-- <a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.MainEffects"></a>`MainEffects *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.MainEffects*`
-- <a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.TotalEffects"></a>`TotalEffects *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.TotalEffects*`
+<a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.Interactions"></a>
+
+#### Interactions *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.Interactions*
+
+<a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.MainEffects"></a>
+
+#### MainEffects *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.MainEffects*
+
+<a id="py_monitoring_gui.ApproximatingCOPMatrixIndicesType.TotalEffects"></a>
+
+#### TotalEffects *= py_monitoring_gui.ApproximatingCOPMatrixIndicesType.TotalEffects*
 
 <a id="py_monitoring_gui.ApproximationHistoryMode"></a>
 
@@ -16,8 +24,13 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.ApproximationHistoryMode.Criteria"></a>`Criteria *= py_monitoring_gui.ApproximationHistoryMode.Criteria*`
-- <a id="py_monitoring_gui.ApproximationHistoryMode.Responses"></a>`Responses *= py_monitoring_gui.ApproximationHistoryMode.Responses*`
+<a id="py_monitoring_gui.ApproximationHistoryMode.Criteria"></a>
+
+#### Criteria *= py_monitoring_gui.ApproximationHistoryMode.Criteria*
+
+<a id="py_monitoring_gui.ApproximationHistoryMode.Responses"></a>
+
+#### Responses *= py_monitoring_gui.ApproximationHistoryMode.Responses*
 
 <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes"></a>
 
@@ -25,11 +38,25 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Automatic"></a>`Automatic *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Automatic*`
-- <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Linear"></a>`Linear *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Linear*`
-- <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.LinearMixed"></a>`LinearMixed *= py_monitoring_gui.CoIVisualPolynomBasisTypes.LinearMixed*`
-- <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Quadratic"></a>`Quadratic *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Quadratic*`
-- <a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.QuadraticMixed"></a>`QuadraticMixed *= py_monitoring_gui.CoIVisualPolynomBasisTypes.QuadraticMixed*`
+<a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Automatic"></a>
+
+#### Automatic *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Automatic*
+
+<a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Linear"></a>
+
+#### Linear *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Linear*
+
+<a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.LinearMixed"></a>
+
+#### LinearMixed *= py_monitoring_gui.CoIVisualPolynomBasisTypes.LinearMixed*
+
+<a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.Quadratic"></a>
+
+#### Quadratic *= py_monitoring_gui.CoIVisualPolynomBasisTypes.Quadratic*
+
+<a id="py_monitoring_gui.CoIVisualPolynomBasisTypes.QuadraticMixed"></a>
+
+#### QuadraticMixed *= py_monitoring_gui.CoIVisualPolynomBasisTypes.QuadraticMixed*
 
 <a id="py_monitoring_gui.CoPMatrixClassicIndicesType"></a>
 
@@ -37,9 +64,17 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.CoPMatrixClassicIndicesType.Interactions"></a>`Interactions *= py_monitoring_gui.CoPMatrixClassicIndicesType.Interactions*`
-- <a id="py_monitoring_gui.CoPMatrixClassicIndicesType.MainEffects"></a>`MainEffects *= py_monitoring_gui.CoPMatrixClassicIndicesType.MainEffects*`
-- <a id="py_monitoring_gui.CoPMatrixClassicIndicesType.TotalEffects"></a>`TotalEffects *= py_monitoring_gui.CoPMatrixClassicIndicesType.TotalEffects*`
+<a id="py_monitoring_gui.CoPMatrixClassicIndicesType.Interactions"></a>
+
+#### Interactions *= py_monitoring_gui.CoPMatrixClassicIndicesType.Interactions*
+
+<a id="py_monitoring_gui.CoPMatrixClassicIndicesType.MainEffects"></a>
+
+#### MainEffects *= py_monitoring_gui.CoPMatrixClassicIndicesType.MainEffects*
+
+<a id="py_monitoring_gui.CoPMatrixClassicIndicesType.TotalEffects"></a>
+
+#### TotalEffects *= py_monitoring_gui.CoPMatrixClassicIndicesType.TotalEffects*
 
 <a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation"></a>
 
@@ -47,9 +82,17 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Automatic"></a>`Automatic *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Automatic*`
-- <a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Horizontal"></a>`Horizontal *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Horizontal*`
-- <a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Vertical"></a>`Vertical *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Vertical*`
+<a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Automatic"></a>
+
+#### Automatic *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Automatic*
+
+<a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Horizontal"></a>
+
+#### Horizontal *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Horizontal*
+
+<a id="py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Vertical"></a>
+
+#### Vertical *= py_monitoring_gui.CoPMatrixClassicObjectTextOrientation.Vertical*
 
 <a id="py_monitoring_gui.CoPMatrixIndicesType"></a>
 
@@ -57,9 +100,17 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.CoPMatrixIndicesType.Interactions"></a>`Interactions *= py_monitoring_gui.CoPMatrixIndicesType.Interactions*`
-- <a id="py_monitoring_gui.CoPMatrixIndicesType.MainEffects"></a>`MainEffects *= py_monitoring_gui.CoPMatrixIndicesType.MainEffects*`
-- <a id="py_monitoring_gui.CoPMatrixIndicesType.TotalEffects"></a>`TotalEffects *= py_monitoring_gui.CoPMatrixIndicesType.TotalEffects*`
+<a id="py_monitoring_gui.CoPMatrixIndicesType.Interactions"></a>
+
+#### Interactions *= py_monitoring_gui.CoPMatrixIndicesType.Interactions*
+
+<a id="py_monitoring_gui.CoPMatrixIndicesType.MainEffects"></a>
+
+#### MainEffects *= py_monitoring_gui.CoPMatrixIndicesType.MainEffects*
+
+<a id="py_monitoring_gui.CoPMatrixIndicesType.TotalEffects"></a>
+
+#### TotalEffects *= py_monitoring_gui.CoPMatrixIndicesType.TotalEffects*
 
 <a id="py_monitoring_gui.CoPMatrixObjectTextOrientation"></a>
 
@@ -67,19 +118,41 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Automatic"></a>`Automatic *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Automatic*`
-- <a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Horizontal"></a>`Horizontal *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Horizontal*`
-- <a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Vertical"></a>`Vertical *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Vertical*`
+<a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Automatic"></a>
+
+#### Automatic *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Automatic*
+
+<a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Horizontal"></a>
+
+#### Horizontal *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Horizontal*
+
+<a id="py_monitoring_gui.CoPMatrixObjectTextOrientation.Vertical"></a>
+
+#### Vertical *= py_monitoring_gui.CoPMatrixObjectTextOrientation.Vertical*
 
 <a id="py_monitoring_gui.ConvenienceGUI"></a>
 
 ## *class* py_monitoring_gui.ConvenienceGUI
 
-- <a id="py_monitoring_gui.ConvenienceGUI.__init__"></a>`__init__()`
-- <a id="py_monitoring_gui.ConvenienceGUI.create_anthill_visuals"></a>`*static* create_anthill_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str)`
-- <a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_2d_visuals"></a>`*static* create_response_surface_2d_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str)`
-- <a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_3d_visuals"></a>`*static* create_response_surface_3d_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str, arg5: str)`
-- <a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_topview_visuals"></a>`*static* create_response_surface_topview_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str, arg5: str)`
+<a id="py_monitoring_gui.ConvenienceGUI.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_gui.ConvenienceGUI.create_anthill_visuals"></a>
+
+#### *static* create_anthill_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str)
+
+<a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_2d_visuals"></a>
+
+#### *static* create_response_surface_2d_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str)
+
+<a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_3d_visuals"></a>
+
+#### *static* create_response_surface_3d_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str, arg5: str)
+
+<a id="py_monitoring_gui.ConvenienceGUI.create_response_surface_topview_visuals"></a>
+
+#### *static* create_response_surface_topview_visuals(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: str, arg4: str, arg5: str)
 
 <a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes"></a>
 
@@ -87,10 +160,21 @@
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Anthills"></a>`All_Anthills *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Anthills*`
-- <a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Correlations"></a>`All_Correlations *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Correlations*`
-- <a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations"></a>`Anthills_vs_Correlations *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations*`
-- <a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills"></a>`Correlations_vs_Anthills *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills*`
+<a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Anthills"></a>
+
+#### All_Anthills *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Anthills*
+
+<a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Correlations"></a>
+
+#### All_Correlations *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.All_Correlations*
+
+<a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations"></a>
+
+#### Anthills_vs_Correlations *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations*
+
+<a id="py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills"></a>
+
+#### Correlations_vs_Anthills *= py_monitoring_gui.ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills*
 
 <a id="py_monitoring_gui.MainWindow"></a>
 
@@ -98,31 +182,84 @@
 
 The main window holding monitoring visuals.
 
-- <a id="py_monitoring_gui.MainWindow.ShowParameterSettings"></a>`ShowParameterSettings(arg2: bool)`<br>
-  Show/Hide parameter settings widget.
-- <a id="py_monitoring_gui.MainWindow.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_monitoring_gui.MainWindow.build_mop"></a>`build_mop()`<br>
-  Build an MOP with current settings
-- <a id="py_monitoring_gui.MainWindow.build_mop_save_as"></a>`build_mop_save_as(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Build a MOP with current settings and write it to a new database
-- <a id="py_monitoring_gui.MainWindow.close"></a>`close(, arg2: int])`
-- <a id="py_monitoring_gui.MainWindow.flush"></a>`flush()`<br>
-  Process any pending events and flush main window to screen. : Use this functionality when changing data or setting to make shure, the changes are actually on-screen. Particularily usefull when exporting pictures or animating visuals.
-- <a id="py_monitoring_gui.MainWindow.init_from_text_import_settings"></a>`init_from_text_import_settings(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [TextImportSettings](py_os_design.md#py_os_design.TextImportSettings))`<br>
-  Initialize monitoring from given text file and text import settings.
-- <a id="py_monitoring_gui.MainWindow.init_from_text_import_settings_file"></a>`init_from_text_import_settings_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Initialize monitoring from given text file and text import settings file.
-- <a id="py_monitoring_gui.MainWindow.is_visual_view_reduced_mode"></a>`is_visual_view_reduced_mode() → bool`<br>
-  Return True when visual view mode is set to ‘Base’.
-- <a id="py_monitoring_gui.MainWindow.maximize"></a>`maximize()`<br>
-  Maximize mainwindow.
-- <a id="py_monitoring_gui.MainWindow.save"></a>`save(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: bool, arg4: bool, arg5: bool) → bool`<br>
-  Create and Save an OMDB file with the current monitoring data
-- <a id="py_monitoring_gui.MainWindow.show_parameter_settings"></a>`show_parameter_settings(arg2: bool)`<br>
-  Show/Hide parameter settings widget.
-- <a id="py_monitoring_gui.MainWindow.tile_subwindows"></a>`tile_subwindows()`<br>
-  Arrange subwindows in a tile pattern.
+<a id="py_monitoring_gui.MainWindow.ShowParameterSettings"></a>
+
+#### ShowParameterSettings(arg2: bool)
+
+Show/Hide parameter settings widget.
+
+<a id="py_monitoring_gui.MainWindow.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_monitoring_gui.MainWindow.build_mop"></a>
+
+#### build_mop()
+
+Build an MOP with current settings
+
+<a id="py_monitoring_gui.MainWindow.build_mop_save_as"></a>
+
+#### build_mop_save_as(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Build a MOP with current settings and write it to a new database
+
+<a id="py_monitoring_gui.MainWindow.close"></a>
+
+#### close(, arg2: int])
+
+<a id="py_monitoring_gui.MainWindow.flush"></a>
+
+#### flush()
+
+Process any pending events and flush main window to screen. 
+: Use this functionality when changing data or setting to make shure, the changes are actually on-screen. 
+  Particularily usefull when exporting pictures or animating visuals.
+
+<a id="py_monitoring_gui.MainWindow.init_from_text_import_settings"></a>
+
+#### init_from_text_import_settings(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [TextImportSettings](py_os_design.md#py_os_design.TextImportSettings))
+
+Initialize monitoring from given text file and text import settings.
+
+<a id="py_monitoring_gui.MainWindow.init_from_text_import_settings_file"></a>
+
+#### init_from_text_import_settings_file(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Initialize monitoring from given text file and text import settings file.
+
+<a id="py_monitoring_gui.MainWindow.is_visual_view_reduced_mode"></a>
+
+#### is_visual_view_reduced_mode() → bool
+
+Return True when visual view mode is set to ‘Base’.
+
+<a id="py_monitoring_gui.MainWindow.maximize"></a>
+
+#### maximize()
+
+Maximize mainwindow.
+
+<a id="py_monitoring_gui.MainWindow.save"></a>
+
+#### save(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: bool, arg4: bool, arg5: bool) → bool
+
+Create and Save an OMDB file with the current monitoring data
+
+<a id="py_monitoring_gui.MainWindow.show_parameter_settings"></a>
+
+#### show_parameter_settings(arg2: bool)
+
+Show/Hide parameter settings widget.
+
+<a id="py_monitoring_gui.MainWindow.tile_subwindows"></a>
+
+#### tile_subwindows()
+
+Arrange subwindows in a tile pattern.
 
 <a id="py_monitoring_gui.OSLMVisual"></a>
 
@@ -130,15 +267,40 @@ The main window holding monitoring visuals.
 
 A visual displaying monitoring data in a certain way.
 
-- <a id="py_monitoring_gui.OSLMVisual.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_monitoring_gui.OSLMVisual.export"></a>`export(file_path: Path)`<br>
-  [0] Export the visual as picture, with given relative scale to file position given as path. : If scale is left empty, 1.0 is used. Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100]. Set Watermark to True to export picture with watermark. [1] Export the visual as picture, with given absolute sizes to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100]. Set Watermark to True to export picture with watermark.
-- `export(file_path: Path, width: int, height: int)`
-- <a id="py_monitoring_gui.OSLMVisual.export_data"></a>`export_data(file_path: Path)`<br>
-  Export the visual as ascii with given format_string to file position given as path. : If format_string is left empty, “%g” is used.
-- <a id="py_monitoring_gui.OSLMVisual.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
+<a id="py_monitoring_gui.OSLMVisual.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_monitoring_gui.OSLMVisual.export"></a>
+
+#### export(file_path: Path)
+
+#### export(file_path: Path, width: int, height: int)
+
+[0] Export the visual as picture, with given relative scale to file position given as path. 
+: If scale is left empty, 1.0 is used. 
+  Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100]. Set Watermark to True to export picture with watermark.
+
+[1] Export the visual as picture, with given absolute sizes to file position given as path.
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100]. Set Watermark to True to export picture with watermark.
+
+<a id="py_monitoring_gui.OSLMVisual.export_data"></a>
+
+#### export_data(file_path: Path)
+
+Export the visual as ascii with given format_string to file position given as path. 
+: If format_string is left empty, “%g” is used.
+
+<a id="py_monitoring_gui.OSLMVisual.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
 
 <a id="py_monitoring_gui.PathBasedVisualTypes"></a>
 
@@ -146,8 +308,13 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.PathBasedVisualTypes.Files"></a>`Files *= py_monitoring_gui.PathBasedVisualTypes.Files*`
-- <a id="py_monitoring_gui.PathBasedVisualTypes.Processes"></a>`Processes *= py_monitoring_gui.PathBasedVisualTypes.Processes*`
+<a id="py_monitoring_gui.PathBasedVisualTypes.Files"></a>
+
+#### Files *= py_monitoring_gui.PathBasedVisualTypes.Files*
+
+<a id="py_monitoring_gui.PathBasedVisualTypes.Processes"></a>
+
+#### Processes *= py_monitoring_gui.PathBasedVisualTypes.Processes*
 
 <a id="py_monitoring_gui.RegressionType"></a>
 
@@ -155,9 +322,17 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.RegressionType.LinearRegression"></a>`LinearRegression *= py_monitoring_gui.RegressionType.LinearRegression*`
-- <a id="py_monitoring_gui.RegressionType.NoRegression"></a>`NoRegression *= py_monitoring_gui.RegressionType.NoRegression*`
-- <a id="py_monitoring_gui.RegressionType.QuadraticRegression"></a>`QuadraticRegression *= py_monitoring_gui.RegressionType.QuadraticRegression*`
+<a id="py_monitoring_gui.RegressionType.LinearRegression"></a>
+
+#### LinearRegression *= py_monitoring_gui.RegressionType.LinearRegression*
+
+<a id="py_monitoring_gui.RegressionType.NoRegression"></a>
+
+#### NoRegression *= py_monitoring_gui.RegressionType.NoRegression*
+
+<a id="py_monitoring_gui.RegressionType.QuadraticRegression"></a>
+
+#### QuadraticRegression *= py_monitoring_gui.RegressionType.QuadraticRegression*
 
 <a id="py_monitoring_gui.ResponseSurfacePaletteData"></a>
 
@@ -165,12 +340,29 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.AbsError"></a>`AbsError *= py_monitoring_gui.ResponseSurfacePaletteData.AbsError*`
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.CoP"></a>`CoP *= py_monitoring_gui.ResponseSurfacePaletteData.CoP*`
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.Error"></a>`Error *= py_monitoring_gui.ResponseSurfacePaletteData.Error*`
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.RMSE"></a>`RMSE *= py_monitoring_gui.ResponseSurfacePaletteData.RMSE*`
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.SPDensity"></a>`SPDensity *= py_monitoring_gui.ResponseSurfacePaletteData.SPDensity*`
-- <a id="py_monitoring_gui.ResponseSurfacePaletteData.Values"></a>`Values *= py_monitoring_gui.ResponseSurfacePaletteData.Values*`
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.AbsError"></a>
+
+#### AbsError *= py_monitoring_gui.ResponseSurfacePaletteData.AbsError*
+
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.CoP"></a>
+
+#### CoP *= py_monitoring_gui.ResponseSurfacePaletteData.CoP*
+
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.Error"></a>
+
+#### Error *= py_monitoring_gui.ResponseSurfacePaletteData.Error*
+
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.RMSE"></a>
+
+#### RMSE *= py_monitoring_gui.ResponseSurfacePaletteData.RMSE*
+
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.SPDensity"></a>
+
+#### SPDensity *= py_monitoring_gui.ResponseSurfacePaletteData.SPDensity*
+
+<a id="py_monitoring_gui.ResponseSurfacePaletteData.Values"></a>
+
+#### Values *= py_monitoring_gui.ResponseSurfacePaletteData.Values*
 
 <a id="py_monitoring_gui.StatisticAnalysisBoxType"></a>
 
@@ -178,9 +370,17 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.StatisticAnalysisBoxType.MeanStddev"></a>`MeanStddev *= py_monitoring_gui.StatisticAnalysisBoxType.MeanStddev*`
-- <a id="py_monitoring_gui.StatisticAnalysisBoxType.None"></a>`None *= py_monitoring_gui.StatisticAnalysisBoxType.None*`
-- <a id="py_monitoring_gui.StatisticAnalysisBoxType.Probability"></a>`Probability *= py_monitoring_gui.StatisticAnalysisBoxType.Probability*`
+<a id="py_monitoring_gui.StatisticAnalysisBoxType.MeanStddev"></a>
+
+#### MeanStddev *= py_monitoring_gui.StatisticAnalysisBoxType.MeanStddev*
+
+<a id="py_monitoring_gui.StatisticAnalysisBoxType.None"></a>
+
+#### None *= py_monitoring_gui.StatisticAnalysisBoxType.None*
+
+<a id="py_monitoring_gui.StatisticAnalysisBoxType.Probability"></a>
+
+#### Probability *= py_monitoring_gui.StatisticAnalysisBoxType.Probability*
 
 <a id="py_monitoring_gui.StatisticAnalysisLimitsType"></a>
 
@@ -188,9 +388,17 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.StatisticAnalysisLimitsType.Lines"></a>`Lines *= py_monitoring_gui.StatisticAnalysisLimitsType.Lines*`
-- <a id="py_monitoring_gui.StatisticAnalysisLimitsType.None"></a>`None *= py_monitoring_gui.StatisticAnalysisLimitsType.None*`
-- <a id="py_monitoring_gui.StatisticAnalysisLimitsType.StackedBar"></a>`StackedBar *= py_monitoring_gui.StatisticAnalysisLimitsType.StackedBar*`
+<a id="py_monitoring_gui.StatisticAnalysisLimitsType.Lines"></a>
+
+#### Lines *= py_monitoring_gui.StatisticAnalysisLimitsType.Lines*
+
+<a id="py_monitoring_gui.StatisticAnalysisLimitsType.None"></a>
+
+#### None *= py_monitoring_gui.StatisticAnalysisLimitsType.None*
+
+<a id="py_monitoring_gui.StatisticAnalysisLimitsType.StackedBar"></a>
+
+#### StackedBar *= py_monitoring_gui.StatisticAnalysisLimitsType.StackedBar*
 
 <a id="py_monitoring_gui.StatisticAnalysisScalingType"></a>
 
@@ -198,9 +406,17 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.StatisticAnalysisScalingType.MeanStddev"></a>`MeanStddev *= py_monitoring_gui.StatisticAnalysisScalingType.MeanStddev*`
-- <a id="py_monitoring_gui.StatisticAnalysisScalingType.MinMax"></a>`MinMax *= py_monitoring_gui.StatisticAnalysisScalingType.MinMax*`
-- <a id="py_monitoring_gui.StatisticAnalysisScalingType.None"></a>`None *= py_monitoring_gui.StatisticAnalysisScalingType.None*`
+<a id="py_monitoring_gui.StatisticAnalysisScalingType.MeanStddev"></a>
+
+#### MeanStddev *= py_monitoring_gui.StatisticAnalysisScalingType.MeanStddev*
+
+<a id="py_monitoring_gui.StatisticAnalysisScalingType.MinMax"></a>
+
+#### MinMax *= py_monitoring_gui.StatisticAnalysisScalingType.MinMax*
+
+<a id="py_monitoring_gui.StatisticAnalysisScalingType.None"></a>
+
+#### None *= py_monitoring_gui.StatisticAnalysisScalingType.None*
 
 <a id="py_monitoring_gui.StatisticAnalysisWhiskerType"></a>
 
@@ -208,2752 +424,8431 @@ A visual displaying monitoring data in a certain way.
 
 **Enumeration**
 
-- <a id="py_monitoring_gui.StatisticAnalysisWhiskerType.MeanStddev"></a>`MeanStddev *= py_monitoring_gui.StatisticAnalysisWhiskerType.MeanStddev*`
-- <a id="py_monitoring_gui.StatisticAnalysisWhiskerType.None"></a>`None *= py_monitoring_gui.StatisticAnalysisWhiskerType.None*`
-- <a id="py_monitoring_gui.StatisticAnalysisWhiskerType.Probability"></a>`Probability *= py_monitoring_gui.StatisticAnalysisWhiskerType.Probability*`
+<a id="py_monitoring_gui.StatisticAnalysisWhiskerType.MeanStddev"></a>
+
+#### MeanStddev *= py_monitoring_gui.StatisticAnalysisWhiskerType.MeanStddev*
+
+<a id="py_monitoring_gui.StatisticAnalysisWhiskerType.None"></a>
+
+#### None *= py_monitoring_gui.StatisticAnalysisWhiskerType.None*
+
+<a id="py_monitoring_gui.StatisticAnalysisWhiskerType.Probability"></a>
+
+#### Probability *= py_monitoring_gui.StatisticAnalysisWhiskerType.Probability*
 
 <a id="py_monitoring_gui.Visual"></a>
 
 ## *class* py_monitoring_gui.Visual
 
-- <a id="py_monitoring_gui.Visual.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="py_monitoring_gui.Visual.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="py_monitoring_gui.Visuals"></a>
 
 ## *class* py_monitoring_gui.Visuals
 
-- <a id="py_monitoring_gui.Visuals.Anthill"></a>`*class* Anthill`
-- <a id="py_monitoring_gui.Visuals.Anthill.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Anthill.SetDimensionForColor"></a>`SetDimensionForColor(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as color.
-- <a id="py_monitoring_gui.Visuals.Anthill.SetDimensionForSize"></a>`SetDimensionForSize(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as symbol_size.
-- <a id="py_monitoring_gui.Visuals.Anthill.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Anthill.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Anthill.UnsetDimensionForColor"></a>`UnsetDimensionForColor()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Anthill.UnsetDimensionForSize"></a>`UnsetDimensionForSize()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Anthill.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Anthill.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_regression_coefficients"></a>`get_regression_coefficients() → list`<br>
-  Return the coefficients of a chosen Regression as list. : Dependent to chosen Regression type linear or quadratic, the list is 2 or 3 entries long. For a + b\*x you get [a,b], for a + b\*x + c\*x\*x yout get [a,b,c]. In case of non valid regression you get an empty list.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Anthill.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Anthill.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Anthill.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.Anthill.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.Anthill.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_dimension_for_color"></a>`set_dimension_for_color(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as color.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_dimension_for_size"></a>`set_dimension_for_size(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as symbol_size.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Anthill.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Anthill.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Anthill.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_regression"></a>`set_regression(arg2: [RegressionType](#py_monitoring_gui.RegressionType))`<br>
-  Set regression
-- <a id="py_monitoring_gui.Visuals.Anthill.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Anthill.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Anthill.unset_dimension_for_color"></a>`unset_dimension_for_color()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Anthill.unset_dimension_for_size"></a>`unset_dimension_for_size()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Anthill.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ApproxDesignTable"></a>`*class* ApproxDesignTable`
-- <a id="py_monitoring_gui.Visuals.ApproxDesignTable.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ApproxDesignTable.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ApproxDesignTable.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo"></a>`*class* ApproxModelInfo`
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.export"></a>`export(file_path: Path)`<br>
-  Export the visual as picture to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100].
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.export_data"></a>`export_data(file_path: Path)`<br>
-  Export the visual as ascii with given format_string to file position given as path. : If format_string is left empty, “%g” is used.
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ApproxModelInfo.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory"></a>`*class* ApproximationHistory`
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_mode"></a>`set_mode(arg2: [ApproximationHistoryMode](#py_monitoring_gui.ApproximationHistoryMode))`<br>
-  Toggle the view between responses and criteria
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_show_all_results"></a>`set_show_all_results(arg2: bool)`<br>
-  Set true to show all results
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_show_minimal_local_cop_values"></a>`set_show_minimal_local_cop_values(arg2: bool)`<br>
-  Set true to additionally show minimum local cop values
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ApproximationHistory.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Bars"></a>`Bars *= py_monitoring_gui.CustomData_Type.Bars*`
-- <a id="py_monitoring_gui.Visuals.Box"></a>`Box *= py_monitoring_gui.CustomData_Type.Box*`
-- <a id="py_monitoring_gui.Visuals.BoxWhisker"></a>`*class* BoxWhisker`
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_box_probability_content"></a>`set_box_probability_content(box_probability_content: float)`<br>
-  Set the probability content for the box. Box goes from median-content\*0.5 to median+content\*0.5.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_group"></a>`set_group(group_name: str)`<br>
-  Set the group to be shown
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_scale"></a>`set_scale(scale: bool)`<br>
-  Scale to min/max.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_box"></a>`set_show_box(show: bool)`<br>
-  Show box.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_limits"></a>`set_show_limits(show: bool)`<br>
-  Show limits.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_samples"></a>`set_show_samples(show_samples: bool)`<br>
-  Show sample points.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_whisker"></a>`set_show_whisker(show: bool)`<br>
-  Show whisker.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_whisker_probability_content"></a>`set_whisker_probability_content(whisker_probability_content: float)`<br>
-  Set the probability content for the whisker. Whisker goes from median-content\*0.5 to median+content\*0.5.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.BoxWhisker.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Cloud"></a>`*class* Cloud`
-- <a id="py_monitoring_gui.Visuals.Cloud.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.SetDimensionForColor"></a>`SetDimensionForColor(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as color.
-- <a id="py_monitoring_gui.Visuals.Cloud.SetDimensionForSize"></a>`SetDimensionForSize(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as symbol_size.
-- <a id="py_monitoring_gui.Visuals.Cloud.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Cloud.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.SetZAxis"></a>`SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.UnsetDimensionForColor"></a>`UnsetDimensionForColor()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Cloud.UnsetDimensionForSize"></a>`UnsetDimensionForSize()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Cloud.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Cloud.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.get_z_axis_label"></a>`get_z_axis_label() → str`<br>
-  Get the z axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Cloud.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.Cloud.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.Cloud.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_alpha"></a>`set_alpha(alpha_angle: float)`<br>
-  Set the first angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_beta"></a>`set_beta(beta_angle: float)`<br>
-  Set the second angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_dimension_for_color"></a>`set_dimension_for_color(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as color.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_dimension_for_size"></a>`set_dimension_for_size(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the additional dimension to be shown as symbol_size.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_gamma"></a>`set_gamma(gamma_angle: float)`<br>
-  Set the third angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Cloud.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Cloud.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_lighting_enabled"></a>`set_lighting_enabled(enabled: bool)`<br>
-  Set lighting enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Cloud.set_log_z_axis"></a>`set_log_z_axis(enabled: bool)`<br>
-  Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Cloud.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.Cloud.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_regression"></a>`set_regression(arg2: [RegressionType](#py_monitoring_gui.RegressionType))`<br>
-  Set regression
-- <a id="py_monitoring_gui.Visuals.Cloud.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_z_axis"></a>`set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_z_axis_format"></a>`set_z_axis_format(z_axis_format: str)`<br>
-  Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
-- <a id="py_monitoring_gui.Visuals.Cloud.set_z_axis_label"></a>`set_z_axis_label(label_z: str)`<br>
-  Set the z axis label.
-- <a id="py_monitoring_gui.Visuals.Cloud.unset_dimension_for_color"></a>`unset_dimension_for_color()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Cloud.unset_dimension_for_size"></a>`unset_dimension_for_size()`<br>
-  Unset the color dimension.
-- <a id="py_monitoring_gui.Visuals.Cloud.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CoI"></a>`*class* CoI`
-- <a id="py_monitoring_gui.Visuals.CoI.ListenToDimensionIndex"></a>`ListenToDimensionIndex(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CoI.SetAdjusted"></a>`SetAdjusted(adjust: bool)`<br>
-  Toggle the view to show adjusted values.
-- <a id="py_monitoring_gui.Visuals.CoI.SetDimension"></a>`SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CoI.SetInverted"></a>`SetInverted(invert: bool)`<br>
-  Toggle the view to show ( value ) or ( CoD - value ).
-- <a id="py_monitoring_gui.Visuals.CoI.SetType"></a>`SetType(coi_type: [CoIVisualPolynomBasisTypes](#py_monitoring_gui.CoIVisualPolynomBasisTypes))`<br>
-  Set the type of coi calculation, where CoIVisualPolynomBasisTypes. : Automatic means that the best found model is used for calculation.
-- <a id="py_monitoring_gui.Visuals.CoI.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CoI.get_actual_dimension"></a>`get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the actual visible dimension.
-- <a id="py_monitoring_gui.Visuals.CoI.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CoI.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CoI.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CoI.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CoI.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CoI.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CoI.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoI.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoI.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CoI.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoI.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoI.set_adjusted"></a>`set_adjusted(adjust: bool)`<br>
-  Toggle the view to show adjusted values.
-- <a id="py_monitoring_gui.Visuals.CoI.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CoI.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CoI.set_inverted"></a>`set_inverted(invert: bool)`<br>
-  Toggle the view to show ( value ) or ( CoD - value ).
-- <a id="py_monitoring_gui.Visuals.CoI.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoI.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.CoI.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoI.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoI.set_type"></a>`set_type(coi_type: [CoIVisualPolynomBasisTypes](#py_monitoring_gui.CoIVisualPolynomBasisTypes))`<br>
-  Set the type of coi calculation, where CoIVisualPolynomBasisTypes. : Automatic means that the best found model is used for calculation.
-- <a id="py_monitoring_gui.Visuals.CoI.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoI.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoI.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CoP"></a>`*class* CoP`
-- <a id="py_monitoring_gui.Visuals.CoP.ListenToDimensionIndex"></a>`ListenToDimensionIndex(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CoP.SetDimension"></a>`SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CoP.SetFiltered"></a>`SetFiltered(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CoP.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CoP.get_actual_dimension"></a>`get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the actual visible dimension.
-- <a id="py_monitoring_gui.Visuals.CoP.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CoP.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CoP.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CoP.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CoP.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CoP.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CoP.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoP.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoP.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CoP.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoP.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoP.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CoP.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CoP.set_filter_limit"></a>`set_filter_limit(filter_value: float[%])`<br>
-  Set the limit below which the single CoP values are filtered in percent.
-- <a id="py_monitoring_gui.Visuals.CoP.set_filtered"></a>`set_filtered(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CoP.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoP.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.CoP.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoP.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoP.set_show_interactions"></a>`set_show_interactions(show: bool)`<br>
-  Toggle view to see “Main effect” and “Interaction “ values additional to “Total effect” values.
-- <a id="py_monitoring_gui.Visuals.CoP.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoP.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoP.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix"></a>`*class* CoPMatrix`
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_approximation_line_width_scale"></a>`set_approximation_line_width_scale(line_width_scale: float)`<br>
-  Set line width scale with which the approximation line is shown.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_enabled"></a>`set_axes_rotation_enabled(enable: bool)`<br>
-  Set axes rotation enabled.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_orthogonal"></a>`set_axes_rotation_orthogonal(enable: bool)`<br>
-  Set rotation angles to 0 degree if enough space for text exist, else to 90.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_x_angle"></a>`set_axes_rotation_x_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_y_angle"></a>`set_axes_rotation_y_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_filter_limit"></a>`set_filter_limit(filter_limit: float[%])`<br>
-  Set the limit below which the values are filtered in percent.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_filter_total_limit"></a>`set_filter_total_limit(total_filter_value: float[%])`<br>
-  Set the limit below which the total CoP values ( ModelCoP’s ) are filtered in percent.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_indices_type"></a>`set_indices_type(indices_type: [CoPMatrixIndicesType](#py_monitoring_gui.CoPMatrixIndicesType))`<br>
-  Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_object_text_orientation"></a>`set_object_text_orientation(orientation: [CoPMatrixObjectTextOrientation](#py_monitoring_gui.CoPMatrixObjectTextOrientation))`<br>
-  Toggle to change orientation of object text on tiles Automatic : horizontal if enough space, else vertical is tested Horizontal : ever show text horizontal Vertical : ever show text vertical.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  [0] Set the minimum and maximum values of palette. [1] Set the minimum and maximum values of palette.
-- `set_palette_limits(minimum: float, maximum: float)`
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_resolution"></a>`set_resolution(resolution: int)`<br>
-  Set resolution of approximation line..
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_additional_points"></a>`set_show_additional_points(show: bool)`<br>
-  Show additional points in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_approximated_points"></a>`set_show_approximated_points(show: bool)`<br>
-  Show approximated points in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_approximation"></a>`set_show_approximation(show: bool)`<br>
-  Show approximation line in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_background_cop"></a>`set_show_background_cop(show: bool)`<br>
-  Show background color in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_calculated_response_value"></a>`set_show_calculated_response_value(show: bool)`<br>
-  Show calculated response value in last column.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_cop"></a>`set_show_cop(show: bool)`<br>
-  Show cop value in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_deactivated_support_points"></a>`set_show_deactivated_support_points(show: bool)`<br>
-  Show deactivated supports points in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_extended"></a>`set_show_extended(show: bool)`<br>
-  Show matrix in extended mode with response surface 2d plots in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_filtered"></a>`set_show_filtered(show: bool)`<br>
-  Show all cop values including these filtered by mop.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_grid"></a>`set_show_grid(show: bool)`<br>
-  Show grid in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_parameter_line"></a>`set_show_parameter_line(show: bool)`<br>
-  Show parameter line in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_round_corners"></a>`set_show_round_corners(show: bool)`<br>
-  Show tile with round corners or as squares.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_selection"></a>`set_show_selection(show: bool)`<br>
-  Show selection lines in grid plot.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_support_points"></a>`set_show_support_points(show: bool)`<br>
-  Show support points in tiles.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrix.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic"></a>`*class* CoPMatrixClassic`
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_enabled"></a>`set_axes_rotation_enabled(enable: bool)`<br>
-  Set axes rotation enabled.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_orthogonal"></a>`set_axes_rotation_orthogonal(enable: bool)`<br>
-  Set rotation angles to 0 degree if enough space for text exist, else to 90.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_x_angle"></a>`set_axes_rotation_x_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_y_angle"></a>`set_axes_rotation_y_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_filter_limit"></a>`set_filter_limit(filter_limit: float[%])`<br>
-  Set the limit below which the values are filtered in percent.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_filter_total_limit"></a>`set_filter_total_limit(total_filter_value: float[%])`<br>
-  Set the limit below which the total CoP values ( ModelCoP’s ) are filtered in percent.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_indices_type"></a>`set_indices_type(indices_type: [CoPMatrixClassicIndicesType](#py_monitoring_gui.CoPMatrixClassicIndicesType))`<br>
-  Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_object_text_orientation"></a>`set_object_text_orientation(orientation: [CoPMatrixClassicObjectTextOrientation](#py_monitoring_gui.CoPMatrixClassicObjectTextOrientation))`<br>
-  Toggle to change orientation of object text on tiles Automatic : horizontal if enough space, else vertical is tested Horizontal : ever show text horizontal Vertical : ever show text vertical.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CoPMatrixClassic.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient"></a>`*class* CorrelationCoefficient`
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.ListenToDimensionIndex"></a>`ListenToDimensionIndex(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.SetDimension"></a>`SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CorrelationCoefficient.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues"></a>`*class* CriteriaValues`
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CriteriaValues.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Custom"></a>`Custom *= py_monitoring_gui.CustomData_Type.Custom*`
-- <a id="py_monitoring_gui.Visuals.CustomData"></a>`*class* CustomData`
-- <a id="py_monitoring_gui.Visuals.CustomData.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.CustomData.add_data"></a>`add_data(layer_name: str, data: PyOSDesignEntry, style_vector: StyleList, channel_names: WStrList, Vizualisation_type: CustomData_Type) → bool`<br>
-  Add data as new layer to the Visual.
-- <a id="py_monitoring_gui.Visuals.CustomData.add_eval_mesh"></a>`add_eval_mesh(layer_name: str, x: doubleVec vector, y: doubleVec vector, color: doubleVec values) → bool`<br>
-  Add data as new eval mesh layer to the Visual.
-- <a id="py_monitoring_gui.Visuals.CustomData.add_grid"></a>`add_grid(layer_name: str, data: PyOSDesignEntry) → bool`<br>
-  Add data as new grid layer to the Visual.
-- <a id="py_monitoring_gui.Visuals.CustomData.add_mesh"></a>`add_mesh(layer_name: str, x: doubleVec vector, y: doubleVec vector, style_vector: StyleList) → bool`<br>
-  Add data as new mesh layer to the Visual. : If single_triangles=True, length of vectors has to be multiple size of 3 and equal. Produces single triangles. If single_triangles=False, then a colored stripe is been produced. Sizes has to be equal or greater equal than 3.
-- <a id="py_monitoring_gui.Visuals.CustomData.clear_data"></a>`clear_data()`<br>
-  Remove all layers.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.CustomData.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.CustomData.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.CustomData.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.CustomData.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CustomData.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_alt_axis"></a>`set_alt_axis(axis: int, _labels: WStrList, ticks: doubleVec)`<br>
-  Set an alternate axis to index (0 == x, 1== y, 2==z). : With labels as string_list, axes_ticks as vector, and an optional rotation_angle
-- <a id="py_monitoring_gui.Visuals.CustomData.set_axes_enabled"></a>`set_axes_enabled(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_background_color"></a>`set_background_color(arg2: float, arg3: float, arg4: float, arg5: float)`<br>
-  Change the background color.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_bar_width"></a>`set_bar_width(layer_name: str, bar_width: float)`<br>
-  Set the width for StackedBar and Box (others will be ignored). : Senseful ranges between 1.0 (no space between bars) and 0.0 (bar is only a thin line). When the value is greater than 1.0 bars overlap.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_box_show_mean_and_median"></a>`set_box_show_mean_and_median(layer_name: str, show_mean: bool)`<br>
-  Toggle visibility of ‘Mean’ point additional to ‘Median’ line, if enough data_points are given.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_box_show_whisker"></a>`set_box_show_whisker(layer_name: str, show_whisker: bool)`<br>
-  Toggle visibility of BoxPlot’s outer lines (whisker).
-- <a id="py_monitoring_gui.Visuals.CustomData.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_iso_line_heights"></a>`set_iso_line_heights(layer_name: str, iso_lines_string: str)`<br>
-  [0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ . Does only have effect when showing eval_mesh in this layer. [1] Set the iso lines as vector for given layer. Does only have effect when showing eval_mesh in this layer.
-- `set_iso_line_heights(layer_name: str, iso_lines: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.CustomData.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.CustomData.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_line_width"></a>`set_line_width(arg2: float)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_lines_enabled"></a>`set_lines_enabled(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_log_x_axis"></a>`set_log_x_axis(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_log_y_axis"></a>`set_log_y_axis(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_object_text"></a>`set_object_text(arg2: str, arg3: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList), arg4: int, arg5: int)`<br>
-  Set the object text (e.g. on bars), from given list, spread to matrix when column is greater than 1 (e.g. multibar).
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_caption"></a>`set_palette_caption(layer_name: str, caption: str)`<br>
-  Set the caption to the palette for given layer.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.CustomData.set_palette_visible"></a>`set_palette_visible(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_ranges_x"></a>`set_ranges_x(arg2: float, arg3: float)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_ranges_y"></a>`set_ranges_y(arg2: float, arg3: float)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_selection_color"></a>`set_selection_color(arg2: str, arg3: int, arg4: int, arg5: int, arg6: int)`<br>
-  Set the selection color.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_selection_text"></a>`set_selection_text(arg2: str, arg3: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))`<br>
-  Set the selection text (e.g. on points, shown when selected), from given list.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_surfaces_enabled"></a>`set_surfaces_enabled(arg2: bool)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_symbol_size"></a>`set_symbol_size(arg2: float)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_x_axis_format"></a>`set_x_axis_format(arg2: str)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.CustomData.set_y_axis_format"></a>`set_y_axis_format(arg2: str)`
-- <a id="py_monitoring_gui.Visuals.CustomData.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.CustomData.unset_alt_axis"></a>`unset_alt_axis(arg2: int)`<br>
-  Unset the alternate axis at index (0 == x, 1== y, 2==z) to default float axis
-- <a id="py_monitoring_gui.Visuals.CustomData.unset_background_color"></a>`unset_background_color()`<br>
-  Reset background color to default [0.9,0.9,0.9,1.0].
-- <a id="py_monitoring_gui.Visuals.CustomData.unset_object_text"></a>`unset_object_text(arg2: str)`<br>
-  Unset the object text.
-- <a id="py_monitoring_gui.Visuals.CustomData.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.CustomData_Type"></a>`*class* CustomData_Type`<br>
-  **Enumeration**
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Bars"></a>`Bars *= py_monitoring_gui.CustomData_Type.Bars*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Box"></a>`Box *= py_monitoring_gui.CustomData_Type.Box*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Custom"></a>`Custom *= py_monitoring_gui.CustomData_Type.Custom*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Grid"></a>`Grid *= py_monitoring_gui.CustomData_Type.Grid*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.HorizontalBars"></a>`HorizontalBars *= py_monitoring_gui.CustomData_Type.HorizontalBars*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.HorizontalBox"></a>`HorizontalBox *= py_monitoring_gui.CustomData_Type.HorizontalBox*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Lines"></a>`Lines *= py_monitoring_gui.CustomData_Type.Lines*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.Points"></a>`Points *= py_monitoring_gui.CustomData_Type.Points*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.StackedBars"></a>`StackedBars *= py_monitoring_gui.CustomData_Type.StackedBars*`
-- <a id="py_monitoring_gui.Visuals.CustomData_Type.StackedHorizontalBars"></a>`StackedHorizontalBars *= py_monitoring_gui.CustomData_Type.StackedHorizontalBars*`
-- <a id="py_monitoring_gui.Visuals.DesignTable"></a>`*class* DesignTable`
-- <a id="py_monitoring_gui.Visuals.DesignTable.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.DesignTable.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.DesignTable.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.DimensionId"></a>`*class* DimensionId`
-- <a id="py_monitoring_gui.Visuals.DimensionId.__init__"></a>`__init__()`
-- <a id="py_monitoring_gui.Visuals.DimensionId.get_dimension_from_index"></a>`get_dimension_from_index(ax_index: int) → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the dimension set at ax_index, if exist, else return dimension().
-- <a id="py_monitoring_gui.Visuals.DimensionId.get_dimension_id_from_index"></a>`get_dimension_id_from_index(ax_index: int) → int`<br>
-  Return the dimension_id set at ax_index, if exist, else return -1.
-- <a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_at_index"></a>`has_dimension_at_index(ax_index: int) → bool`<br>
-  Return True when a dimension is set at ax-index of plot.
-- <a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_id_at_index"></a>`has_dimension_id_at_index(ax_index: int) → bool`<br>
-  Return True when the plot has a dimension_combo_box id set at ax_index.
-- <a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_set_at_index"></a>`has_dimension_set_at_index(ax_index: int) → bool`<br>
-  Return True when a dimension is set at ax-index of plot.
-- <a id="py_monitoring_gui.Visuals.DimensionId.listen_to_dimension_index"></a>`listen_to_dimension_index(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.DimensionId.reset_user_defined_variable_selection"></a>`reset_user_defined_variable_selection()`<br>
-  Reset the previously made changes on dimension id to the predefined values, been saved at the visual on creation.
-- <a id="py_monitoring_gui.Visuals.DimensionId.set_dimension"></a>`set_dimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.DimensionId.set_dimension_at_index"></a>`set_dimension_at_index(ax_index: int, dimension_at_x_i: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set a dimension at given ax_index to plot.
-- <a id="py_monitoring_gui.Visuals.DimensionId.set_dimension_id_at_index"></a>`set_dimension_id_at_index(ax_index: int, combo_box_id: int)`<br>
-  Set a combo_box_id at ax_index. : Plot now shows content of belonging combo_box at ax_index. e.g. SetDimensionToId(1,2) means that the plot now shows the chosen dimension from 3rd combo_box at y-axis.
-- <a id="py_monitoring_gui.Visuals.DimensionId.unset_dimension_at_index"></a>`unset_dimension_at_index(ax_index: int)`<br>
-  Unset the dimension at given ax_index. : Plot now shows the predefined behavior.
-- <a id="py_monitoring_gui.Visuals.DimensionId.unset_dimension_id_at_index"></a>`unset_dimension_id_at_index(ax_index: int)`<br>
-  Unset the dimension_id at given ax_index. : Plot now shows the predefined behavior.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix"></a>`*class* ExtendedCoPMatrix`
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.export"></a>`export(file_path: Path)`<br>
-  [0] Export the visual as picture, with given relative scale to file position given as path. : If scale is left empty, 1.0 is used. [1] Export the visual as picture, with given absolute sizes to file position given as path.
-- `export(file_path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), width: int, height: int)`
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_auto_rotate_axis_labels_enabled"></a>`set_auto_rotate_axis_labels_enabled(enable: bool)`<br>
-  Enable/disable axis label auto rotation.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_fix_projection_to_design"></a>`set_fix_projection_to_design(show: bool)`<br>
-  Enables/disables fix projection to designs.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_indices_type"></a>`set_indices_type(indices_type: [ApproximatingCOPMatrixIndicesType](#py_monitoring_gui.ApproximatingCOPMatrixIndicesType))`<br>
-  Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_limit_axis_label_size"></a>`set_limit_axis_label_size(enable: bool)`<br>
-  Limit axis label size.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_approximation"></a>`set_show_approximation(show: bool)`<br>
-  Show/hide approximation line.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_background_cop"></a>`set_show_background_cop(show: bool)`<br>
-  Show/hide background COP.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_cop"></a>`set_show_cop(show: bool)`<br>
-  Show/hide COP.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_filtered"></a>`set_show_filtered(show: bool)`<br>
-  Show/hide filtered parameters/responses.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_grid"></a>`set_show_grid(show: bool)`<br>
-  Show/hide grid.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_parameter_line"></a>`set_show_parameter_line(show: bool)`<br>
-  Show/hide parameter line.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_support_points"></a>`set_show_support_points(show: bool)`<br>
-  Show/hide support points.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_use_rectangular_view"></a>`set_use_rectangular_view(show: bool)`<br>
-  Enables/disables rectangular view.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix"></a>`*class* ExtendedCorrelationMatrix`
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.export_with_given_tile_sizes"></a>`export_with_given_tile_sizes(arg2: Path, arg3: int, file_path: int)`<br>
-  Export the visual as picture, with given absolute tile sizes to file position given as path.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. : Be aware that much memory can be allocated, in case of many dimensions.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_sizes_with_given_tile_sizes"></a>`get_sizes_with_given_tile_sizes(tile_width: float, tile_height: float) → list`<br>
-  Return list with size of plot when tiles have to be sized with x_tile_size and y_tile_size. Index 0 : width. index 1 : height.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_enabled"></a>`set_axes_rotation_enabled(enable: bool)`<br>
-  Set axes rotation enabled.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_orthogonal"></a>`set_axes_rotation_orthogonal(enable: bool)`<br>
-  Set rotation angles to 0 degree if possible, else to 90.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_x_angle"></a>`set_axes_rotation_x_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_y_angle"></a>`set_axes_rotation_y_angle(angle: float)`<br>
-  Set the rotation angle for y-axis.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_histogram_classes"></a>`set_histogram_classes(classes: int)`<br>
-  Set the number of histogram classes.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_view_type"></a>`set_view_type(view_type: [ExtendedCorrelationMatrixViewTypes](#py_monitoring_gui.ExtendedCorrelationMatrixViewTypes))`<br>
-  Change the view of the visual to show the entils as : ExtendedCorrelationMatrixViewTypes.All_Correlations - correlation values in all entils ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills - correlation values in upper left part, histograms on main diagonal and anthills in lower right part. ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations - anthills in upper left part, histograms on main diagonal and correlation values in lower right part. ExtendedCorrelationMatrixViewTypes.All_Anthills - histograms on main diagonal, elsewhere anthills.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Grid"></a>`Grid *= py_monitoring_gui.CustomData_Type.Grid*`
-- <a id="py_monitoring_gui.Visuals.Histogram"></a>`*class* Histogram`
-- <a id="py_monitoring_gui.Visuals.Histogram.ListenToDimensionIndex"></a>`ListenToDimensionIndex(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Histogram.SetAlpha"></a>`SetAlpha(alpha_value: float)`<br>
-  Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
-- <a id="py_monitoring_gui.Visuals.Histogram.SetChi2"></a>`SetChi2(chi_flag: bool)`<br>
-  Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
-- <a id="py_monitoring_gui.Visuals.Histogram.SetDimension"></a>`SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Histogram.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Histogram.get_actual_dimension"></a>`get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the actual visible dimension.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_statistical_data"></a>`get_statistical_data() → list`<br>
-  Get statistical data as list of lists.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Histogram.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Histogram.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Histogram.set_alpha"></a>`set_alpha(alpha_value: float)`<br>
-  Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
-- <a id="py_monitoring_gui.Visuals.Histogram.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_chi_2"></a>`set_chi_2(chi_flag: bool)`<br>
-  Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
-- <a id="py_monitoring_gui.Visuals.Histogram.set_fit_type"></a>`set_fit_type(fit_type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))`<br>
-  Set a random variable type for the fit.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_fit_type_to_automatic"></a>`set_fit_type_to_automatic()`<br>
-  Set fit to automatic.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_fit_type_to_none"></a>`set_fit_type_to_none()`<br>
-  Set fit to none.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_fit_types_for_automatic"></a>`set_fit_types_for_automatic(rv_type: [RandomVariableTypeVec](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableTypeVec))`<br>
-  Set a vector of random variable types to be used for automatic fit.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_histogram_classes"></a>`set_histogram_classes(classes: int)`<br>
-  Set the number of histogram classes.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Histogram.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Histogram.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_probability_value"></a>`set_probability_value(probability_value: float)`<br>
-  Set probability value.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_sigma_level"></a>`set_sigma_level(sigma_level: float)`<br>
-  Set sigma level for pdf.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Histogram.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Histogram.show_as_cdf"></a>`show_as_cdf(show_as_cdf: bool)`<br>
-  Show histogram bars, defined pdf and fitted pdf as cdf.
-- <a id="py_monitoring_gui.Visuals.Histogram.show_defined_pdf"></a>`show_defined_pdf(show_defined_pdf: bool)`<br>
-  Show defined pdf.
-- <a id="py_monitoring_gui.Visuals.Histogram.show_limits"></a>`show_limits(sigma_level: bool)`<br>
-  Show limits.
-- <a id="py_monitoring_gui.Visuals.Histogram.show_probability"></a>`show_probability(show_probability: bool)`<br>
-  Show probability.
-- <a id="py_monitoring_gui.Visuals.Histogram.show_process_capability"></a>`show_process_capability(show_process_capability: bool)`<br>
-  Show process capability.
-- <a id="py_monitoring_gui.Visuals.Histogram.unset_fit_types_for_automatic"></a>`unset_fit_types_for_automatic()`<br>
-  Unset the vector of random variable types to standard.
-- <a id="py_monitoring_gui.Visuals.Histogram.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.History"></a>`*class* History`
-- <a id="py_monitoring_gui.Visuals.History.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.History.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.History.get_actual_dimension"></a>`get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the actual visible dimension.
-- <a id="py_monitoring_gui.Visuals.History.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.History.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.History.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.History.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.History.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.History.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.History.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.History.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.History.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.History.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.History.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.History.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.History.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.History.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.History.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.History.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.History.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.History.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.History.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.History.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.History.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.History.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.History.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.History.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.HorizontalBars"></a>`HorizontalBars *= py_monitoring_gui.CustomData_Type.HorizontalBars*`
-- <a id="py_monitoring_gui.Visuals.HorizontalBox"></a>`HorizontalBox *= py_monitoring_gui.CustomData_Type.HorizontalBox*`
-- <a id="py_monitoring_gui.Visuals.Lines"></a>`Lines *= py_monitoring_gui.CustomData_Type.Lines*`
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot"></a>`*class* New_ParallelCoordinatesPlot`
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.export"></a>`export(file_path: Path)`<br>
-  [0] Export the visual as picture, with given relative scale to file position given as path. : If scale is left empty, 1.0 is used. Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100]. [1] Export the visual as picture, with given absolute sizes to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100].
-- `export(file_path: Path, width: int, height: int)`
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory"></a>`*class* OptimizationHistory`
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_active_layer_names"></a>`get_active_layer_names() → list`<br>
-  Get actual active layer names.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_available_layer_names"></a>`get_available_layer_names() → list`<br>
-  Get all possible layer names.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_all_layers_active_state"></a>`set_all_layers_active_state(arg2: bool)`<br>
-  Set active state of all layers.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_layer_active_state"></a>`set_layer_active_state(arg2: str, arg3: bool)`<br>
-  Set active state of layer with given layer name.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_layers_active_state"></a>`set_layers_active_state(arg2: list, arg3: bool)`<br>
-  Set active state of layers with given layer names.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.OptimizationHistory.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.PCAData"></a>`*class* PCAData`
-- <a id="py_monitoring_gui.Visuals.PCAData.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.PCAData.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.PCAData.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.PCAData.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.PCAData.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.PCAData.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.PCAData.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.PCAData.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.PCAData.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot"></a>`*class* ParallelCoordinatesPlot`
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.export"></a>`export(file_path: Path)`<br>
-  [0] Export the visual as picture, with given relative scale to file position given as path. : If scale is left empty, 1.0 is used. Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100]. [1] Export the visual as picture, with given absolute sizes to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100].
-- `export(file_path: Path, width: int, height: int)`
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ParameterValues"></a>`*class* ParameterValues`
-- <a id="py_monitoring_gui.Visuals.ParameterValues.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ParameterValues.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Parametrization"></a>`*class* Parametrization`
-- <a id="py_monitoring_gui.Visuals.Parametrization.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Parametrization.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Parametrization.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Pareto2D"></a>`*class* Pareto2D`
-- <a id="py_monitoring_gui.Visuals.Pareto2D.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto2D.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Pareto3D"></a>`*class* Pareto3D`
-- <a id="py_monitoring_gui.Visuals.Pareto3D.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.get_z_axis_label"></a>`get_z_axis_label() → str`<br>
-  Get the z axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_alpha"></a>`set_alpha(alpha_angle: float)`<br>
-  Set the first angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_beta"></a>`set_beta(beta_angle: float)`<br>
-  Set the second angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_gamma"></a>`set_gamma(gamma_angle: float)`<br>
-  Set the third angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_lighting_enabled"></a>`set_lighting_enabled(enabled: bool)`<br>
-  Set lighting enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_log_z_axis"></a>`set_log_z_axis(enabled: bool)`<br>
-  Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis"></a>`set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis_format"></a>`set_z_axis_format(z_axis_format: str)`<br>
-  Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis_label"></a>`set_z_axis_label(label_z: str)`<br>
-  Set the z axis label.
-- <a id="py_monitoring_gui.Visuals.Pareto3D.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.PathBase"></a>`*class* PathBase`
-- <a id="py_monitoring_gui.Visuals.PathBase.SetPath"></a>`SetPath(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Set the path to the image/process executable.
-- <a id="py_monitoring_gui.Visuals.PathBase.SetPathFixed"></a>`SetPathFixed(arg2: bool)`<br>
-  Set the path to the image/process executable. Contained placeholders will not be resolved.
-- <a id="py_monitoring_gui.Visuals.PathBase.__init__"></a>`__init__()`
-- `__init__(arg2: [PathBasedVisualTypes](#py_monitoring_gui.PathBasedVisualTypes), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [PathBasedVisualTypes](#py_monitoring_gui.PathBasedVisualTypes), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg4: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.PathBase.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.PathBase.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.PathBase.set_arguments"></a>`set_arguments(arg2: str)`<br>
-  Set the argument string, used by a process.
-- <a id="py_monitoring_gui.Visuals.PathBase.set_auto_insert_placeholders"></a>`set_auto_insert_placeholders(arg2: bool)`<br>
-  If placeholders (e.g. $DESIGN_DIR) should be inserted automatically.
-- <a id="py_monitoring_gui.Visuals.PathBase.set_path"></a>`set_path(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Set the path to the image/process executable.
-- <a id="py_monitoring_gui.Visuals.PathBase.set_path_fixed"></a>`set_path_fixed(arg2: bool)`<br>
-  Set the path to the image/process executable. Contained placeholders will not be resolved.
-- <a id="py_monitoring_gui.Visuals.Points"></a>`Points *= py_monitoring_gui.CustomData_Type.Points*`
-- <a id="py_monitoring_gui.Visuals.Probability"></a>`*class* Probability`
-- <a id="py_monitoring_gui.Visuals.Probability.ListenToDimensionIndex"></a>`ListenToDimensionIndex(arg2: int)`<br>
-  deprecated - use set_dimension_id_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.Probability.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Probability.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Probability.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Probability.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Probability.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Probability.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Probability.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Probability.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Probability.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Probability.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Probability.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Probability.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Probability.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Probability.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Probability.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Probability.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Probability.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Probability.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Probability.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo"></a>`*class* ReliAlgoInfo`
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.export"></a>`export(file_path: Path)`<br>
-  Export the visual as picture to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100].
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.export_data"></a>`export_data(file_path: Path)`<br>
-  Export the visual as ascii with given format_string to file position given as path. : If format_string is left empty, “%g” is used.
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ReliAlgoInfo.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill"></a>`*class* ReliAnthill`
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.show_designs_in_standard_gauss"></a>`show_designs_in_standard_gauss(arg2: bool)`<br>
-  Toggle view of designs to standard gauss. : Does not have an effect when original distribution is already standard gauss.
-- <a id="py_monitoring_gui.Visuals.ReliAnthill.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ReliCloud"></a>`*class* ReliCloud`
-- <a id="py_monitoring_gui.Visuals.ReliCloud.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.SetZAxis"></a>`SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.get_z_axis_label"></a>`get_z_axis_label() → str`<br>
-  Get the z axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_alpha"></a>`set_alpha(alpha_angle: float)`<br>
-  Set the first angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_beta"></a>`set_beta(beta_angle: float)`<br>
-  Set the second angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_gamma"></a>`set_gamma(gamma_angle: float)`<br>
-  Set the third angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_lighting_enabled"></a>`set_lighting_enabled(enabled: bool)`<br>
-  Set lighting enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_log_z_axis"></a>`set_log_z_axis(enabled: bool)`<br>
-  Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis"></a>`set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis_format"></a>`set_z_axis_format(z_axis_format: str)`<br>
-  Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis_label"></a>`set_z_axis_label(label_z: str)`<br>
-  Set the z axis label.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.show_designs_in_standard_gauss"></a>`show_designs_in_standard_gauss(arg2: bool)`<br>
-  Toggle view of designs to standard gauss. : Does not have an effect when original distribution is already standard gauss.
-- <a id="py_monitoring_gui.Visuals.ReliCloud.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory"></a>`*class* ReliFailureHistory`
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_active_layer_names"></a>`get_active_layer_names() → list`<br>
-  Get actual active layer names.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_available_layer_names"></a>`get_available_layer_names() → list`<br>
-  Get all possible layer names.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_all_layers_active_state"></a>`set_all_layers_active_state(arg2: bool)`<br>
-  Set active state of all layers.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_layer_active_state"></a>`set_layer_active_state(arg2: str, arg3: bool)`<br>
-  Set active state of layer with given layer name.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_layers_active_state"></a>`set_layers_active_state(arg2: list, arg3: bool)`<br>
-  Set active state of layers with given layer names.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliFailureHistory.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance"></a>`*class* ReliInputImportance`
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ReliInputImportance.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.Residual"></a>`*class* Residual`
-- <a id="py_monitoring_gui.Visuals.Residual.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.Residual.get_actual_dimension"></a>`get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)`<br>
-  Return the actual visible dimension.
-- <a id="py_monitoring_gui.Visuals.Residual.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.Residual.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.Residual.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.Residual.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.Residual.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.Residual.get_statistical_data"></a>`get_statistical_data() → list`<br>
-  Get statistical data as list of lists.
-- <a id="py_monitoring_gui.Visuals.Residual.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.Residual.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.Residual.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.Residual.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.Residual.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.Residual.set_error_relative"></a>`set_error_relative(error_relative: bool)`<br>
-  When show_errors or show_absolute_errors is set, toggle view to show errors relative to range.
-- <a id="py_monitoring_gui.Visuals.Residual.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.Residual.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Residual.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.Residual.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.Residual.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.Residual.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.Residual.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.Residual.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Residual.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.Residual.set_sigma_level"></a>`set_sigma_level(sigma: float)`<br>
-  Set the sigma level, which determines the distance the red sigma_lines have, to the black diagonal. : Distance is equal sigma_value times sigma_level.
-- <a id="py_monitoring_gui.Visuals.Residual.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.Residual.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.Residual.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.Residual.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.Residual.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.Residual.show_absolute_errors"></a>`show_absolute_errors()`<br>
-  Show values in visual as absolute error of dimension_cv_value vs dimension_value over dimension_value.
-- <a id="py_monitoring_gui.Visuals.Residual.show_errors"></a>`show_errors()`<br>
-  Show values in visual as error of dimension_cv vs dimension_value over dimension_value.
-- <a id="py_monitoring_gui.Visuals.Residual.show_maximum_error"></a>`show_maximum_error(arg2: bool)`<br>
-  Show an arrow pointing to the maximum error. : Only visible when show_errors or show_absolute_errors is set.
-- <a id="py_monitoring_gui.Visuals.Residual.show_sample_cops"></a>`show_sample_cops()`<br>
-  Show values in visual as SampleCoPs over dimension_value.
-- <a id="py_monitoring_gui.Visuals.Residual.show_values"></a>`show_values()`<br>
-  Show values in visual as dimension_cv_value over dimension_value.
-- <a id="py_monitoring_gui.Visuals.Residual.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D"></a>`*class* ResponseSurface2D`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_resolution"></a>`set_resolution(resolution: int)`<br>
-  Sets the resolution with which the response surface line is been plotted.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_show_additional_points"></a>`set_show_additional_points(show_additional_data: bool)`<br>
-  Show additional data points or not.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface2D.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D"></a>`*class* ResponseSurface3D`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetZAxis"></a>`SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_z_axis_label"></a>`get_z_axis_label() → str`<br>
-  Get the z axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_alpha"></a>`set_alpha(alpha_angle: float)`<br>
-  Set the first angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_beta"></a>`set_beta(beta_angle: float)`<br>
-  Set the second angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_gamma"></a>`set_gamma(gamma_angle: float)`<br>
-  Set the third angle for an rotation based on Euler angles z-x’-z’’.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_iso_line_heights"></a>`set_iso_line_heights(iso_lines_string: str)`<br>
-  [0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ . [1] Set the iso_lines given as python list.
-- `set_iso_line_heights(iso_lines: list)`
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_lighting_enabled"></a>`set_lighting_enabled(enabled: bool)`<br>
-  Set lighting enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_z_axis"></a>`set_log_z_axis(enabled: bool)`<br>
-  Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_data"></a>`set_palette_data(palette_data: [ResponseSurfacePaletteData](#py_monitoring_gui.ResponseSurfacePaletteData))`<br>
-  Set the palette_data so that response surface show certain specific values.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_resolution"></a>`set_resolution(resolution: int)`<br>
-  Set the resolution with which the response surface is been plotted.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_show_additional_points"></a>`set_show_additional_points(show_additional_data: bool)`<br>
-  Show additional data points or not.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis"></a>`set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis_format"></a>`set_z_axis_format(z_axis_format: str)`<br>
-  Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis_label"></a>`set_z_axis_label(label_z: str)`<br>
-  Set the z axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurface3D.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV"></a>`*class* ResponseSurfaceTV`
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetAbscissa"></a>`SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetDimensions"></a>`SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetOrdinate"></a>`SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetZAxis"></a>`SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_actual_dimensions"></a>`get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)`<br>
-  Return the actual visible dimensions as vector.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_abscissa"></a>`set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(0, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_dimensions"></a>`set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the dimensions to be shown in visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_iso_line_heights"></a>`set_iso_line_heights(iso_lines_string: str)`<br>
-  [0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ . [1] Set the iso_lines given as python list.
-- `set_iso_line_heights(iso_lines: list)`
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ordinate"></a>`set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(1, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_data"></a>`set_palette_data(palette_data: [ResponseSurfacePaletteData](#py_monitoring_gui.ResponseSurfacePaletteData))`<br>
-  Set the palette_data so that response surface show certain specific values.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_resolution"></a>`set_resolution(resolution: int)`<br>
-  Set the resolution with which the response surface is been plotted.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_show_additional_points"></a>`set_show_additional_points(show_additional_data: bool)`<br>
-  Show additional data points or not.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_z_axis"></a>`set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  deprecated - use set_dimension_at_index(2, … ) instead.
-- <a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.ResponseValues"></a>`*class* ResponseValues`
-- <a id="py_monitoring_gui.Visuals.ResponseValues.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.ResponseValues.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.SignalDesignList"></a>`*class* SignalDesignList`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.IdExportList"></a>`IdExportList() → [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList)`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.__init__"></a>`__init__()`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.__iter__"></a>`__iter__() → object`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.id_export_list"></a>`id_export_list() → [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList)`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.push_back"></a>`push_back(arg2: [HID](id.md#id.HID))`
-- <a id="py_monitoring_gui.Visuals.SignalDesignList.size"></a>`size() → int`
-- <a id="py_monitoring_gui.Visuals.SignalLayer"></a>`*class* SignalLayer`
-- <a id="py_monitoring_gui.Visuals.SignalLayer.SetChannel"></a>`SetChannel(channel: int)`<br>
-  Set the channel index.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.SetIds"></a>`SetIds(ids: [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList))`<br>
-  Set the ids.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.SetLayer"></a>`SetLayer(layer_name: str)`<br>
-  Set the layer name.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.SetSignal"></a>`SetSignal(signal: str)`<br>
-  Set the signal dimension.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.SetStyle"></a>`SetStyle(style: [Style](py_monitoring_kernel.md#py_monitoring_kernel.Style))`<br>
-  Set the style.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.__init__"></a>`__init__()`
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_channel"></a>`set_channel(channel: int)`<br>
-  Set the channel index.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_channel_name"></a>`set_channel_name(channel_name: str)`<br>
-  Set the channel name (sig_info).
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_data_name"></a>`set_data_name(data_name: str)`<br>
-  Set the data name (sig_info).
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_ids"></a>`set_ids(ids: [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList))`<br>
-  Set the ids.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_layer"></a>`set_layer(layer_name: str)`<br>
-  Set the layer name.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_number_of_data"></a>`set_number_of_data(number_of_data: int)`<br>
-  Set the number of lines to be shown (sig_info).
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_signal"></a>`set_signal(signal: str)`<br>
-  Set the signal dimension.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_style"></a>`set_style(style: [Style](py_monitoring_kernel.md#py_monitoring_kernel.Style))`<br>
-  Set the style.
-- <a id="py_monitoring_gui.Visuals.SignalLayer.set_take_all_ids"></a>`set_take_all_ids(take_all_ids: bool)`<br>
-  Take all possible design ids when True. Overrides set_ids.
-- <a id="py_monitoring_gui.Visuals.SignalPlot"></a>`*class* SignalPlot`
-- <a id="py_monitoring_gui.Visuals.SignalPlot.AddLayer"></a>`AddLayer(signal_layer: [SignalLayer](#py_monitoring_gui.Visuals.SignalLayer))`<br>
-  Add a layer of type SignalLayer. : In this layer one can set the signal-channel combination he wants, showing the designs wished with a certain style. Style is been applied to all designs, if wished otherwise more than one layer has to be added. Design style set in e.g. DesignTable is NOT applied to this layer.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.RemoveAllLayers"></a>`RemoveAllLayers()`<br>
-  Remove all layers, now showing “no valid data”. Every previous signal/reference setting is been resetted, to make a clean start possible.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.SetChannel"></a>`SetChannel(channel_index: int)`<br>
-  Set the channel index for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.SetReference"></a>`SetReference(reference: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the reference signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.SetReferenceChannel"></a>`SetReferenceChannel(reference_channel_index: int)`<br>
-  Set the reference channel index for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.SetReferenceDesign"></a>`SetReferenceDesign(reference_design_id: [HID](id.md#id.HID))`<br>
-  Set the reference design id. For reference signal only one design is shown.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.SetSignal"></a>`SetSignal(signal: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.SignalPlot.add_layer"></a>`add_layer(signal_layer: [SignalLayer](#py_monitoring_gui.Visuals.SignalLayer))`<br>
-  Add a layer of type SignalLayer. : In this layer one can set the signal-channel combination he wants, showing the designs wished with a certain style. Style is been applied to all designs, if wished otherwise more than one layer has to be added. Design style set in e.g. DesignTable is NOT applied to this layer.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.adjust_resolution"></a>`adjust_resolution(arg2: bool)`<br>
-  Modify signals to be shown with given resolution.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.SignalPlot.is_reference_of_type_signal_info"></a>`is_reference_of_type_signal_info() → bool`<br>
-  Get info about reference be signal info type.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.is_signal_of_type_signal_info"></a>`is_signal_of_type_signal_info() → bool`<br>
-  Get info about signal be signal info type.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.remove_all_layers"></a>`remove_all_layers()`<br>
-  Remove all layers, now showing “no valid data”. Every previous signal/reference setting is been resetted, to make a clean start possible.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_channel"></a>`set_channel(channel_index: int)`<br>
-  Set the channel index for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_channel_name"></a>`set_channel_name(channel_name: str)`<br>
-  Set the channel name for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_data_name"></a>`set_data_name(data_name: str)`<br>
-  Set the data name for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_interpolation_type"></a>`set_interpolation_type(arg2: int)`<br>
-  Set the interpolation type, for changed resolution to 1 = LINEAR, 2 = QUADRATIC, other values will be ignored.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_number_of_classes"></a>`set_number_of_classes(arg2: int)`<br>
-  Set the number of classes (parts in y direction) with which the contour plot is been shown.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_number_of_data"></a>`set_number_of_data(number_of_data: int)`<br>
-  Set the maximum number of lines for signal_info view.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference"></a>`set_reference(reference: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the reference signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_channel"></a>`set_reference_channel(reference_channel_index: int)`<br>
-  Set the reference channel index for signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_channel_name"></a>`set_reference_channel_name(channel_name: str)`<br>
-  Set the channel name for reference.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_data_name"></a>`set_reference_data_name(data_name: str)`<br>
-  Set the data name for reference.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_design"></a>`set_reference_design(reference_design_id: [HID](id.md#id.HID))`<br>
-  Set the reference design id. For reference signal only one design is shown.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_number_of_data"></a>`set_reference_number_of_data(number_of_data: int)`<br>
-  Set the maximum number of lines for reference signal_info view.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_resolution"></a>`set_resolution(arg2: int)`<br>
-  Set the resolution with which the signals are shown, when adjust_resolution is set to True. Minimum 2.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_sigma_factor"></a>`set_sigma_factor(arg2: float)`<br>
-  Set the factor with which standard deviation is shown. Change plot only when statistical data is shown.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_signal"></a>`set_signal(signal: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))`<br>
-  Set the signal.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_x_axis_format"></a>`set_x_axis_format(x_axis_format: str)`<br>
-  Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.show_as_contour_plot"></a>`show_as_contour_plot(arg2: bool)`<br>
-  Show signal data as contour plot with given number of classes.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.show_statistical_values"></a>`show_statistical_values(arg2: bool)`<br>
-  Show additional to signal, mean and standard deviation for signals with more than one line.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.SignalPlot.use_textures"></a>`use_textures(toggle_texture_usage: bool)`<br>
-  Modify the plot to show textures or not. : Does only afllict plots with many points. Setting is to be meant as possibility to deactivate texture usage on certain (graphic) systems, where showing as texture leads to graphical problems. Not showing as texture means in most cases a reduce in performance.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot"></a>`*class* SpiderPlot`
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.export"></a>`export(file_path: Path)`<br>
-  [0] Export the visual as picture, with given relative scale to file position given as path. : If scale is left empty, 1.0 is used. Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100]. [1] Export the visual as picture, with given absolute sizes to file position given as path. : Transparency produces plot with transparent background which is available when having picture types supporting this, like png. Quality is available for jpg, determining the quality of the output in percent [0:100].
-- `export(file_path: Path, width: int, height: int)`
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.set_font_size"></a>`set_font_size(arg2: int)`<br>
-  Set the font size at the visual.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.SpiderPlot.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.StackedBars"></a>`StackedBars *= py_monitoring_gui.CustomData_Type.StackedBars*`
-- <a id="py_monitoring_gui.Visuals.StackedHorizontalBars"></a>`StackedHorizontalBars *= py_monitoring_gui.CustomData_Type.StackedHorizontalBars*`
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis"></a>`*class* StatisticAnalysis`
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_probability_content"></a>`set_box_probability_content(box_probability_content: float)`<br>
-  Set the probability content for the box. Box goes from median-content\*0.5 to median+content\*0.5.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_sigma_factor"></a>`set_box_sigma_factor(box_sigma_factor: float)`<br>
-  Set the sigma factor for the box. Box goes from mean-factor to mean+factor.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_type"></a>`set_box_type(box_type: [StatisticAnalysisBoxType](#py_monitoring_gui.StatisticAnalysisBoxType))`<br>
-  Set the box type.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_group"></a>`set_group(group_name: str)`<br>
-  Set the group to be shown
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_limit_type"></a>`set_limit_type(limit_type: [StatisticAnalysisLimitsType](#py_monitoring_gui.StatisticAnalysisLimitsType))`<br>
-  Set the limit type.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_scaling_type"></a>`set_scaling_type(scaling_type: [StatisticAnalysisScalingType](#py_monitoring_gui.StatisticAnalysisScalingType))`<br>
-  Set the scaling type.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_separate_box_and_whisker"></a>`set_separate_box_and_whisker(separate: bool)`<br>
-  Show Box and Whisker on two layers.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_show_samples"></a>`set_show_samples(show_samples: bool)`<br>
-  Show sample points.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_probability_content"></a>`set_whisker_probability_content(whisker_probability_content: float)`<br>
-  Set the probability content for the whisker. Whisker goes from median-content\*0.5 to median+content\*0.5.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_sigma_factor"></a>`set_whisker_sigma_factor(whisker_sigma_factor: float)`<br>
-  Set the sigma factor for the whisker. Whisker goes from mean-factor to mean+factor.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_type"></a>`set_whisker_type(whisker_type: [StatisticAnalysisWhiskerType](#py_monitoring_gui.StatisticAnalysisWhiskerType))`<br>
-  Set the whisker type.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.StatisticAnalysis.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.StatisticValues"></a>`*class* StatisticValues`
-- <a id="py_monitoring_gui.Visuals.StatisticValues.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.StatisticValues.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.StatisticValues.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot"></a>`*class* TrafficLightPlot`
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.HideResponses"></a>`HideResponses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))`<br>
-  Hide given dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.SetResponseVisible"></a>`SetResponseVisible(dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), visible: bool)`<br>
-  Toggle the visibility of one single dimension.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.SetSigmaFactor"></a>`SetSigmaFactor(sigma: float)`<br>
-  Change the sigma value used for statistical_values and for whole plot when values_sigma_based is chosen.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowAllResponses"></a>`ShowAllResponses()`<br>
-  Show all dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowResponses"></a>`ShowResponses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))`<br>
-  Show given dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowStatisticValues"></a>`ShowStatisticValues(visible: bool)`<br>
-  Toggle visibility of statistical values, shown as additional box_plot on top of the bars.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.has_legend"></a>`has_legend() → bool`
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.hide_responses"></a>`hide_responses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))`<br>
-  Hide given dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_enabled"></a>`set_axes_rotation_enabled(enable: bool)`<br>
-  Set axes rotation enabled.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_orthogonal"></a>`set_axes_rotation_orthogonal(enable: bool)`<br>
-  Set rotation angles to 0 degree if enough space for text exist, else to 90.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_x_angle"></a>`set_axes_rotation_x_angle(angle: float)`<br>
-  Set the rotation angle for x-axis.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_font_size"></a>`set_legend_font_size(font_size: int)`<br>
-  Set the font_size used in legend.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_position"></a>`set_legend_position(x_position: float, y_position: float)`<br>
-  Set the position of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_size"></a>`set_legend_size(width: float, height: float)`<br>
-  Set the size of the legend, using absolute or relative coordinates. : (Internally stored as relative.)
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_visible"></a>`set_legend_visible(enabled: bool)`<br>
-  Set legend visibilty to True or False.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_response_visible"></a>`set_response_visible(dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), visible: bool)`<br>
-  Toggle the visibility of one single dimension.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_sigma_factor"></a>`set_sigma_factor(sigma: float)`<br>
-  Change the sigma value used for statistical_values and for whole plot when values_sigma_based is chosen.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_y_axis_format"></a>`set_y_axis_format(y_axis_format: str)`<br>
-  Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_all_responses"></a>`show_all_responses()`<br>
-  Show all dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_responses"></a>`show_responses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))`<br>
-  Show given dimensions.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_statistical_values"></a>`show_statistical_values(visible: bool)`<br>
-  Toggle visibility of statistical values, shown as additional box_plot on top of the bars.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_values_sigma_based"></a>`show_values_sigma_based(toggle: bool)`<br>
-  Toggle the values view, base on mean and sigma vs. original values.
-- <a id="py_monitoring_gui.Visuals.TrafficLightPlot.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.VectorElements"></a>`*class* VectorElements`
-- <a id="py_monitoring_gui.Visuals.VectorElements.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.VectorElements.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.VectorElements.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.VectorElements.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.WebViewer"></a>`*class* WebViewer`
-- <a id="py_monitoring_gui.Visuals.WebViewer.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.WebViewer.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.WebViewer.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.WebViewer.set_source"></a>`set_source(path: str)`<br>
-  [0] Set path to html file to be viewed [1] Set path to html file to be viewed
-- `set_source(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="py_monitoring_gui.Visuals.WebViewer.set_source_data"></a>`set_source_data(content: str)`<br>
-  Set content of html to be viewed
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues"></a>`*class* WeightedPCValues`
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.__init__"></a>`__init__()`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- `__init__(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_caption"></a>`get_caption() → str`<br>
-  Get the caption.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_data"></a>`get_data(layer_name: str) → list`<br>
-  Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_display_name"></a>`*static* get_display_name() → str`<br>
-  Get a descriptive title for this visual type.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_group_name"></a>`*static* get_group_name() → str`<br>
-  Get the name of the containing group.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_header_data"></a>`get_header_data(layer_name: str, horizontal: bool) → list`<br>
-  Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_palette_preset_names"></a>`get_palette_preset_names() → list`<br>
-  Get a list of available palette preset names.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_x_axis_label"></a>`get_x_axis_label() → str`<br>
-  Get the x axis label.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.get_y_axis_label"></a>`get_y_axis_label() → str`<br>
-  Get the y axis label.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_limits"></a>`reset_palette_limits()`<br>
-  ReSet the minimum and maximum values of palette to default.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_maximum"></a>`reset_palette_maximum()`<br>
-  Reset the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_minimum"></a>`reset_palette_minimum()`<br>
-  Reset the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_axes_enabled"></a>`set_axes_enabled(enabled: bool)`<br>
-  Set axes enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_caption"></a>`set_caption(caption: str)`<br>
-  Set the caption.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_line_width"></a>`set_line_width(line_width: float)`<br>
-  Set the line width at the visual.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_lines_enabled"></a>`set_lines_enabled(enabled: bool)`<br>
-  Set lines enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_log_x_axis"></a>`set_log_x_axis(enabled: bool)`<br>
-  Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_log_y_axis"></a>`set_log_y_axis(enabled: bool)`<br>
-  Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_limits"></a>`set_palette_limits(minimum: float, maximum: float)`<br>
-  Set the minimum and maximum values of palette.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_maximum"></a>`set_palette_maximum(maximum: float)`<br>
-  Set the maximum value of palette.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_minimum"></a>`set_palette_minimum(minimum: float)`<br>
-  Set the minimum value of palette.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_position"></a>`set_palette_position(x_position: float, y_position: float)`<br>
-  Set the position of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_preset"></a>`set_palette_preset(name: str)`<br>
-  Set palette preset with given name.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_size"></a>`set_palette_size(x_position: float, y_position: float)`<br>
-  Set the size of the palette, using absolute or relative[%] coordinates. : (Internally stored as relative[%].)
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_visible"></a>`set_palette_visible(enabled: bool)`<br>
-  Set palette visibility to True or False.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_ranges_x"></a>`set_ranges_x(minimum: float, maximum: float)`<br>
-  Set the ranges to x-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_ranges_y"></a>`set_ranges_y(minimum: float, maximum: float)`<br>
-  Set the ranges to y-axis, Two inputs : minimum and maximum.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_surfaces_enabled"></a>`set_surfaces_enabled(enabled: bool)`<br>
-  Set surfaces enabled state to True or False.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_symbol_size"></a>`set_symbol_size(symbol_size: float)`<br>
-  Set the symbol size at the visual.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_x_axis_label"></a>`set_x_axis_label(label_x: str)`<br>
-  Set the x axis label.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.set_y_axis_label"></a>`set_y_axis_label(label_y: str)`<br>
-  Set the y axis label.
-- <a id="py_monitoring_gui.Visuals.WeightedPCValues.update_plot"></a>`update_plot()`<br>
-  Trigger an additional update on visual.
-- <a id="py_monitoring_gui.Visuals.__init__"></a>`__init__()`
+<a id="py_monitoring_gui.Visuals.Anthill"></a>
+
+#### *class* Anthill
+
+<a id="py_monitoring_gui.Visuals.Anthill.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Anthill.SetDimensionForColor"></a>
+
+#### SetDimensionForColor(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as color.
+
+<a id="py_monitoring_gui.Visuals.Anthill.SetDimensionForSize"></a>
+
+#### SetDimensionForSize(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as symbol_size.
+
+<a id="py_monitoring_gui.Visuals.Anthill.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Anthill.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Anthill.UnsetDimensionForColor"></a>
+
+#### UnsetDimensionForColor()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Anthill.UnsetDimensionForSize"></a>
+
+#### UnsetDimensionForSize()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Anthill.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_regression_coefficients"></a>
+
+#### get_regression_coefficients() → list
+
+Return the coefficients of a chosen Regression as list. 
+: Dependent to chosen Regression type linear or quadratic, the list is 2 or 3 entries long. 
+  For a + b\*x you get [a,b], for a + b\*x + c\*x\*x yout get [a,b,c]. 
+  In case of non valid regression you get an empty list.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Anthill.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Anthill.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Anthill.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.Anthill.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Anthill.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_dimension_for_color"></a>
+
+#### set_dimension_for_color(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as color.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_dimension_for_size"></a>
+
+#### set_dimension_for_size(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as symbol_size.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_regression"></a>
+
+#### set_regression(arg2: [RegressionType](#py_monitoring_gui.RegressionType))
+
+Set regression
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Anthill.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Anthill.unset_dimension_for_color"></a>
+
+#### unset_dimension_for_color()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Anthill.unset_dimension_for_size"></a>
+
+#### unset_dimension_for_size()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Anthill.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ApproxDesignTable"></a>
+
+#### *class* ApproxDesignTable
+
+<a id="py_monitoring_gui.Visuals.ApproxDesignTable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ApproxDesignTable.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ApproxDesignTable.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo"></a>
+
+#### *class* ApproxModelInfo
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.export"></a>
+
+#### export(file_path: Path)
+
+Export the visual as picture to file position given as path. 
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.export_data"></a>
+
+#### export_data(file_path: Path)
+
+Export the visual as ascii with given format_string to file position given as path. 
+: If format_string is left empty, “%g” is used.
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ApproxModelInfo.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory"></a>
+
+#### *class* ApproximationHistory
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_mode"></a>
+
+#### set_mode(arg2: [ApproximationHistoryMode](#py_monitoring_gui.ApproximationHistoryMode))
+
+Toggle the view between responses and criteria
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_show_all_results"></a>
+
+#### set_show_all_results(arg2: bool)
+
+Set true to show all results
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_show_minimal_local_cop_values"></a>
+
+#### set_show_minimal_local_cop_values(arg2: bool)
+
+Set true to additionally show minimum local cop values
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ApproximationHistory.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Bars"></a>
+
+#### Bars *= py_monitoring_gui.CustomData_Type.Bars*
+
+<a id="py_monitoring_gui.Visuals.Box"></a>
+
+#### Box *= py_monitoring_gui.CustomData_Type.Box*
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker"></a>
+
+#### *class* BoxWhisker
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_box_probability_content"></a>
+
+#### set_box_probability_content(box_probability_content: float)
+
+Set the probability content for the box. Box goes from median-content\*0.5 to median+content\*0.5.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_group"></a>
+
+#### set_group(group_name: str)
+
+Set the group to be shown
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_scale"></a>
+
+#### set_scale(scale: bool)
+
+Scale to min/max.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_box"></a>
+
+#### set_show_box(show: bool)
+
+Show box.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_limits"></a>
+
+#### set_show_limits(show: bool)
+
+Show limits.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_samples"></a>
+
+#### set_show_samples(show_samples: bool)
+
+Show sample points.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_show_whisker"></a>
+
+#### set_show_whisker(show: bool)
+
+Show whisker.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_whisker_probability_content"></a>
+
+#### set_whisker_probability_content(whisker_probability_content: float)
+
+Set the probability content for the whisker. Whisker goes from median-content\*0.5 to median+content\*0.5.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.BoxWhisker.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Cloud"></a>
+
+#### *class* Cloud
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetDimensionForColor"></a>
+
+#### SetDimensionForColor(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as color.
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetDimensionForSize"></a>
+
+#### SetDimensionForSize(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as symbol_size.
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.SetZAxis"></a>
+
+#### SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.UnsetDimensionForColor"></a>
+
+#### UnsetDimensionForColor()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Cloud.UnsetDimensionForSize"></a>
+
+#### UnsetDimensionForSize()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Cloud.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.get_z_axis_label"></a>
+
+#### get_z_axis_label() → str
+
+Get the z axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Cloud.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.Cloud.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Cloud.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_alpha"></a>
+
+#### set_alpha(alpha_angle: float)
+
+Set the first angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_beta"></a>
+
+#### set_beta(beta_angle: float)
+
+Set the second angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_dimension_for_color"></a>
+
+#### set_dimension_for_color(color: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as color.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_dimension_for_size"></a>
+
+#### set_dimension_for_size(size: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the additional dimension to be shown as symbol_size.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_gamma"></a>
+
+#### set_gamma(gamma_angle: float)
+
+Set the third angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_lighting_enabled"></a>
+
+#### set_lighting_enabled(enabled: bool)
+
+Set lighting enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_log_z_axis"></a>
+
+#### set_log_z_axis(enabled: bool)
+
+Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_regression"></a>
+
+#### set_regression(arg2: [RegressionType](#py_monitoring_gui.RegressionType))
+
+Set regression
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_z_axis"></a>
+
+#### set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_z_axis_format"></a>
+
+#### set_z_axis_format(z_axis_format: str)
+
+Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
+
+<a id="py_monitoring_gui.Visuals.Cloud.set_z_axis_label"></a>
+
+#### set_z_axis_label(label_z: str)
+
+Set the z axis label.
+
+<a id="py_monitoring_gui.Visuals.Cloud.unset_dimension_for_color"></a>
+
+#### unset_dimension_for_color()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Cloud.unset_dimension_for_size"></a>
+
+#### unset_dimension_for_size()
+
+Unset the color dimension.
+
+<a id="py_monitoring_gui.Visuals.Cloud.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CoI"></a>
+
+#### *class* CoI
+
+<a id="py_monitoring_gui.Visuals.CoI.ListenToDimensionIndex"></a>
+
+#### ListenToDimensionIndex(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CoI.SetAdjusted"></a>
+
+#### SetAdjusted(adjust: bool)
+
+Toggle the view to show adjusted values.
+
+<a id="py_monitoring_gui.Visuals.CoI.SetDimension"></a>
+
+#### SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CoI.SetInverted"></a>
+
+#### SetInverted(invert: bool)
+
+Toggle the view to show ( value ) or ( CoD - value ).
+
+<a id="py_monitoring_gui.Visuals.CoI.SetType"></a>
+
+#### SetType(coi_type: [CoIVisualPolynomBasisTypes](#py_monitoring_gui.CoIVisualPolynomBasisTypes))
+
+Set the type of coi calculation, where CoIVisualPolynomBasisTypes. 
+: Automatic means that the best found model is used for calculation.
+
+<a id="py_monitoring_gui.Visuals.CoI.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CoI.get_actual_dimension"></a>
+
+#### get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the actual visible dimension.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoI.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoI.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CoI.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoI.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_adjusted"></a>
+
+#### set_adjusted(adjust: bool)
+
+Toggle the view to show adjusted values.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_inverted"></a>
+
+#### set_inverted(invert: bool)
+
+Toggle the view to show ( value ) or ( CoD - value ).
+
+<a id="py_monitoring_gui.Visuals.CoI.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoI.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_type"></a>
+
+#### set_type(coi_type: [CoIVisualPolynomBasisTypes](#py_monitoring_gui.CoIVisualPolynomBasisTypes))
+
+Set the type of coi calculation, where CoIVisualPolynomBasisTypes. 
+: Automatic means that the best found model is used for calculation.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoI.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoI.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CoP"></a>
+
+#### *class* CoP
+
+<a id="py_monitoring_gui.Visuals.CoP.ListenToDimensionIndex"></a>
+
+#### ListenToDimensionIndex(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CoP.SetDimension"></a>
+
+#### SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CoP.SetFiltered"></a>
+
+#### SetFiltered(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CoP.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CoP.get_actual_dimension"></a>
+
+#### get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the actual visible dimension.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoP.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoP.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CoP.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoP.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_filter_limit"></a>
+
+#### set_filter_limit(filter_value: float[%])
+
+Set the limit below which the single CoP values are filtered in percent.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_filtered"></a>
+
+#### set_filtered(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CoP.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoP.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_show_interactions"></a>
+
+#### set_show_interactions(show: bool)
+
+Toggle view to see “Main effect” and “Interaction “ values additional to “Total effect” values.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoP.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoP.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix"></a>
+
+#### *class* CoPMatrix
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_approximation_line_width_scale"></a>
+
+#### set_approximation_line_width_scale(line_width_scale: float)
+
+Set line width scale with which the approximation line is shown.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_enabled"></a>
+
+#### set_axes_rotation_enabled(enable: bool)
+
+Set axes rotation enabled.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_orthogonal"></a>
+
+#### set_axes_rotation_orthogonal(enable: bool)
+
+Set rotation angles to 0 degree if enough space for text exist, else to 90.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_x_angle"></a>
+
+#### set_axes_rotation_x_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_axes_rotation_y_angle"></a>
+
+#### set_axes_rotation_y_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_filter_limit"></a>
+
+#### set_filter_limit(filter_limit: float[%])
+
+Set the limit below which the values are filtered in percent.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_filter_total_limit"></a>
+
+#### set_filter_total_limit(total_filter_value: float[%])
+
+Set the limit below which the total CoP values ( ModelCoP’s ) are filtered in percent.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_indices_type"></a>
+
+#### set_indices_type(indices_type: [CoPMatrixIndicesType](#py_monitoring_gui.CoPMatrixIndicesType))
+
+Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_object_text_orientation"></a>
+
+#### set_object_text_orientation(orientation: [CoPMatrixObjectTextOrientation](#py_monitoring_gui.CoPMatrixObjectTextOrientation))
+
+Toggle to change orientation of object text on tiles 
+Automatic : horizontal if enough space, else vertical is tested 
+Horizontal : ever show text horizontal
+Vertical : ever show text vertical.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+[0] Set the minimum and maximum values of palette.
+
+[1] Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_resolution"></a>
+
+#### set_resolution(resolution: int)
+
+Set resolution of approximation line..
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_additional_points"></a>
+
+#### set_show_additional_points(show: bool)
+
+Show additional points in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_approximated_points"></a>
+
+#### set_show_approximated_points(show: bool)
+
+Show approximated points in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_approximation"></a>
+
+#### set_show_approximation(show: bool)
+
+Show approximation line in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_background_cop"></a>
+
+#### set_show_background_cop(show: bool)
+
+Show background color in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_calculated_response_value"></a>
+
+#### set_show_calculated_response_value(show: bool)
+
+Show calculated response value in last column.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_cop"></a>
+
+#### set_show_cop(show: bool)
+
+Show cop value in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_deactivated_support_points"></a>
+
+#### set_show_deactivated_support_points(show: bool)
+
+Show deactivated supports points in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_extended"></a>
+
+#### set_show_extended(show: bool)
+
+Show matrix in extended mode with response surface 2d plots in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_filtered"></a>
+
+#### set_show_filtered(show: bool)
+
+Show all cop values including these filtered by mop.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_grid"></a>
+
+#### set_show_grid(show: bool)
+
+Show grid in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_parameter_line"></a>
+
+#### set_show_parameter_line(show: bool)
+
+Show parameter line in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_round_corners"></a>
+
+#### set_show_round_corners(show: bool)
+
+Show tile with round corners or as squares.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_selection"></a>
+
+#### set_show_selection(show: bool)
+
+Show selection lines in grid plot.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_show_support_points"></a>
+
+#### set_show_support_points(show: bool)
+
+Show support points in tiles.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrix.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic"></a>
+
+#### *class* CoPMatrixClassic
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_enabled"></a>
+
+#### set_axes_rotation_enabled(enable: bool)
+
+Set axes rotation enabled.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_orthogonal"></a>
+
+#### set_axes_rotation_orthogonal(enable: bool)
+
+Set rotation angles to 0 degree if enough space for text exist, else to 90.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_x_angle"></a>
+
+#### set_axes_rotation_x_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_axes_rotation_y_angle"></a>
+
+#### set_axes_rotation_y_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_filter_limit"></a>
+
+#### set_filter_limit(filter_limit: float[%])
+
+Set the limit below which the values are filtered in percent.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_filter_total_limit"></a>
+
+#### set_filter_total_limit(total_filter_value: float[%])
+
+Set the limit below which the total CoP values ( ModelCoP’s ) are filtered in percent.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_indices_type"></a>
+
+#### set_indices_type(indices_type: [CoPMatrixClassicIndicesType](#py_monitoring_gui.CoPMatrixClassicIndicesType))
+
+Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_object_text_orientation"></a>
+
+#### set_object_text_orientation(orientation: [CoPMatrixClassicObjectTextOrientation](#py_monitoring_gui.CoPMatrixClassicObjectTextOrientation))
+
+Toggle to change orientation of object text on tiles 
+Automatic : horizontal if enough space, else vertical is tested 
+Horizontal : ever show text horizontal
+Vertical : ever show text vertical.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CoPMatrixClassic.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient"></a>
+
+#### *class* CorrelationCoefficient
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.ListenToDimensionIndex"></a>
+
+#### ListenToDimensionIndex(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.SetDimension"></a>
+
+#### SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CorrelationCoefficient.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues"></a>
+
+#### *class* CriteriaValues
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CriteriaValues.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Custom"></a>
+
+#### Custom *= py_monitoring_gui.CustomData_Type.Custom*
+
+<a id="py_monitoring_gui.Visuals.CustomData"></a>
+
+#### *class* CustomData
+
+<a id="py_monitoring_gui.Visuals.CustomData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.CustomData.add_data"></a>
+
+#### add_data(layer_name: str, data: PyOSDesignEntry, style_vector: StyleList, channel_names: WStrList, Vizualisation_type: CustomData_Type) → bool
+
+Add data as new layer to the Visual.
+
+<a id="py_monitoring_gui.Visuals.CustomData.add_eval_mesh"></a>
+
+#### add_eval_mesh(layer_name: str, x: doubleVec vector, y: doubleVec vector, color: doubleVec values) → bool
+
+Add data as new eval mesh layer to the Visual.
+
+<a id="py_monitoring_gui.Visuals.CustomData.add_grid"></a>
+
+#### add_grid(layer_name: str, data: PyOSDesignEntry) → bool
+
+Add data as new grid layer to the Visual.
+
+<a id="py_monitoring_gui.Visuals.CustomData.add_mesh"></a>
+
+#### add_mesh(layer_name: str, x: doubleVec vector, y: doubleVec vector, style_vector: StyleList) → bool
+
+Add data as new mesh layer to the Visual. 
+: If single_triangles=True, length of vectors has to be multiple size of 3 and equal. Produces single triangles. 
+  If single_triangles=False, then a colored stripe is been produced. Sizes has to be equal or greater equal than 3.
+
+<a id="py_monitoring_gui.Visuals.CustomData.clear_data"></a>
+
+#### clear_data()
+
+Remove all layers.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CustomData.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CustomData.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.CustomData.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.CustomData.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CustomData.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_alt_axis"></a>
+
+#### set_alt_axis(axis: int, \_labels: WStrList, ticks: doubleVec)
+
+Set an alternate axis to index (0 == x, 1== y, 2==z).
+: With labels as string_list, axes_ticks as vector, and an optional rotation_angle
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_axes_enabled"></a>
+
+#### set_axes_enabled(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_background_color"></a>
+
+#### set_background_color(arg2: float, arg3: float, arg4: float, arg5: float)
+
+Change the background color.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_bar_width"></a>
+
+#### set_bar_width(layer_name: str, bar_width: float)
+
+Set the width for StackedBar and Box (others will be ignored). 
+: Senseful ranges between 1.0 (no space between bars) and 0.0 (bar is only a thin line). 
+  When the value is greater than 1.0 bars overlap.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_box_show_mean_and_median"></a>
+
+#### set_box_show_mean_and_median(layer_name: str, show_mean: bool)
+
+Toggle visibility of ‘Mean’ point additional to ‘Median’ line, if enough data_points are given.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_box_show_whisker"></a>
+
+#### set_box_show_whisker(layer_name: str, show_whisker: bool)
+
+Toggle visibility of BoxPlot’s outer lines (whisker).
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_iso_line_heights"></a>
+
+#### set_iso_line_heights(layer_name: str, iso_lines_string: str)
+
+#### set_iso_line_heights(layer_name: str, iso_lines: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+[0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ . Does only have effect when showing eval_mesh in this layer.
+
+[1] Set the iso lines as vector for given layer. Does only have effect when showing eval_mesh in this layer.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_line_width"></a>
+
+#### set_line_width(arg2: float)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_lines_enabled"></a>
+
+#### set_lines_enabled(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_log_x_axis"></a>
+
+#### set_log_x_axis(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_log_y_axis"></a>
+
+#### set_log_y_axis(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_object_text"></a>
+
+#### set_object_text(arg2: str, arg3: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList), arg4: int, arg5: int)
+
+Set the object text (e.g. on bars), from given list, spread to matrix when column is greater than 1 (e.g. multibar).
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_caption"></a>
+
+#### set_palette_caption(layer_name: str, caption: str)
+
+Set the caption to the palette for given layer.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_palette_visible"></a>
+
+#### set_palette_visible(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_ranges_x"></a>
+
+#### set_ranges_x(arg2: float, arg3: float)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_ranges_y"></a>
+
+#### set_ranges_y(arg2: float, arg3: float)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_selection_color"></a>
+
+#### set_selection_color(arg2: str, arg3: int, arg4: int, arg5: int, arg6: int)
+
+Set the selection color.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_selection_text"></a>
+
+#### set_selection_text(arg2: str, arg3: [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList))
+
+Set the selection text (e.g. on points, shown when selected), from given list.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(arg2: bool)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_symbol_size"></a>
+
+#### set_symbol_size(arg2: float)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_x_axis_format"></a>
+
+#### set_x_axis_format(arg2: str)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_y_axis_format"></a>
+
+#### set_y_axis_format(arg2: str)
+
+<a id="py_monitoring_gui.Visuals.CustomData.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.CustomData.unset_alt_axis"></a>
+
+#### unset_alt_axis(arg2: int)
+
+Unset the alternate axis at index (0 == x, 1== y, 2==z) to default float axis
+
+<a id="py_monitoring_gui.Visuals.CustomData.unset_background_color"></a>
+
+#### unset_background_color()
+
+Reset background color to default [0.9,0.9,0.9,1.0].
+
+<a id="py_monitoring_gui.Visuals.CustomData.unset_object_text"></a>
+
+#### unset_object_text(arg2: str)
+
+Unset the object text.
+
+<a id="py_monitoring_gui.Visuals.CustomData.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type"></a>
+
+#### *class* CustomData_Type
+
+**Enumeration**
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Bars"></a>
+
+#### Bars *= py_monitoring_gui.CustomData_Type.Bars*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Box"></a>
+
+#### Box *= py_monitoring_gui.CustomData_Type.Box*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Custom"></a>
+
+#### Custom *= py_monitoring_gui.CustomData_Type.Custom*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Grid"></a>
+
+#### Grid *= py_monitoring_gui.CustomData_Type.Grid*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.HorizontalBars"></a>
+
+#### HorizontalBars *= py_monitoring_gui.CustomData_Type.HorizontalBars*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.HorizontalBox"></a>
+
+#### HorizontalBox *= py_monitoring_gui.CustomData_Type.HorizontalBox*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Lines"></a>
+
+#### Lines *= py_monitoring_gui.CustomData_Type.Lines*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.Points"></a>
+
+#### Points *= py_monitoring_gui.CustomData_Type.Points*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.StackedBars"></a>
+
+#### StackedBars *= py_monitoring_gui.CustomData_Type.StackedBars*
+
+<a id="py_monitoring_gui.Visuals.CustomData_Type.StackedHorizontalBars"></a>
+
+#### StackedHorizontalBars *= py_monitoring_gui.CustomData_Type.StackedHorizontalBars*
+
+<a id="py_monitoring_gui.Visuals.DesignTable"></a>
+
+#### *class* DesignTable
+
+<a id="py_monitoring_gui.Visuals.DesignTable.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.DesignTable.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.DesignTable.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.DimensionId"></a>
+
+#### *class* DimensionId
+
+<a id="py_monitoring_gui.Visuals.DimensionId.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_gui.Visuals.DimensionId.get_dimension_from_index"></a>
+
+#### get_dimension_from_index(ax_index: int) → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the dimension set at ax_index, if exist, else return dimension().
+
+<a id="py_monitoring_gui.Visuals.DimensionId.get_dimension_id_from_index"></a>
+
+#### get_dimension_id_from_index(ax_index: int) → int
+
+Return the dimension_id set at ax_index, if exist, else return -1.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_at_index"></a>
+
+#### has_dimension_at_index(ax_index: int) → bool
+
+Return True when a dimension is set at ax-index of plot.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_id_at_index"></a>
+
+#### has_dimension_id_at_index(ax_index: int) → bool
+
+Return True when the plot has a dimension_combo_box id set at ax_index.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.has_dimension_set_at_index"></a>
+
+#### has_dimension_set_at_index(ax_index: int) → bool
+
+Return True when a dimension is set at ax-index of plot.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.listen_to_dimension_index"></a>
+
+#### listen_to_dimension_index(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.reset_user_defined_variable_selection"></a>
+
+#### reset_user_defined_variable_selection()
+
+Reset the previously made changes on dimension id to the predefined values, been saved at the visual on creation.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.set_dimension"></a>
+
+#### set_dimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.set_dimension_at_index"></a>
+
+#### set_dimension_at_index(ax_index: int, dimension_at_x_i: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set a dimension at given ax_index to plot.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.set_dimension_id_at_index"></a>
+
+#### set_dimension_id_at_index(ax_index: int, combo_box_id: int)
+
+Set a combo_box_id at ax_index. 
+: Plot now shows content of belonging combo_box at ax_index. 
+  e.g. SetDimensionToId(1,2) means that the plot now shows the chosen dimension from 3rd combo_box at y-axis.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.unset_dimension_at_index"></a>
+
+#### unset_dimension_at_index(ax_index: int)
+
+Unset the dimension at given ax_index. 
+: Plot now shows the predefined behavior.
+
+<a id="py_monitoring_gui.Visuals.DimensionId.unset_dimension_id_at_index"></a>
+
+#### unset_dimension_id_at_index(ax_index: int)
+
+Unset the dimension_id at given ax_index. 
+: Plot now shows the predefined behavior.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix"></a>
+
+#### *class* ExtendedCoPMatrix
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.export"></a>
+
+#### export(file_path: Path)
+
+#### export(file_path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), width: int, height: int)
+
+[0] Export the visual as picture, with given relative scale to file position given as path. 
+: If scale is left empty, 1.0 is used.
+
+[1] Export the visual as picture, with given absolute sizes to file position given as path.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_auto_rotate_axis_labels_enabled"></a>
+
+#### set_auto_rotate_axis_labels_enabled(enable: bool)
+
+Enable/disable axis label auto rotation.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_fix_projection_to_design"></a>
+
+#### set_fix_projection_to_design(show: bool)
+
+Enables/disables fix projection to designs.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_indices_type"></a>
+
+#### set_indices_type(indices_type: [ApproximatingCOPMatrixIndicesType](#py_monitoring_gui.ApproximatingCOPMatrixIndicesType))
+
+Toggle the view to see “Total effects”, “Main effects” or “Interactions” in matrix.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_limit_axis_label_size"></a>
+
+#### set_limit_axis_label_size(enable: bool)
+
+Limit axis label size.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_approximation"></a>
+
+#### set_show_approximation(show: bool)
+
+Show/hide approximation line.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_background_cop"></a>
+
+#### set_show_background_cop(show: bool)
+
+Show/hide background COP.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_cop"></a>
+
+#### set_show_cop(show: bool)
+
+Show/hide COP.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_filtered"></a>
+
+#### set_show_filtered(show: bool)
+
+Show/hide filtered parameters/responses.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_grid"></a>
+
+#### set_show_grid(show: bool)
+
+Show/hide grid.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_parameter_line"></a>
+
+#### set_show_parameter_line(show: bool)
+
+Show/hide parameter line.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_show_support_points"></a>
+
+#### set_show_support_points(show: bool)
+
+Show/hide support points.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCoPMatrix.set_use_rectangular_view"></a>
+
+#### set_use_rectangular_view(show: bool)
+
+Enables/disables rectangular view.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix"></a>
+
+#### *class* ExtendedCorrelationMatrix
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.export_with_given_tile_sizes"></a>
+
+#### export_with_given_tile_sizes(arg2: Path, arg3: int, file_path: int)
+
+Export the visual as picture, with given absolute tile sizes to file position given as path.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. 
+: Be aware that much memory can be allocated, in case of many dimensions.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_sizes_with_given_tile_sizes"></a>
+
+#### get_sizes_with_given_tile_sizes(tile_width: float, tile_height: float) → list
+
+Return list with size of plot when tiles have to be sized with x_tile_size and y_tile_size. Index 0 : width. index 1 : height.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_enabled"></a>
+
+#### set_axes_rotation_enabled(enable: bool)
+
+Set axes rotation enabled.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_orthogonal"></a>
+
+#### set_axes_rotation_orthogonal(enable: bool)
+
+Set rotation angles to 0 degree if possible, else to 90.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_x_angle"></a>
+
+#### set_axes_rotation_x_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_axes_rotation_y_angle"></a>
+
+#### set_axes_rotation_y_angle(angle: float)
+
+Set the rotation angle for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_histogram_classes"></a>
+
+#### set_histogram_classes(classes: int)
+
+Set the number of histogram classes.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_view_type"></a>
+
+#### set_view_type(view_type: [ExtendedCorrelationMatrixViewTypes](#py_monitoring_gui.ExtendedCorrelationMatrixViewTypes))
+
+Change the view of the visual to show the entils as
+: ExtendedCorrelationMatrixViewTypes.All_Correlations - correlation values in all entils 
+  ExtendedCorrelationMatrixViewTypes.Correlations_vs_Anthills - correlation values in upper left part, histograms on main diagonal and anthills in lower right part. 
+  ExtendedCorrelationMatrixViewTypes.Anthills_vs_Correlations - anthills in upper left part, histograms on main diagonal and correlation values in lower right part. 
+  ExtendedCorrelationMatrixViewTypes.All_Anthills - histograms on main diagonal, elsewhere anthills.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ExtendedCorrelationMatrix.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Grid"></a>
+
+#### Grid *= py_monitoring_gui.CustomData_Type.Grid*
+
+<a id="py_monitoring_gui.Visuals.Histogram"></a>
+
+#### *class* Histogram
+
+<a id="py_monitoring_gui.Visuals.Histogram.ListenToDimensionIndex"></a>
+
+#### ListenToDimensionIndex(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Histogram.SetAlpha"></a>
+
+#### SetAlpha(alpha_value: float)
+
+Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
+
+<a id="py_monitoring_gui.Visuals.Histogram.SetChi2"></a>
+
+#### SetChi2(chi_flag: bool)
+
+Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
+
+<a id="py_monitoring_gui.Visuals.Histogram.SetDimension"></a>
+
+#### SetDimension(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Histogram.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_actual_dimension"></a>
+
+#### get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the actual visible dimension.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_statistical_data"></a>
+
+#### get_statistical_data() → list
+
+Get statistical data as list of lists.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Histogram.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Histogram.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_alpha"></a>
+
+#### set_alpha(alpha_value: float)
+
+Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_chi_2"></a>
+
+#### set_chi_2(chi_flag: bool)
+
+Adjust the result wenn automatic fit is been chosen (actual when rv_types size is greater 1).
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_fit_type"></a>
+
+#### set_fit_type(fit_type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))
+
+Set a random variable type for the fit.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_fit_type_to_automatic"></a>
+
+#### set_fit_type_to_automatic()
+
+Set fit to automatic.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_fit_type_to_none"></a>
+
+#### set_fit_type_to_none()
+
+Set fit to none.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_fit_types_for_automatic"></a>
+
+#### set_fit_types_for_automatic(rv_type: [RandomVariableTypeVec](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableTypeVec))
+
+Set a vector of random variable types to be used for automatic fit.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_histogram_classes"></a>
+
+#### set_histogram_classes(classes: int)
+
+Set the number of histogram classes.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_probability_value"></a>
+
+#### set_probability_value(probability_value: float)
+
+Set probability value.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_sigma_level"></a>
+
+#### set_sigma_level(sigma_level: float)
+
+Set sigma level for pdf.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Histogram.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Histogram.show_as_cdf"></a>
+
+#### show_as_cdf(show_as_cdf: bool)
+
+Show histogram bars, defined pdf and fitted pdf as cdf.
+
+<a id="py_monitoring_gui.Visuals.Histogram.show_defined_pdf"></a>
+
+#### show_defined_pdf(show_defined_pdf: bool)
+
+Show defined pdf.
+
+<a id="py_monitoring_gui.Visuals.Histogram.show_limits"></a>
+
+#### show_limits(sigma_level: bool)
+
+Show limits.
+
+<a id="py_monitoring_gui.Visuals.Histogram.show_probability"></a>
+
+#### show_probability(show_probability: bool)
+
+Show probability.
+
+<a id="py_monitoring_gui.Visuals.Histogram.show_process_capability"></a>
+
+#### show_process_capability(show_process_capability: bool)
+
+Show process capability.
+
+<a id="py_monitoring_gui.Visuals.Histogram.unset_fit_types_for_automatic"></a>
+
+#### unset_fit_types_for_automatic()
+
+Unset the vector of random variable types to standard.
+
+<a id="py_monitoring_gui.Visuals.Histogram.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.History"></a>
+
+#### *class* History
+
+<a id="py_monitoring_gui.Visuals.History.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.History.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.History.get_actual_dimension"></a>
+
+#### get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the actual visible dimension.
+
+<a id="py_monitoring_gui.Visuals.History.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.History.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.History.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.History.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.History.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.History.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.History.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.History.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.History.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.History.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.History.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.History.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.History.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.History.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.History.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.History.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.History.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.History.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.History.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.History.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.History.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.History.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.History.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.History.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.HorizontalBars"></a>
+
+#### HorizontalBars *= py_monitoring_gui.CustomData_Type.HorizontalBars*
+
+<a id="py_monitoring_gui.Visuals.HorizontalBox"></a>
+
+#### HorizontalBox *= py_monitoring_gui.CustomData_Type.HorizontalBox*
+
+<a id="py_monitoring_gui.Visuals.Lines"></a>
+
+#### Lines *= py_monitoring_gui.CustomData_Type.Lines*
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot"></a>
+
+#### *class* New_ParallelCoordinatesPlot
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.export"></a>
+
+#### export(file_path: Path)
+
+#### export(file_path: Path, width: int, height: int)
+
+[0] Export the visual as picture, with given relative scale to file position given as path. 
+: If scale is left empty, 1.0 is used. 
+  Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+[1] Export the visual as picture, with given absolute sizes to file position given as path.
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.New_ParallelCoordinatesPlot.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory"></a>
+
+#### *class* OptimizationHistory
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_active_layer_names"></a>
+
+#### get_active_layer_names() → list
+
+Get actual active layer names.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_available_layer_names"></a>
+
+#### get_available_layer_names() → list
+
+Get all possible layer names.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_all_layers_active_state"></a>
+
+#### set_all_layers_active_state(arg2: bool)
+
+Set active state of all layers.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_layer_active_state"></a>
+
+#### set_layer_active_state(arg2: str, arg3: bool)
+
+Set active state of layer with given layer name.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_layers_active_state"></a>
+
+#### set_layers_active_state(arg2: list, arg3: bool)
+
+Set active state of layers with given layer names.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.OptimizationHistory.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.PCAData"></a>
+
+#### *class* PCAData
+
+<a id="py_monitoring_gui.Visuals.PCAData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.PCAData.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.PCAData.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.PCAData.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.PCAData.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.PCAData.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.PCAData.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot"></a>
+
+#### *class* ParallelCoordinatesPlot
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.export"></a>
+
+#### export(file_path: Path)
+
+#### export(file_path: Path, width: int, height: int)
+
+[0] Export the visual as picture, with given relative scale to file position given as path. 
+: If scale is left empty, 1.0 is used. 
+  Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+[1] Export the visual as picture, with given absolute sizes to file position given as path.
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ParallelCoordinatesPlot.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues"></a>
+
+#### *class* ParameterValues
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ParameterValues.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Parametrization"></a>
+
+#### *class* Parametrization
+
+<a id="py_monitoring_gui.Visuals.Parametrization.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Parametrization.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Parametrization.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D"></a>
+
+#### *class* Pareto2D
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto2D.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D"></a>
+
+#### *class* Pareto3D
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.get_z_axis_label"></a>
+
+#### get_z_axis_label() → str
+
+Get the z axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_alpha"></a>
+
+#### set_alpha(alpha_angle: float)
+
+Set the first angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_beta"></a>
+
+#### set_beta(beta_angle: float)
+
+Set the second angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_gamma"></a>
+
+#### set_gamma(gamma_angle: float)
+
+Set the third angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_lighting_enabled"></a>
+
+#### set_lighting_enabled(enabled: bool)
+
+Set lighting enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_log_z_axis"></a>
+
+#### set_log_z_axis(enabled: bool)
+
+Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis"></a>
+
+#### set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis_format"></a>
+
+#### set_z_axis_format(z_axis_format: str)
+
+Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.set_z_axis_label"></a>
+
+#### set_z_axis_label(label_z: str)
+
+Set the z axis label.
+
+<a id="py_monitoring_gui.Visuals.Pareto3D.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.PathBase"></a>
+
+#### *class* PathBase
+
+<a id="py_monitoring_gui.Visuals.PathBase.SetPath"></a>
+
+#### SetPath(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Set the path to the image/process executable.
+
+<a id="py_monitoring_gui.Visuals.PathBase.SetPathFixed"></a>
+
+#### SetPathFixed(arg2: bool)
+
+Set the path to the image/process executable. Contained placeholders will not be resolved.
+
+<a id="py_monitoring_gui.Visuals.PathBase.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [PathBasedVisualTypes](#py_monitoring_gui.PathBasedVisualTypes), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [PathBasedVisualTypes](#py_monitoring_gui.PathBasedVisualTypes), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg4: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.PathBase.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.PathBase.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.PathBase.set_arguments"></a>
+
+#### set_arguments(arg2: str)
+
+Set the argument string, used by a process.
+
+<a id="py_monitoring_gui.Visuals.PathBase.set_auto_insert_placeholders"></a>
+
+#### set_auto_insert_placeholders(arg2: bool)
+
+If placeholders (e.g. $DESIGN_DIR) should be inserted automatically.
+
+<a id="py_monitoring_gui.Visuals.PathBase.set_path"></a>
+
+#### set_path(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Set the path to the image/process executable.
+
+<a id="py_monitoring_gui.Visuals.PathBase.set_path_fixed"></a>
+
+#### set_path_fixed(arg2: bool)
+
+Set the path to the image/process executable. Contained placeholders will not be resolved.
+
+<a id="py_monitoring_gui.Visuals.Points"></a>
+
+#### Points *= py_monitoring_gui.CustomData_Type.Points*
+
+<a id="py_monitoring_gui.Visuals.Probability"></a>
+
+#### *class* Probability
+
+<a id="py_monitoring_gui.Visuals.Probability.ListenToDimensionIndex"></a>
+
+#### ListenToDimensionIndex(arg2: int)
+
+deprecated - use set_dimension_id_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.Probability.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Probability.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Probability.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Probability.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Probability.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo"></a>
+
+#### *class* ReliAlgoInfo
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.export"></a>
+
+#### export(file_path: Path)
+
+Export the visual as picture to file position given as path. 
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.export_data"></a>
+
+#### export_data(file_path: Path)
+
+Export the visual as ascii with given format_string to file position given as path. 
+: If format_string is left empty, “%g” is used.
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ReliAlgoInfo.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill"></a>
+
+#### *class* ReliAnthill
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.show_designs_in_standard_gauss"></a>
+
+#### show_designs_in_standard_gauss(arg2: bool)
+
+Toggle view of designs to standard gauss. 
+: Does not have an effect when original distribution is already standard gauss.
+
+<a id="py_monitoring_gui.Visuals.ReliAnthill.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud"></a>
+
+#### *class* ReliCloud
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.SetZAxis"></a>
+
+#### SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.get_z_axis_label"></a>
+
+#### get_z_axis_label() → str
+
+Get the z axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_alpha"></a>
+
+#### set_alpha(alpha_angle: float)
+
+Set the first angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_beta"></a>
+
+#### set_beta(beta_angle: float)
+
+Set the second angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_gamma"></a>
+
+#### set_gamma(gamma_angle: float)
+
+Set the third angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_lighting_enabled"></a>
+
+#### set_lighting_enabled(enabled: bool)
+
+Set lighting enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_log_z_axis"></a>
+
+#### set_log_z_axis(enabled: bool)
+
+Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis"></a>
+
+#### set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis_format"></a>
+
+#### set_z_axis_format(z_axis_format: str)
+
+Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.set_z_axis_label"></a>
+
+#### set_z_axis_label(label_z: str)
+
+Set the z axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.show_designs_in_standard_gauss"></a>
+
+#### show_designs_in_standard_gauss(arg2: bool)
+
+Toggle view of designs to standard gauss. 
+: Does not have an effect when original distribution is already standard gauss.
+
+<a id="py_monitoring_gui.Visuals.ReliCloud.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory"></a>
+
+#### *class* ReliFailureHistory
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_active_layer_names"></a>
+
+#### get_active_layer_names() → list
+
+Get actual active layer names.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_available_layer_names"></a>
+
+#### get_available_layer_names() → list
+
+Get all possible layer names.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_all_layers_active_state"></a>
+
+#### set_all_layers_active_state(arg2: bool)
+
+Set active state of all layers.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_layer_active_state"></a>
+
+#### set_layer_active_state(arg2: str, arg3: bool)
+
+Set active state of layer with given layer name.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_layers_active_state"></a>
+
+#### set_layers_active_state(arg2: list, arg3: bool)
+
+Set active state of layers with given layer names.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliFailureHistory.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance"></a>
+
+#### *class* ReliInputImportance
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ReliInputImportance.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.Residual"></a>
+
+#### *class* Residual
+
+<a id="py_monitoring_gui.Visuals.Residual.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.Residual.get_actual_dimension"></a>
+
+#### get_actual_dimension() → [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension)
+
+Return the actual visible dimension.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_statistical_data"></a>
+
+#### get_statistical_data() → list
+
+Get statistical data as list of lists.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Residual.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Residual.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.Residual.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_error_relative"></a>
+
+#### set_error_relative(error_relative: bool)
+
+When show_errors or show_absolute_errors is set, toggle view to show errors relative to range.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Residual.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.Residual.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.Residual.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_sigma_level"></a>
+
+#### set_sigma_level(sigma: float)
+
+Set the sigma level, which determines the distance the red sigma_lines have, to the black diagonal. 
+: Distance is equal sigma_value times sigma_level.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.Residual.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.Residual.show_absolute_errors"></a>
+
+#### show_absolute_errors()
+
+Show values in visual as absolute error of dimension_cv_value vs dimension_value over dimension_value.
+
+<a id="py_monitoring_gui.Visuals.Residual.show_errors"></a>
+
+#### show_errors()
+
+Show values in visual as error of dimension_cv vs dimension_value over dimension_value.
+
+<a id="py_monitoring_gui.Visuals.Residual.show_maximum_error"></a>
+
+#### show_maximum_error(arg2: bool)
+
+Show an arrow pointing to the maximum error. 
+: Only visible when show_errors or show_absolute_errors is set.
+
+<a id="py_monitoring_gui.Visuals.Residual.show_sample_cops"></a>
+
+#### show_sample_cops()
+
+Show values in visual as SampleCoPs over dimension_value.
+
+<a id="py_monitoring_gui.Visuals.Residual.show_values"></a>
+
+#### show_values()
+
+Show values in visual as dimension_cv_value over dimension_value.
+
+<a id="py_monitoring_gui.Visuals.Residual.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D"></a>
+
+#### *class* ResponseSurface2D
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_resolution"></a>
+
+#### set_resolution(resolution: int)
+
+Sets the resolution with which the response surface line is been plotted.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_show_additional_points"></a>
+
+#### set_show_additional_points(show_additional_data: bool)
+
+Show additional data points or not.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface2D.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D"></a>
+
+#### *class* ResponseSurface3D
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.SetZAxis"></a>
+
+#### SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.get_z_axis_label"></a>
+
+#### get_z_axis_label() → str
+
+Get the z axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_alpha"></a>
+
+#### set_alpha(alpha_angle: float)
+
+Set the first angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_beta"></a>
+
+#### set_beta(beta_angle: float)
+
+Set the second angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_gamma"></a>
+
+#### set_gamma(gamma_angle: float)
+
+Set the third angle for an rotation based on Euler angles z-x’-z’’.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_iso_line_heights"></a>
+
+#### set_iso_line_heights(iso_lines_string: str)
+
+#### set_iso_line_heights(iso_lines: list)
+
+[0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ .
+
+[1] Set the iso_lines given as python list.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_lighting_enabled"></a>
+
+#### set_lighting_enabled(enabled: bool)
+
+Set lighting enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_log_z_axis"></a>
+
+#### set_log_z_axis(enabled: bool)
+
+Set the z-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_data"></a>
+
+#### set_palette_data(palette_data: [ResponseSurfacePaletteData](#py_monitoring_gui.ResponseSurfacePaletteData))
+
+Set the palette_data so that response surface show certain specific values.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_resolution"></a>
+
+#### set_resolution(resolution: int)
+
+Set the resolution with which the response surface is been plotted.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_show_additional_points"></a>
+
+#### set_show_additional_points(show_additional_data: bool)
+
+Show additional data points or not.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis"></a>
+
+#### set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis_format"></a>
+
+#### set_z_axis_format(z_axis_format: str)
+
+Set the axis format for z axis. Will be ignored if log axis is been chosen for z-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.set_z_axis_label"></a>
+
+#### set_z_axis_label(label_z: str)
+
+Set the z axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurface3D.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV"></a>
+
+#### *class* ResponseSurfaceTV
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetAbscissa"></a>
+
+#### SetAbscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetDimensions"></a>
+
+#### SetDimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetOrdinate"></a>
+
+#### SetOrdinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.SetZAxis"></a>
+
+#### SetZAxis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_actual_dimensions"></a>
+
+#### get_actual_dimensions() → [DimensionVector](py_monitoring_kernel.md#py_monitoring_kernel.DimensionVector)
+
+Return the actual visible dimensions as vector.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_abscissa"></a>
+
+#### set_abscissa(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(0, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_dimensions"></a>
+
+#### set_dimensions(x_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), y_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), z_axis_dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the dimensions to be shown in visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_iso_line_heights"></a>
+
+#### set_iso_line_heights(iso_lines_string: str)
+
+#### set_iso_line_heights(iso_lines: list)
+
+[0] Set the iso_lines given as string with delimiters space and ‘,’ and ‘;’ .
+
+[1] Set the iso_lines given as python list.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ordinate"></a>
+
+#### set_ordinate(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(1, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_data"></a>
+
+#### set_palette_data(palette_data: [ResponseSurfacePaletteData](#py_monitoring_gui.ResponseSurfacePaletteData))
+
+Set the palette_data so that response surface show certain specific values.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_resolution"></a>
+
+#### set_resolution(resolution: int)
+
+Set the resolution with which the response surface is been plotted.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_show_additional_points"></a>
+
+#### set_show_additional_points(show_additional_data: bool)
+
+Show additional data points or not.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.set_z_axis"></a>
+
+#### set_z_axis(arg2: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+deprecated - use set_dimension_at_index(2, … ) instead.
+
+<a id="py_monitoring_gui.Visuals.ResponseSurfaceTV.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues"></a>
+
+#### *class* ResponseValues
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.ResponseValues.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList"></a>
+
+#### *class* SignalDesignList
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.IdExportList"></a>
+
+#### IdExportList() → [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList)
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.id_export_list"></a>
+
+#### id_export_list() → [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList)
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.push_back"></a>
+
+#### push_back(arg2: [HID](id.md#id.HID))
+
+<a id="py_monitoring_gui.Visuals.SignalDesignList.size"></a>
+
+#### size() → int
+
+<a id="py_monitoring_gui.Visuals.SignalLayer"></a>
+
+#### *class* SignalLayer
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.SetChannel"></a>
+
+#### SetChannel(channel: int)
+
+Set the channel index.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.SetIds"></a>
+
+#### SetIds(ids: [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList))
+
+Set the ids.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.SetLayer"></a>
+
+#### SetLayer(layer_name: str)
+
+Set the layer name.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.SetSignal"></a>
+
+#### SetSignal(signal: str)
+
+Set the signal dimension.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.SetStyle"></a>
+
+#### SetStyle(style: [Style](py_monitoring_kernel.md#py_monitoring_kernel.Style))
+
+Set the style.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_channel"></a>
+
+#### set_channel(channel: int)
+
+Set the channel index.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_channel_name"></a>
+
+#### set_channel_name(channel_name: str)
+
+Set the channel name (sig_info).
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_data_name"></a>
+
+#### set_data_name(data_name: str)
+
+Set the data name (sig_info).
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_ids"></a>
+
+#### set_ids(ids: [SignalDesignList](#py_monitoring_gui.Visuals.SignalDesignList))
+
+Set the ids.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_layer"></a>
+
+#### set_layer(layer_name: str)
+
+Set the layer name.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_number_of_data"></a>
+
+#### set_number_of_data(number_of_data: int)
+
+Set the number of lines to be shown (sig_info).
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_signal"></a>
+
+#### set_signal(signal: str)
+
+Set the signal dimension.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_style"></a>
+
+#### set_style(style: [Style](py_monitoring_kernel.md#py_monitoring_kernel.Style))
+
+Set the style.
+
+<a id="py_monitoring_gui.Visuals.SignalLayer.set_take_all_ids"></a>
+
+#### set_take_all_ids(take_all_ids: bool)
+
+Take all possible design ids when True. Overrides set_ids.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot"></a>
+
+#### *class* SignalPlot
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.AddLayer"></a>
+
+#### AddLayer(signal_layer: [SignalLayer](#py_monitoring_gui.Visuals.SignalLayer))
+
+Add a layer of type SignalLayer.
+: In this layer one can set the signal-channel combination he wants, showing the designs wished with a certain style. 
+  Style is been applied to all designs, if wished otherwise more than one layer has to be added. 
+  Design style set in e.g. DesignTable is NOT applied to this layer.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.RemoveAllLayers"></a>
+
+#### RemoveAllLayers()
+
+Remove all layers, now showing “no valid data”. Every previous signal/reference setting is been resetted, to make a clean start possible.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.SetChannel"></a>
+
+#### SetChannel(channel_index: int)
+
+Set the channel index for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.SetReference"></a>
+
+#### SetReference(reference: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the reference signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.SetReferenceChannel"></a>
+
+#### SetReferenceChannel(reference_channel_index: int)
+
+Set the reference channel index for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.SetReferenceDesign"></a>
+
+#### SetReferenceDesign(reference_design_id: [HID](id.md#id.HID))
+
+Set the reference design id. For reference signal only one design is shown.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.SetSignal"></a>
+
+#### SetSignal(signal: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.add_layer"></a>
+
+#### add_layer(signal_layer: [SignalLayer](#py_monitoring_gui.Visuals.SignalLayer))
+
+Add a layer of type SignalLayer.
+: In this layer one can set the signal-channel combination he wants, showing the designs wished with a certain style. 
+  Style is been applied to all designs, if wished otherwise more than one layer has to be added. 
+  Design style set in e.g. DesignTable is NOT applied to this layer.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.adjust_resolution"></a>
+
+#### adjust_resolution(arg2: bool)
+
+Modify signals to be shown with given resolution.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.is_reference_of_type_signal_info"></a>
+
+#### is_reference_of_type_signal_info() → bool
+
+Get info about reference be signal info type.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.is_signal_of_type_signal_info"></a>
+
+#### is_signal_of_type_signal_info() → bool
+
+Get info about signal be signal info type.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.remove_all_layers"></a>
+
+#### remove_all_layers()
+
+Remove all layers, now showing “no valid data”. Every previous signal/reference setting is been resetted, to make a clean start possible.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_channel"></a>
+
+#### set_channel(channel_index: int)
+
+Set the channel index for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_channel_name"></a>
+
+#### set_channel_name(channel_name: str)
+
+Set the channel name for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_data_name"></a>
+
+#### set_data_name(data_name: str)
+
+Set the data name for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_interpolation_type"></a>
+
+#### set_interpolation_type(arg2: int)
+
+Set the interpolation type, for changed resolution to 1 = LINEAR, 2 = QUADRATIC, other values will be ignored.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_number_of_classes"></a>
+
+#### set_number_of_classes(arg2: int)
+
+Set the number of classes (parts in y direction) with which the contour plot is been shown.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_number_of_data"></a>
+
+#### set_number_of_data(number_of_data: int)
+
+Set the maximum number of lines for signal_info view.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference"></a>
+
+#### set_reference(reference: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the reference signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_channel"></a>
+
+#### set_reference_channel(reference_channel_index: int)
+
+Set the reference channel index for signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_channel_name"></a>
+
+#### set_reference_channel_name(channel_name: str)
+
+Set the channel name for reference.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_data_name"></a>
+
+#### set_reference_data_name(data_name: str)
+
+Set the data name for reference.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_design"></a>
+
+#### set_reference_design(reference_design_id: [HID](id.md#id.HID))
+
+Set the reference design id. For reference signal only one design is shown.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_reference_number_of_data"></a>
+
+#### set_reference_number_of_data(number_of_data: int)
+
+Set the maximum number of lines for reference signal_info view.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_resolution"></a>
+
+#### set_resolution(arg2: int)
+
+Set the resolution with which the signals are shown, when adjust_resolution is set to True. Minimum 2.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_sigma_factor"></a>
+
+#### set_sigma_factor(arg2: float)
+
+Set the factor with which standard deviation is shown. Change plot only when statistical data is shown.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_signal"></a>
+
+#### set_signal(signal: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension))
+
+Set the signal.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_x_axis_format"></a>
+
+#### set_x_axis_format(x_axis_format: str)
+
+Set the axis format for x axis. Will be ignored if log axis is been chosen for x-axis.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.show_as_contour_plot"></a>
+
+#### show_as_contour_plot(arg2: bool)
+
+Show signal data as contour plot with given number of classes.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.show_statistical_values"></a>
+
+#### show_statistical_values(arg2: bool)
+
+Show additional to signal, mean and standard deviation for signals with more than one line.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.SignalPlot.use_textures"></a>
+
+#### use_textures(toggle_texture_usage: bool)
+
+Modify the plot to show textures or not. 
+: Does only afllict plots with many points. 
+  Setting is to be meant as possibility to deactivate texture usage on certain (graphic) systems, where showing as texture leads to graphical problems. 
+  Not showing as texture means in most cases a reduce in performance.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot"></a>
+
+#### *class* SpiderPlot
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.export"></a>
+
+#### export(file_path: Path)
+
+#### export(file_path: Path, width: int, height: int)
+
+[0] Export the visual as picture, with given relative scale to file position given as path. 
+: If scale is left empty, 1.0 is used. 
+  Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+[1] Export the visual as picture, with given absolute sizes to file position given as path.
+: Transparency produces plot with transparent background which is available when having picture types supporting this, like png. 
+  Quality is available for jpg, determining the quality of the output in percent [0:100].
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.set_font_size"></a>
+
+#### set_font_size(arg2: int)
+
+Set the font size at the visual.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.SpiderPlot.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.StackedBars"></a>
+
+#### StackedBars *= py_monitoring_gui.CustomData_Type.StackedBars*
+
+<a id="py_monitoring_gui.Visuals.StackedHorizontalBars"></a>
+
+#### StackedHorizontalBars *= py_monitoring_gui.CustomData_Type.StackedHorizontalBars*
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis"></a>
+
+#### *class* StatisticAnalysis
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_probability_content"></a>
+
+#### set_box_probability_content(box_probability_content: float)
+
+Set the probability content for the box. Box goes from median-content\*0.5 to median+content\*0.5.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_sigma_factor"></a>
+
+#### set_box_sigma_factor(box_sigma_factor: float)
+
+Set the sigma factor for the box. Box goes from mean-factor to mean+factor.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_box_type"></a>
+
+#### set_box_type(box_type: [StatisticAnalysisBoxType](#py_monitoring_gui.StatisticAnalysisBoxType))
+
+Set the box type.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_group"></a>
+
+#### set_group(group_name: str)
+
+Set the group to be shown
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_limit_type"></a>
+
+#### set_limit_type(limit_type: [StatisticAnalysisLimitsType](#py_monitoring_gui.StatisticAnalysisLimitsType))
+
+Set the limit type.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_scaling_type"></a>
+
+#### set_scaling_type(scaling_type: [StatisticAnalysisScalingType](#py_monitoring_gui.StatisticAnalysisScalingType))
+
+Set the scaling type.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_separate_box_and_whisker"></a>
+
+#### set_separate_box_and_whisker(separate: bool)
+
+Show Box and Whisker on two layers.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_show_samples"></a>
+
+#### set_show_samples(show_samples: bool)
+
+Show sample points.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_probability_content"></a>
+
+#### set_whisker_probability_content(whisker_probability_content: float)
+
+Set the probability content for the whisker. Whisker goes from median-content\*0.5 to median+content\*0.5.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_sigma_factor"></a>
+
+#### set_whisker_sigma_factor(whisker_sigma_factor: float)
+
+Set the sigma factor for the whisker. Whisker goes from mean-factor to mean+factor.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_whisker_type"></a>
+
+#### set_whisker_type(whisker_type: [StatisticAnalysisWhiskerType](#py_monitoring_gui.StatisticAnalysisWhiskerType))
+
+Set the whisker type.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.StatisticAnalysis.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.StatisticValues"></a>
+
+#### *class* StatisticValues
+
+<a id="py_monitoring_gui.Visuals.StatisticValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.StatisticValues.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.StatisticValues.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot"></a>
+
+#### *class* TrafficLightPlot
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.HideResponses"></a>
+
+#### HideResponses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))
+
+Hide given dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.SetResponseVisible"></a>
+
+#### SetResponseVisible(dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), visible: bool)
+
+Toggle the visibility of one single dimension.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.SetSigmaFactor"></a>
+
+#### SetSigmaFactor(sigma: float)
+
+Change the sigma value used for statistical_values and for whole plot when values_sigma_based is chosen.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowAllResponses"></a>
+
+#### ShowAllResponses()
+
+Show all dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowResponses"></a>
+
+#### ShowResponses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))
+
+Show given dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.ShowStatisticValues"></a>
+
+#### ShowStatisticValues(visible: bool)
+
+Toggle visibility of statistical values, shown as additional box_plot on top of the bars.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.has_legend"></a>
+
+#### has_legend() → bool
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.hide_responses"></a>
+
+#### hide_responses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))
+
+Hide given dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_enabled"></a>
+
+#### set_axes_rotation_enabled(enable: bool)
+
+Set axes rotation enabled.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_orthogonal"></a>
+
+#### set_axes_rotation_orthogonal(enable: bool)
+
+Set rotation angles to 0 degree if enough space for text exist, else to 90.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_axes_rotation_x_angle"></a>
+
+#### set_axes_rotation_x_angle(angle: float)
+
+Set the rotation angle for x-axis.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_font_size"></a>
+
+#### set_legend_font_size(font_size: int)
+
+Set the font_size used in legend.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_position"></a>
+
+#### set_legend_position(x_position: float, y_position: float)
+
+Set the position of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_size"></a>
+
+#### set_legend_size(width: float, height: float)
+
+Set the size of the legend, using absolute or relative coordinates. 
+: (Internally stored as relative.)
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_legend_visible"></a>
+
+#### set_legend_visible(enabled: bool)
+
+Set legend visibilty to True or False.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_response_visible"></a>
+
+#### set_response_visible(dimension: [Dimension](py_monitoring_kernel.md#py_monitoring_kernel.Dimension), visible: bool)
+
+Toggle the visibility of one single dimension.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_sigma_factor"></a>
+
+#### set_sigma_factor(sigma: float)
+
+Change the sigma value used for statistical_values and for whole plot when values_sigma_based is chosen.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_y_axis_format"></a>
+
+#### set_y_axis_format(y_axis_format: str)
+
+Set the axis format for y axis. Will be ignored if log axis is been chosen for y-axis.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_all_responses"></a>
+
+#### show_all_responses()
+
+Show all dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_responses"></a>
+
+#### show_responses(dimension_list: [DimensionList](py_monitoring_kernel.md#py_monitoring_kernel.DimensionList))
+
+Show given dimensions.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_statistical_values"></a>
+
+#### show_statistical_values(visible: bool)
+
+Toggle visibility of statistical values, shown as additional box_plot on top of the bars.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.show_values_sigma_based"></a>
+
+#### show_values_sigma_based(toggle: bool)
+
+Toggle the values view, base on mean and sigma vs. original values.
+
+<a id="py_monitoring_gui.Visuals.TrafficLightPlot.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.VectorElements"></a>
+
+#### *class* VectorElements
+
+<a id="py_monitoring_gui.Visuals.VectorElements.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.VectorElements.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.WebViewer"></a>
+
+#### *class* WebViewer
+
+<a id="py_monitoring_gui.Visuals.WebViewer.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.WebViewer.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.WebViewer.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.WebViewer.set_source"></a>
+
+#### set_source(path: str)
+
+#### set_source(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+[0] Set path to html file to be viewed
+
+[1] Set path to html file to be viewed
+
+<a id="py_monitoring_gui.Visuals.WebViewer.set_source_data"></a>
+
+#### set_source_data(content: str)
+
+Set content of html to be viewed
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues"></a>
+
+#### *class* WeightedPCValues
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+#### \_\_init_\_(arg2: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id), arg3: [py_monitoring_kernel.Id](py_monitoring_kernel.md#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_caption"></a>
+
+#### get_caption() → str
+
+Get the caption.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_data"></a>
+
+#### get_data(layer_name: str) → list
+
+Get data from DataTable of layer layer_name as list of lists. When force_as_text is True then data returns as text.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_display_name"></a>
+
+#### *static* get_display_name() → str
+
+Get a descriptive title for this visual type.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_group_name"></a>
+
+#### *static* get_group_name() → str
+
+Get the name of the containing group.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_header_data"></a>
+
+#### get_header_data(layer_name: str, horizontal: bool) → list
+
+Get header data from DataTable of layer layer_name as list. horizontal = True - get horizontal header, horizontal = False - get vertical header.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_palette_preset_names"></a>
+
+#### get_palette_preset_names() → list
+
+Get a list of available palette preset names.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_x_axis_label"></a>
+
+#### get_x_axis_label() → str
+
+Get the x axis label.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.get_y_axis_label"></a>
+
+#### get_y_axis_label() → str
+
+Get the y axis label.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_limits"></a>
+
+#### reset_palette_limits()
+
+ReSet the minimum and maximum values of palette to default.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_maximum"></a>
+
+#### reset_palette_maximum()
+
+Reset the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.reset_palette_minimum"></a>
+
+#### reset_palette_minimum()
+
+Reset the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_axes_enabled"></a>
+
+#### set_axes_enabled(enabled: bool)
+
+Set axes enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_caption"></a>
+
+#### set_caption(caption: str)
+
+Set the caption.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_line_width"></a>
+
+#### set_line_width(line_width: float)
+
+Set the line width at the visual.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_lines_enabled"></a>
+
+#### set_lines_enabled(enabled: bool)
+
+Set lines enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_log_x_axis"></a>
+
+#### set_log_x_axis(enabled: bool)
+
+Set the x-axis to show values logarithmic. Will be ignored if data range contains values <=0.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_log_y_axis"></a>
+
+#### set_log_y_axis(enabled: bool)
+
+Set the y-axis to show values logarithmic. Will be ignored if data range contains values <=0
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_limits"></a>
+
+#### set_palette_limits(minimum: float, maximum: float)
+
+Set the minimum and maximum values of palette.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_maximum"></a>
+
+#### set_palette_maximum(maximum: float)
+
+Set the maximum value of palette.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_minimum"></a>
+
+#### set_palette_minimum(minimum: float)
+
+Set the minimum value of palette.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_position"></a>
+
+#### set_palette_position(x_position: float, y_position: float)
+
+Set the position of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_preset"></a>
+
+#### set_palette_preset(name: str)
+
+Set palette preset with given name.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_size"></a>
+
+#### set_palette_size(x_position: float, y_position: float)
+
+Set the size of the palette, using absolute or relative[%] coordinates. 
+: (Internally stored as relative[%].)
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_palette_visible"></a>
+
+#### set_palette_visible(enabled: bool)
+
+Set palette visibility to True or False.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_ranges_x"></a>
+
+#### set_ranges_x(minimum: float, maximum: float)
+
+Set the ranges to x-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_ranges_y"></a>
+
+#### set_ranges_y(minimum: float, maximum: float)
+
+Set the ranges to y-axis, Two inputs : minimum and maximum.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_surfaces_enabled"></a>
+
+#### set_surfaces_enabled(enabled: bool)
+
+Set surfaces enabled state to True or False.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_symbol_size"></a>
+
+#### set_symbol_size(symbol_size: float)
+
+Set the symbol size at the visual.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_x_axis_label"></a>
+
+#### set_x_axis_label(label_x: str)
+
+Set the x axis label.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.set_y_axis_label"></a>
+
+#### set_y_axis_label(label_y: str)
+
+Set the y axis label.
+
+<a id="py_monitoring_gui.Visuals.WeightedPCValues.update_plot"></a>
+
+#### update_plot()
+
+Trigger an additional update on visual.
+
+<a id="py_monitoring_gui.Visuals.__init__"></a>
+
+#### \_\_init_\_()

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_monitoring_kernel.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_monitoring_kernel.md
@@ -6,26 +6,52 @@
 
 Color object used to style designs.
 
-- <a id="py_monitoring_kernel.Color.__init__"></a>`__init__()`
-- `__init__(arg2: [PredefinedColor](#py_monitoring_kernel.PredefinedColor))`
-- `__init__(arg2: int, arg3: int, arg4: int)`
-- `__init__(arg2: int, arg3: int, arg4: int, arg5: int)`
-- `__init__(arg2: int, arg3: int)`
-- <a id="py_monitoring_kernel.Color.a"></a>*property* `a`<br>
-  Alpha component of the color.
-- <a id="py_monitoring_kernel.Color.b"></a>*property* `b`<br>
-  Blue component of the color.
-- <a id="py_monitoring_kernel.Color.g"></a>*property* `g`<br>
-  Green component of the color.
-- <a id="py_monitoring_kernel.Color.r"></a>*property* `r`<br>
-  Red component of the color.
+<a id="py_monitoring_kernel.Color.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [PredefinedColor](#py_monitoring_kernel.PredefinedColor))
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int)
+
+#### \_\_init_\_(arg2: int, arg3: int, arg4: int, arg5: int)
+
+#### \_\_init_\_(arg2: int, arg3: int)
+
+<a id="py_monitoring_kernel.Color.a"></a>
+
+#### *property* a
+
+Alpha component of the color.
+
+<a id="py_monitoring_kernel.Color.b"></a>
+
+#### *property* b
+
+Blue component of the color.
+
+<a id="py_monitoring_kernel.Color.g"></a>
+
+#### *property* g
+
+Green component of the color.
+
+<a id="py_monitoring_kernel.Color.r"></a>
+
+#### *property* r
+
+Red component of the color.
 
 <a id="py_monitoring_kernel.Control"></a>
 
 ## *class* py_monitoring_kernel.Control
 
-- <a id="py_monitoring_kernel.Control.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="py_monitoring_kernel.Control.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="py_monitoring_kernel.ControlInterface"></a>
 
@@ -33,10 +59,20 @@ Color object used to style designs.
 
 Base interface of a monitoring control. Controls display data and/or provide data editing functionality.
 
-- <a id="py_monitoring_kernel.ControlInterface.GetId"></a>`GetId() → [Id](#py_monitoring_kernel.Id)`
-- <a id="py_monitoring_kernel.ControlInterface.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_monitoring_kernel.ControlInterface.get_id"></a>`get_id() → [Id](#py_monitoring_kernel.Id)`
+<a id="py_monitoring_kernel.ControlInterface.GetId"></a>
+
+#### GetId() → [Id](#py_monitoring_kernel.Id)
+
+<a id="py_monitoring_kernel.ControlInterface.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_monitoring_kernel.ControlInterface.get_id"></a>
+
+#### get_id() → [Id](#py_monitoring_kernel.Id)
 
 <a id="py_monitoring_kernel.ControlPositioning"></a>
 
@@ -46,15 +82,25 @@ Base interface of a monitoring control. Controls display data and/or provide dat
 
 Enumerates possible control positioning alternatives.
 
-- <a id="py_monitoring_kernel.ControlPositioning.ABSOLUTE_POSITIONING"></a>`ABSOLUTE_POSITIONING *= py_monitoring_kernel.ControlPositioning.ABSOLUTE_POSITIONING*`
-- <a id="py_monitoring_kernel.ControlPositioning.FREE_POSITIONING"></a>`FREE_POSITIONING *= py_monitoring_kernel.ControlPositioning.FREE_POSITIONING*`
-- <a id="py_monitoring_kernel.ControlPositioning.RELATIVE_POSITIONING"></a>`RELATIVE_POSITIONING *= py_monitoring_kernel.ControlPositioning.RELATIVE_POSITIONING*`
+<a id="py_monitoring_kernel.ControlPositioning.ABSOLUTE_POSITIONING"></a>
+
+#### ABSOLUTE_POSITIONING *= py_monitoring_kernel.ControlPositioning.ABSOLUTE_POSITIONING*
+
+<a id="py_monitoring_kernel.ControlPositioning.FREE_POSITIONING"></a>
+
+#### FREE_POSITIONING *= py_monitoring_kernel.ControlPositioning.FREE_POSITIONING*
+
+<a id="py_monitoring_kernel.ControlPositioning.RELATIVE_POSITIONING"></a>
+
+#### RELATIVE_POSITIONING *= py_monitoring_kernel.ControlPositioning.RELATIVE_POSITIONING*
 
 <a id="py_monitoring_kernel.Controller"></a>
 
 ## *class* py_monitoring_kernel.Controller
 
-- <a id="py_monitoring_kernel.Controller.__init__"></a>`__init__()`
+<a id="py_monitoring_kernel.Controller.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_monitoring_kernel.ControllerInterface"></a>
 
@@ -62,140 +108,398 @@ Enumerates possible control positioning alternatives.
 
 Base interface of a controller object, managing monitoring data, monitoring visuals and controls, and data change requests.
 
-- <a id="py_monitoring_kernel.ControllerInterface.GetMonitoringData"></a>`GetMonitoringData(arg2: [Id](#py_monitoring_kernel.Id)) → [MonitoringData](#py_monitoring_kernel.MonitoringData)`<br>
-  Get a certain monitoring data object.
-- <a id="py_monitoring_kernel.ControllerInterface.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_monitoring_kernel.ControllerInterface.get_monitoring_data"></a>`get_monitoring_data(arg2: [Id](#py_monitoring_kernel.Id)) → [MonitoringData](#py_monitoring_kernel.MonitoringData)`<br>
-  Get a certain monitoring data object.
+<a id="py_monitoring_kernel.ControllerInterface.GetMonitoringData"></a>
+
+#### GetMonitoringData(arg2: [Id](#py_monitoring_kernel.Id)) → [MonitoringData](#py_monitoring_kernel.MonitoringData)
+
+Get a certain monitoring data object.
+
+<a id="py_monitoring_kernel.ControllerInterface.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_monitoring_kernel.ControllerInterface.get_monitoring_data"></a>
+
+#### get_monitoring_data(arg2: [Id](#py_monitoring_kernel.Id)) → [MonitoringData](#py_monitoring_kernel.MonitoringData)
+
+Get a certain monitoring data object.
 
 <a id="py_monitoring_kernel.Convenience"></a>
 
 ## *class* py_monitoring_kernel.Convenience
 
-- <a id="py_monitoring_kernel.Convenience.__init__"></a>`__init__()`
-- <a id="py_monitoring_kernel.Convenience.activate_all_criteria"></a>`*static* activate_all_criteria(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally activate all criteria.
-- <a id="py_monitoring_kernel.Convenience.activate_all_parameters"></a>`*static* activate_all_parameters(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally activate all parameters.
-- <a id="py_monitoring_kernel.Convenience.activate_all_responses"></a>`*static* activate_all_responses(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally activate all responses.
-- <a id="py_monitoring_kernel.Convenience.add_limit"></a>`*static* add_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit))`<br>
-  Add a global limit value.
-- <a id="py_monitoring_kernel.Convenience.deactivate_all_designs"></a>`*static* deactivate_all_designs(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally deactivate all designs.
-- <a id="py_monitoring_kernel.Convenience.deactivate_unimportant_parameters"></a>`*static* deactivate_unimportant_parameters(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally deactivate all unimportant parameters.
-- <a id="py_monitoring_kernel.Convenience.deselect_all_designs"></a>`*static* deselect_all_designs(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally deselect all designs.
-- <a id="py_monitoring_kernel.Convenience.export_palette"></a>`*static* export_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg5: bool)`<br>
-  Export palette.
-- <a id="py_monitoring_kernel.Convenience.get_limit_by_name"></a>`*static* get_limit_by_name(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → [Limit](#py_monitoring_kernel.Limit)`<br>
-  Get limit with given name when found.
-- <a id="py_monitoring_kernel.Convenience.get_num_deactivated_parameters"></a>`*static* get_num_deactivated_parameters(arg2: [Id](#py_monitoring_kernel.Id)) → int`<br>
-  Get number of deactivated parameters.
-- <a id="py_monitoring_kernel.Convenience.get_palette"></a>`*static* get_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → [PaletteData](#py_monitoring_kernel.PaletteData)`<br>
-  Get palette by name.
-- <a id="py_monitoring_kernel.Convenience.get_palette_names"></a>`*static* get_palette_names(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get all exitings palette names.
-- <a id="py_monitoring_kernel.Convenience.get_unimportant_parameters"></a>`*static* get_unimportant_parameters(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet)`<br>
-  Get names of all unimportant parameters.
-- <a id="py_monitoring_kernel.Convenience.get_unused_responses"></a>`*static* get_unused_responses(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet)`<br>
-  Get names of all unused responses.
-- <a id="py_monitoring_kernel.Convenience.has_limit"></a>`*static* has_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit)) → bool`<br>
-  Return true when limit is found.
-- <a id="py_monitoring_kernel.Convenience.is_parameter_active"></a>`*static* is_parameter_active(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → bool`<br>
-  Returns true when parameter is active.
-- <a id="py_monitoring_kernel.Convenience.is_response_active"></a>`*static* is_response_active(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → bool`<br>
-  Returns true when response is active.
-- <a id="py_monitoring_kernel.Convenience.load_palette_from_file"></a>`*static* load_palette_from_file(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Load palette from file.
-- <a id="py_monitoring_kernel.Convenience.load_palette_from_folder"></a>`*static* load_palette_from_folder(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Load palettes from folder.
-- <a id="py_monitoring_kernel.Convenience.preserve_param_activation"></a>`*static* preserve_param_activation() → bool`<br>
-  Returns true when parameter activation should be preserved.
-- <a id="py_monitoring_kernel.Convenience.remove_default_limits"></a>`*static* remove_default_limits(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Remove all default limits.
-- <a id="py_monitoring_kernel.Convenience.remove_limit"></a>`*static* remove_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit))`<br>
-  Remove a global limit.
-- <a id="py_monitoring_kernel.Convenience.select_best_designs"></a>`*static* select_best_designs(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Select best designs.
-- <a id="py_monitoring_kernel.Convenience.set_1st_axis"></a>`*static* set_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))`<br>
-  Globally change what object to display at first axis.
-- <a id="py_monitoring_kernel.Convenience.set_2nd_axis"></a>`*static* set_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))`<br>
-  Globally change what object to display at second axis.
-- <a id="py_monitoring_kernel.Convenience.set_3rd_axis"></a>`*static* set_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))`<br>
-  Globally change what object to display at third axis.
-- <a id="py_monitoring_kernel.Convenience.set_criteria_activated"></a>`*static* set_criteria_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))`<br>
-  Globally activate criteria.
-- <a id="py_monitoring_kernel.Convenience.set_criteria_deactivated"></a>`*static* set_criteria_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))`<br>
-  Globally deactivate criteria.
-- <a id="py_monitoring_kernel.Convenience.set_criterion_activated"></a>`*static* set_criterion_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally activate a certain criterion.
-- <a id="py_monitoring_kernel.Convenience.set_criterion_deactivated"></a>`*static* set_criterion_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally deactivate a certain criterion.
-- <a id="py_monitoring_kernel.Convenience.set_criterion_to_1st_axis"></a>`*static* set_criterion_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what criterion to display at first axis.
-- <a id="py_monitoring_kernel.Convenience.set_criterion_to_2nd_axis"></a>`*static* set_criterion_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what criterion to display at second axis.
-- <a id="py_monitoring_kernel.Convenience.set_criterion_to_3rd_axis"></a>`*static* set_criterion_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what criterion to display at third axis.
-- <a id="py_monitoring_kernel.Convenience.set_default_palette"></a>`*static* set_default_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Set default palette.
-- <a id="py_monitoring_kernel.Convenience.set_design_activated"></a>`*static* set_design_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: bool)`<br>
-  Globally activate/deactivate a certain design.
-- <a id="py_monitoring_kernel.Convenience.set_design_selected"></a>`*static* set_design_selected(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: bool)`<br>
-  Globally select/deselect a certain design.
-- <a id="py_monitoring_kernel.Convenience.set_design_set"></a>`*static* set_design_set(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change set of designs to display.
-- <a id="py_monitoring_kernel.Convenience.set_design_style"></a>`*static* set_design_style(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: [Style](#py_monitoring_kernel.Style))`<br>
-  Globally change the style of a certain design.
-- <a id="py_monitoring_kernel.Convenience.set_designs_selected"></a>`*static* set_designs_selected(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HIDSet](id.md#id.HIDSet), arg4: bool)`<br>
-  Globally select/deselect certain designs.
-- <a id="py_monitoring_kernel.Convenience.set_designs_style"></a>`*static* set_designs_style(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HIDSet](id.md#id.HIDSet), arg4: [Style](#py_monitoring_kernel.Style))`<br>
-  Globally change the style of a given designs.
-- <a id="py_monitoring_kernel.Convenience.set_limit_lower_value_at_dimension"></a>`*static* set_limit_lower_value_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)`<br>
-  Set limit lower value at a dimension.
-- <a id="py_monitoring_kernel.Convenience.set_limit_target_at_dimension"></a>`*static* set_limit_target_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)`<br>
-  Set limit target at a dimension.
-- <a id="py_monitoring_kernel.Convenience.set_limit_upper_value_at_dimension"></a>`*static* set_limit_upper_value_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)`<br>
-  Set limit upper value at a dimension.
-- <a id="py_monitoring_kernel.Convenience.set_palette"></a>`*static* set_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: [PaletteData](#py_monitoring_kernel.PaletteData), arg4: bool)`<br>
-  Set palette with the option to overwrite. If overwrite is False palette name will be made unique.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_activated"></a>`*static* set_parameter_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: bool)`<br>
-  Globally activate/deactivate a certain parameter.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_to_1st_axis"></a>`*static* set_parameter_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what parameter to display at first axis.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_to_2nd_axis"></a>`*static* set_parameter_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what parameter to display at second axis.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_to_3rd_axis"></a>`*static* set_parameter_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what parameter to display at third axis.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_value"></a>`*static* set_parameter_value(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: float)`<br>
-  Globally set the value of a certain parameter.
-- <a id="py_monitoring_kernel.Convenience.set_parameter_values"></a>`*static* set_parameter_values(arg2: [Id](#py_monitoring_kernel.Id), arg3: [string_to_double_map](stdcpp_python_export.md#stdcpp_python_export.string_to_double_map))`<br>
-  Globally set the value of certain parameters.
-- <a id="py_monitoring_kernel.Convenience.set_parameters_activated"></a>`*static* set_parameters_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet), arg4: bool)`<br>
-  Globally activate/deactivate parameters.
-- <a id="py_monitoring_kernel.Convenience.set_parameters_deactivated"></a>`*static* set_parameters_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))`<br>
-  Globally deactivate parameters.
-- <a id="py_monitoring_kernel.Convenience.set_response_activated"></a>`*static* set_response_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally activate a certain response.
-- <a id="py_monitoring_kernel.Convenience.set_response_deactivated"></a>`*static* set_response_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally deactivate a certain response.
-- <a id="py_monitoring_kernel.Convenience.set_response_to_1st_axis"></a>`*static* set_response_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what response to display at first axis.
-- <a id="py_monitoring_kernel.Convenience.set_response_to_2nd_axis"></a>`*static* set_response_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what response to display at second axis.
-- <a id="py_monitoring_kernel.Convenience.set_response_to_3rd_axis"></a>`*static* set_response_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what response to display at third axis.
-- <a id="py_monitoring_kernel.Convenience.set_response_to_cop_axis"></a>`*static* set_response_to_cop_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)`<br>
-  Globally change what response to display at CoP listener axis.
-- <a id="py_monitoring_kernel.Convenience.set_responses_activated"></a>`*static* set_responses_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))`<br>
-  Globally activate responses.
-- <a id="py_monitoring_kernel.Convenience.set_responses_deactivated"></a>`*static* set_responses_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))`<br>
-  Globally deactivate responses.
-- <a id="py_monitoring_kernel.Convenience.switch_first_and_second_axis"></a>`*static* switch_first_and_second_axis(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Globally switch what is being displayed at first and second axis.
+<a id="py_monitoring_kernel.Convenience.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.Convenience.activate_all_criteria"></a>
+
+#### *static* activate_all_criteria(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally activate all criteria.
+
+<a id="py_monitoring_kernel.Convenience.activate_all_parameters"></a>
+
+#### *static* activate_all_parameters(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally activate all parameters.
+
+<a id="py_monitoring_kernel.Convenience.activate_all_responses"></a>
+
+#### *static* activate_all_responses(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally activate all responses.
+
+<a id="py_monitoring_kernel.Convenience.add_limit"></a>
+
+#### *static* add_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit))
+
+Add a global limit value.
+
+<a id="py_monitoring_kernel.Convenience.deactivate_all_designs"></a>
+
+#### *static* deactivate_all_designs(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally deactivate all designs.
+
+<a id="py_monitoring_kernel.Convenience.deactivate_unimportant_parameters"></a>
+
+#### *static* deactivate_unimportant_parameters(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally deactivate all unimportant parameters.
+
+<a id="py_monitoring_kernel.Convenience.deselect_all_designs"></a>
+
+#### *static* deselect_all_designs(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally deselect all designs.
+
+<a id="py_monitoring_kernel.Convenience.export_palette"></a>
+
+#### *static* export_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg5: bool)
+
+Export palette.
+
+<a id="py_monitoring_kernel.Convenience.get_limit_by_name"></a>
+
+#### *static* get_limit_by_name(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → [Limit](#py_monitoring_kernel.Limit)
+
+Get limit with given name when found.
+
+<a id="py_monitoring_kernel.Convenience.get_num_deactivated_parameters"></a>
+
+#### *static* get_num_deactivated_parameters(arg2: [Id](#py_monitoring_kernel.Id)) → int
+
+Get number of deactivated parameters.
+
+<a id="py_monitoring_kernel.Convenience.get_palette"></a>
+
+#### *static* get_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → [PaletteData](#py_monitoring_kernel.PaletteData)
+
+Get palette by name.
+
+<a id="py_monitoring_kernel.Convenience.get_palette_names"></a>
+
+#### *static* get_palette_names(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get all exitings palette names.
+
+<a id="py_monitoring_kernel.Convenience.get_unimportant_parameters"></a>
+
+#### *static* get_unimportant_parameters(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet)
+
+Get names of all unimportant parameters.
+
+<a id="py_monitoring_kernel.Convenience.get_unused_responses"></a>
+
+#### *static* get_unused_responses(arg2: [Id](#py_monitoring_kernel.Id)) → [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet)
+
+Get names of all unused responses.
+
+<a id="py_monitoring_kernel.Convenience.has_limit"></a>
+
+#### *static* has_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit)) → bool
+
+Return true when limit is found.
+
+<a id="py_monitoring_kernel.Convenience.is_parameter_active"></a>
+
+#### *static* is_parameter_active(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → bool
+
+Returns true when parameter is active.
+
+<a id="py_monitoring_kernel.Convenience.is_response_active"></a>
+
+#### *static* is_response_active(arg2: [Id](#py_monitoring_kernel.Id), arg3: str) → bool
+
+Returns true when response is active.
+
+<a id="py_monitoring_kernel.Convenience.load_palette_from_file"></a>
+
+#### *static* load_palette_from_file(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Load palette from file.
+
+<a id="py_monitoring_kernel.Convenience.load_palette_from_folder"></a>
+
+#### *static* load_palette_from_folder(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Load palettes from folder.
+
+<a id="py_monitoring_kernel.Convenience.preserve_param_activation"></a>
+
+#### *static* preserve_param_activation() → bool
+
+Returns true when parameter activation should be preserved.
+
+<a id="py_monitoring_kernel.Convenience.remove_default_limits"></a>
+
+#### *static* remove_default_limits(arg2: [Id](#py_monitoring_kernel.Id))
+
+Remove all default limits.
+
+<a id="py_monitoring_kernel.Convenience.remove_limit"></a>
+
+#### *static* remove_limit(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Limit](#py_monitoring_kernel.Limit))
+
+Remove a global limit.
+
+<a id="py_monitoring_kernel.Convenience.select_best_designs"></a>
+
+#### *static* select_best_designs(arg2: [Id](#py_monitoring_kernel.Id))
+
+Select best designs.
+
+<a id="py_monitoring_kernel.Convenience.set_1st_axis"></a>
+
+#### *static* set_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))
+
+Globally change what object to display at first axis.
+
+<a id="py_monitoring_kernel.Convenience.set_2nd_axis"></a>
+
+#### *static* set_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))
+
+Globally change what object to display at second axis.
+
+<a id="py_monitoring_kernel.Convenience.set_3rd_axis"></a>
+
+#### *static* set_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension))
+
+Globally change what object to display at third axis.
+
+<a id="py_monitoring_kernel.Convenience.set_criteria_activated"></a>
+
+#### *static* set_criteria_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))
+
+Globally activate criteria.
+
+<a id="py_monitoring_kernel.Convenience.set_criteria_deactivated"></a>
+
+#### *static* set_criteria_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))
+
+Globally deactivate criteria.
+
+<a id="py_monitoring_kernel.Convenience.set_criterion_activated"></a>
+
+#### *static* set_criterion_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally activate a certain criterion.
+
+<a id="py_monitoring_kernel.Convenience.set_criterion_deactivated"></a>
+
+#### *static* set_criterion_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally deactivate a certain criterion.
+
+<a id="py_monitoring_kernel.Convenience.set_criterion_to_1st_axis"></a>
+
+#### *static* set_criterion_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what criterion to display at first axis.
+
+<a id="py_monitoring_kernel.Convenience.set_criterion_to_2nd_axis"></a>
+
+#### *static* set_criterion_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what criterion to display at second axis.
+
+<a id="py_monitoring_kernel.Convenience.set_criterion_to_3rd_axis"></a>
+
+#### *static* set_criterion_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what criterion to display at third axis.
+
+<a id="py_monitoring_kernel.Convenience.set_default_palette"></a>
+
+#### *static* set_default_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Set default palette.
+
+<a id="py_monitoring_kernel.Convenience.set_design_activated"></a>
+
+#### *static* set_design_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: bool)
+
+Globally activate/deactivate a certain design.
+
+<a id="py_monitoring_kernel.Convenience.set_design_selected"></a>
+
+#### *static* set_design_selected(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: bool)
+
+Globally select/deselect a certain design.
+
+<a id="py_monitoring_kernel.Convenience.set_design_set"></a>
+
+#### *static* set_design_set(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change set of designs to display.
+
+<a id="py_monitoring_kernel.Convenience.set_design_style"></a>
+
+#### *static* set_design_style(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HID](id.md#id.HID), arg4: [Style](#py_monitoring_kernel.Style))
+
+Globally change the style of a certain design.
+
+<a id="py_monitoring_kernel.Convenience.set_designs_selected"></a>
+
+#### *static* set_designs_selected(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HIDSet](id.md#id.HIDSet), arg4: bool)
+
+Globally select/deselect certain designs.
+
+<a id="py_monitoring_kernel.Convenience.set_designs_style"></a>
+
+#### *static* set_designs_style(arg2: [Id](#py_monitoring_kernel.Id), arg3: [HIDSet](id.md#id.HIDSet), arg4: [Style](#py_monitoring_kernel.Style))
+
+Globally change the style of a given designs.
+
+<a id="py_monitoring_kernel.Convenience.set_limit_lower_value_at_dimension"></a>
+
+#### *static* set_limit_lower_value_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)
+
+Set limit lower value at a dimension.
+
+<a id="py_monitoring_kernel.Convenience.set_limit_target_at_dimension"></a>
+
+#### *static* set_limit_target_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)
+
+Set limit target at a dimension.
+
+<a id="py_monitoring_kernel.Convenience.set_limit_upper_value_at_dimension"></a>
+
+#### *static* set_limit_upper_value_at_dimension(arg2: [Id](#py_monitoring_kernel.Id), arg3: [Dimension](#py_monitoring_kernel.Dimension), arg4: [Limit](#py_monitoring_kernel.Limit), arg5: float)
+
+Set limit upper value at a dimension.
+
+<a id="py_monitoring_kernel.Convenience.set_palette"></a>
+
+#### *static* set_palette(arg2: [Id](#py_monitoring_kernel.Id), arg3: [PaletteData](#py_monitoring_kernel.PaletteData), arg4: bool)
+
+Set palette with the option to overwrite. If overwrite is False palette name will be made unique.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_activated"></a>
+
+#### *static* set_parameter_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: bool)
+
+Globally activate/deactivate a certain parameter.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_to_1st_axis"></a>
+
+#### *static* set_parameter_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what parameter to display at first axis.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_to_2nd_axis"></a>
+
+#### *static* set_parameter_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what parameter to display at second axis.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_to_3rd_axis"></a>
+
+#### *static* set_parameter_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what parameter to display at third axis.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_value"></a>
+
+#### *static* set_parameter_value(arg2: [Id](#py_monitoring_kernel.Id), arg3: str, arg4: float)
+
+Globally set the value of a certain parameter.
+
+<a id="py_monitoring_kernel.Convenience.set_parameter_values"></a>
+
+#### *static* set_parameter_values(arg2: [Id](#py_monitoring_kernel.Id), arg3: [string_to_double_map](stdcpp_python_export.md#stdcpp_python_export.string_to_double_map))
+
+Globally set the value of certain parameters.
+
+<a id="py_monitoring_kernel.Convenience.set_parameters_activated"></a>
+
+#### *static* set_parameters_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet), arg4: bool)
+
+Globally activate/deactivate parameters.
+
+<a id="py_monitoring_kernel.Convenience.set_parameters_deactivated"></a>
+
+#### *static* set_parameters_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))
+
+Globally deactivate parameters.
+
+<a id="py_monitoring_kernel.Convenience.set_response_activated"></a>
+
+#### *static* set_response_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally activate a certain response.
+
+<a id="py_monitoring_kernel.Convenience.set_response_deactivated"></a>
+
+#### *static* set_response_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally deactivate a certain response.
+
+<a id="py_monitoring_kernel.Convenience.set_response_to_1st_axis"></a>
+
+#### *static* set_response_to_1st_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what response to display at first axis.
+
+<a id="py_monitoring_kernel.Convenience.set_response_to_2nd_axis"></a>
+
+#### *static* set_response_to_2nd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what response to display at second axis.
+
+<a id="py_monitoring_kernel.Convenience.set_response_to_3rd_axis"></a>
+
+#### *static* set_response_to_3rd_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what response to display at third axis.
+
+<a id="py_monitoring_kernel.Convenience.set_response_to_cop_axis"></a>
+
+#### *static* set_response_to_cop_axis(arg2: [Id](#py_monitoring_kernel.Id), arg3: str)
+
+Globally change what response to display at CoP listener axis.
+
+<a id="py_monitoring_kernel.Convenience.set_responses_activated"></a>
+
+#### *static* set_responses_activated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))
+
+Globally activate responses.
+
+<a id="py_monitoring_kernel.Convenience.set_responses_deactivated"></a>
+
+#### *static* set_responses_deactivated(arg2: [Id](#py_monitoring_kernel.Id), arg3: [WStrSet](stdcpp_python_export.md#stdcpp_python_export.WStrSet))
+
+Globally deactivate responses.
+
+<a id="py_monitoring_kernel.Convenience.switch_first_and_second_axis"></a>
+
+#### *static* switch_first_and_second_axis(arg2: [Id](#py_monitoring_kernel.Id))
+
+Globally switch what is being displayed at first and second axis.
 
 <a id="py_monitoring_kernel.CorrelationTypes"></a>
 
@@ -203,11 +507,25 @@ Base interface of a controller object, managing monitoring data, monitoring visu
 
 **Enumeration**
 
-- <a id="py_monitoring_kernel.CorrelationTypes.DistanceCorr"></a>`DistanceCorr *= py_monitoring_kernel.CorrelationTypes.DistanceCorr*`
-- <a id="py_monitoring_kernel.CorrelationTypes.LinearCorr"></a>`LinearCorr *= py_monitoring_kernel.CorrelationTypes.LinearCorr*`
-- <a id="py_monitoring_kernel.CorrelationTypes.QuadraticCorr"></a>`QuadraticCorr *= py_monitoring_kernel.CorrelationTypes.QuadraticCorr*`
-- <a id="py_monitoring_kernel.CorrelationTypes.QuadraticMinusLinear"></a>`QuadraticMinusLinear *= py_monitoring_kernel.CorrelationTypes.QuadraticMinusLinear*`
-- <a id="py_monitoring_kernel.CorrelationTypes.SpearmanRankOrder"></a>`SpearmanRankOrder *= py_monitoring_kernel.CorrelationTypes.SpearmanRankOrder*`
+<a id="py_monitoring_kernel.CorrelationTypes.DistanceCorr"></a>
+
+#### DistanceCorr *= py_monitoring_kernel.CorrelationTypes.DistanceCorr*
+
+<a id="py_monitoring_kernel.CorrelationTypes.LinearCorr"></a>
+
+#### LinearCorr *= py_monitoring_kernel.CorrelationTypes.LinearCorr*
+
+<a id="py_monitoring_kernel.CorrelationTypes.QuadraticCorr"></a>
+
+#### QuadraticCorr *= py_monitoring_kernel.CorrelationTypes.QuadraticCorr*
+
+<a id="py_monitoring_kernel.CorrelationTypes.QuadraticMinusLinear"></a>
+
+#### QuadraticMinusLinear *= py_monitoring_kernel.CorrelationTypes.QuadraticMinusLinear*
+
+<a id="py_monitoring_kernel.CorrelationTypes.SpearmanRankOrder"></a>
+
+#### SpearmanRankOrder *= py_monitoring_kernel.CorrelationTypes.SpearmanRankOrder*
 
 <a id="py_monitoring_kernel.DefaultStyle"></a>
 
@@ -221,42 +539,113 @@ Default style of designs.
 
 Dimension object, which holds a dimension type (parameter/response/criterion) and a name.
 
-- <a id="py_monitoring_kernel.Dimension.__init__"></a>`__init__()`<br>
-  [1] Create a Dimension with DimensionType and name. [2] Create a Dimension with DimensionType and name and additionally a vector component index indicator, either an integer value, which is directly used as index, or a boolean value, then the index is created from the name if the name contains something like [%d].
-- `__init__(DimensionType: [DimensionType](#py_monitoring_kernel.DimensionType), name: str)`
-- `__init__(DimensionType: [DimensionType](#py_monitoring_kernel.DimensionType), name: str, vector_component: object) → object`
-- <a id="py_monitoring_kernel.Dimension.get_index"></a>`get_index() → object`
-- <a id="py_monitoring_kernel.Dimension.is_criterion"></a>`is_criterion() → bool`<br>
-  Return true if the dimension is a criterion.
-- <a id="py_monitoring_kernel.Dimension.is_parameter"></a>`is_parameter() → bool`<br>
-  Return true if the dimension is a parameter.
-- <a id="py_monitoring_kernel.Dimension.is_response"></a>`is_response() → bool`<br>
-  Return true if the dimension is a response.
-- <a id="py_monitoring_kernel.Dimension.is_signal"></a>`is_signal() → bool`<br>
-  Return true if the dimension is a signal.
-- <a id="py_monitoring_kernel.Dimension.is_vector_component"></a>`is_vector_component() → bool`<br>
-  Return true if the dimension is a vector component.
-- <a id="py_monitoring_kernel.Dimension.name"></a>*property* `name`<br>
-  The name of the dimension.
-- <a id="py_monitoring_kernel.Dimension.type"></a>*property* `type`<br>
-  The type of the dimension.
+<a id="py_monitoring_kernel.Dimension.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(DimensionType: [DimensionType](#py_monitoring_kernel.DimensionType), name: str)
+
+#### \_\_init_\_(DimensionType: [DimensionType](#py_monitoring_kernel.DimensionType), name: str, vector_component: object) → object
+
+[1] Create a Dimension with DimensionType and name.
+
+[2] Create a Dimension with DimensionType and name and additionally a vector component index indicator, either an integer value, which is directly used as index, or a boolean value, then the index is created from the name if the name contains something like [%d].
+
+<a id="py_monitoring_kernel.Dimension.get_index"></a>
+
+#### get_index() → object
+
+<a id="py_monitoring_kernel.Dimension.is_criterion"></a>
+
+#### is_criterion() → bool
+
+Return true if the dimension is a criterion.
+
+<a id="py_monitoring_kernel.Dimension.is_parameter"></a>
+
+#### is_parameter() → bool
+
+Return true if the dimension is a parameter.
+
+<a id="py_monitoring_kernel.Dimension.is_response"></a>
+
+#### is_response() → bool
+
+Return true if the dimension is a response.
+
+<a id="py_monitoring_kernel.Dimension.is_signal"></a>
+
+#### is_signal() → bool
+
+Return true if the dimension is a signal.
+
+<a id="py_monitoring_kernel.Dimension.is_vector_component"></a>
+
+#### is_vector_component() → bool
+
+Return true if the dimension is a vector component.
+
+<a id="py_monitoring_kernel.Dimension.name"></a>
+
+#### *property* name
+
+The name of the dimension.
+
+<a id="py_monitoring_kernel.Dimension.type"></a>
+
+#### *property* type
+
+The type of the dimension.
 
 <a id="py_monitoring_kernel.DimensionList"></a>
 
 ## *class* py_monitoring_kernel.DimensionList
 
-- <a id="py_monitoring_kernel.DimensionList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_monitoring_kernel.DimensionList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_monitoring_kernel.DimensionList.__init__"></a>`__init__()`
-- <a id="py_monitoring_kernel.DimensionList.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_monitoring_kernel.DimensionList.__len__"></a>`__len__() → int`
-- <a id="py_monitoring_kernel.DimensionList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_monitoring_kernel.DimensionList.append"></a>`append(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionList.extend"></a>`extend(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionList.push_back"></a>`push_back(arg2: [Dimension](#py_monitoring_kernel.Dimension))`
-- <a id="py_monitoring_kernel.DimensionList.size"></a>`size() → int`
+<a id="py_monitoring_kernel.DimensionList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_monitoring_kernel.DimensionList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_monitoring_kernel.DimensionList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.DimensionList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_kernel.DimensionList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_monitoring_kernel.DimensionList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_monitoring_kernel.DimensionList.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionList.push_back"></a>
+
+#### push_back(arg2: [Dimension](#py_monitoring_kernel.Dimension))
+
+<a id="py_monitoring_kernel.DimensionList.size"></a>
+
+#### size() → int
 
 <a id="py_monitoring_kernel.DimensionType"></a>
 
@@ -266,28 +655,75 @@ Dimension object, which holds a dimension type (parameter/response/criterion) an
 
 Enumerates available dimension types.
 
-- <a id="py_monitoring_kernel.DimensionType.DIM_TYPE_CRITERION"></a>`DIM_TYPE_CRITERION *= py_monitoring_kernel.DimensionType.DIM_TYPE_CRITERION*`
-- <a id="py_monitoring_kernel.DimensionType.DIM_TYPE_INVALID"></a>`DIM_TYPE_INVALID *= py_monitoring_kernel.DimensionType.DIM_TYPE_INVALID*`
-- <a id="py_monitoring_kernel.DimensionType.DIM_TYPE_PARAMETER"></a>`DIM_TYPE_PARAMETER *= py_monitoring_kernel.DimensionType.DIM_TYPE_PARAMETER*`
-- <a id="py_monitoring_kernel.DimensionType.DIM_TYPE_RESPONSE"></a>`DIM_TYPE_RESPONSE *= py_monitoring_kernel.DimensionType.DIM_TYPE_RESPONSE*`
-- <a id="py_monitoring_kernel.DimensionType.DIM_TYPE_SIGNAL"></a>`DIM_TYPE_SIGNAL *= py_monitoring_kernel.DimensionType.DIM_TYPE_SIGNAL*`
+<a id="py_monitoring_kernel.DimensionType.DIM_TYPE_CRITERION"></a>
+
+#### DIM_TYPE_CRITERION *= py_monitoring_kernel.DimensionType.DIM_TYPE_CRITERION*
+
+<a id="py_monitoring_kernel.DimensionType.DIM_TYPE_INVALID"></a>
+
+#### DIM_TYPE_INVALID *= py_monitoring_kernel.DimensionType.DIM_TYPE_INVALID*
+
+<a id="py_monitoring_kernel.DimensionType.DIM_TYPE_PARAMETER"></a>
+
+#### DIM_TYPE_PARAMETER *= py_monitoring_kernel.DimensionType.DIM_TYPE_PARAMETER*
+
+<a id="py_monitoring_kernel.DimensionType.DIM_TYPE_RESPONSE"></a>
+
+#### DIM_TYPE_RESPONSE *= py_monitoring_kernel.DimensionType.DIM_TYPE_RESPONSE*
+
+<a id="py_monitoring_kernel.DimensionType.DIM_TYPE_SIGNAL"></a>
+
+#### DIM_TYPE_SIGNAL *= py_monitoring_kernel.DimensionType.DIM_TYPE_SIGNAL*
 
 <a id="py_monitoring_kernel.DimensionVector"></a>
 
 ## *class* py_monitoring_kernel.DimensionVector
 
-- <a id="py_monitoring_kernel.DimensionVector.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_monitoring_kernel.DimensionVector.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionVector.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_monitoring_kernel.DimensionVector.__init__"></a>`__init__()`
-- <a id="py_monitoring_kernel.DimensionVector.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_monitoring_kernel.DimensionVector.__len__"></a>`__len__() → int`
-- <a id="py_monitoring_kernel.DimensionVector.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_monitoring_kernel.DimensionVector.append"></a>`append(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionVector.extend"></a>`extend(arg2: object)`
-- <a id="py_monitoring_kernel.DimensionVector.push_back"></a>`push_back(arg2: [Dimension](#py_monitoring_kernel.Dimension))`
-- <a id="py_monitoring_kernel.DimensionVector.size"></a>`size() → int`
+<a id="py_monitoring_kernel.DimensionVector.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_monitoring_kernel.DimensionVector.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionVector.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_monitoring_kernel.DimensionVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.DimensionVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_kernel.DimensionVector.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_monitoring_kernel.DimensionVector.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_monitoring_kernel.DimensionVector.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionVector.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_monitoring_kernel.DimensionVector.push_back"></a>
+
+#### push_back(arg2: [Dimension](#py_monitoring_kernel.Dimension))
+
+<a id="py_monitoring_kernel.DimensionVector.size"></a>
+
+#### size() → int
 
 <a id="py_monitoring_kernel.Id"></a>
 
@@ -295,10 +731,17 @@ Enumerates available dimension types.
 
 An id to identify arbitrary objects within monitoring. Consists of a unique UUID and a name.
 
-- <a id="py_monitoring_kernel.Id.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="py_monitoring_kernel.Id.name"></a>*property* `name`<br>
-  Name of the object. May not be unique.
+<a id="py_monitoring_kernel.Id.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="py_monitoring_kernel.Id.name"></a>
+
+#### *property* name
+
+Name of the object. May not be unique.
 
 <a id="py_monitoring_kernel.Limit"></a>
 
@@ -306,16 +749,35 @@ An id to identify arbitrary objects within monitoring. Consists of a unique UUID
 
 Limit object, which holds a default lower and a default upper value, an ID and a style.
 
-- <a id="py_monitoring_kernel.Limit.__init__"></a>`__init__()`
-- `__init__(arg2: str, arg3: LimitValue, arg4: LimitValue)`
-- <a id="py_monitoring_kernel.Limit.default_lower_value"></a>*property* `default_lower_value`<br>
-  The default lower value of the limit.
-- <a id="py_monitoring_kernel.Limit.default_upper_value"></a>*property* `default_upper_value`<br>
-  The default upper value of the limit.
-- <a id="py_monitoring_kernel.Limit.name"></a>*property* `name`<br>
-  The name of the limit.
-- <a id="py_monitoring_kernel.Limit.style"></a>*property* `style`<br>
-  The name of the limit.
+<a id="py_monitoring_kernel.Limit.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str, arg3: LimitValue, arg4: LimitValue)
+
+<a id="py_monitoring_kernel.Limit.default_lower_value"></a>
+
+#### *property* default_lower_value
+
+The default lower value of the limit.
+
+<a id="py_monitoring_kernel.Limit.default_upper_value"></a>
+
+#### *property* default_upper_value
+
+The default upper value of the limit.
+
+<a id="py_monitoring_kernel.Limit.name"></a>
+
+#### *property* name
+
+The name of the limit.
+
+<a id="py_monitoring_kernel.Limit.style"></a>
+
+#### *property* style
+
+The name of the limit.
 
 <a id="py_monitoring_kernel.LimitValue"></a>
 
@@ -325,13 +787,33 @@ Limit object, which holds a default lower and a default upper value, an ID and a
 
 Enumerates available limit values.
 
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_FAILURE_VALUE"></a>`LIMIT_DEFAULT_FAILURE_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_FAILURE_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_SAFETY_VALUE"></a>`LIMIT_DEFAULT_SAFETY_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_SAFETY_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_MAX_VALUE"></a>`LIMIT_MAX_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MAX_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_MEAN_PLUS_STDDEV_VALUE"></a>`LIMIT_MEAN_PLUS_STDDEV_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MEAN_PLUS_STDDEV_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_MEAN_VALUE"></a>`LIMIT_MEAN_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MEAN_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_MIN_VALUE"></a>`LIMIT_MIN_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MIN_VALUE*`
-- <a id="py_monitoring_kernel.LimitValue.LIMIT_NONE_VALUE"></a>`LIMIT_NONE_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_NONE_VALUE*`
+<a id="py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_FAILURE_VALUE"></a>
+
+#### LIMIT_DEFAULT_FAILURE_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_FAILURE_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_SAFETY_VALUE"></a>
+
+#### LIMIT_DEFAULT_SAFETY_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_DEFAULT_SAFETY_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_MAX_VALUE"></a>
+
+#### LIMIT_MAX_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MAX_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_MEAN_PLUS_STDDEV_VALUE"></a>
+
+#### LIMIT_MEAN_PLUS_STDDEV_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MEAN_PLUS_STDDEV_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_MEAN_VALUE"></a>
+
+#### LIMIT_MEAN_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MEAN_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_MIN_VALUE"></a>
+
+#### LIMIT_MIN_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_MIN_VALUE*
+
+<a id="py_monitoring_kernel.LimitValue.LIMIT_NONE_VALUE"></a>
+
+#### LIMIT_NONE_VALUE *= py_monitoring_kernel.LimitValue.LIMIT_NONE_VALUE*
 
 <a id="py_monitoring_kernel.MonitoringData"></a>
 
@@ -339,66 +821,187 @@ Enumerates available limit values.
 
 Encapsulates a block of data to be monitored.
 
-- <a id="py_monitoring_kernel.MonitoringData.GetAlgorithmInfo"></a>`GetAlgorithmInfo() → [AlgorithmInfo](py_algorithm_info.md#py_algorithm_info.AlgorithmInfo)`<br>
-  Get structure providing information about the underlying algorithm that lead to the results.
-- <a id="py_monitoring_kernel.MonitoringData.GetBoundsOfParameter"></a>`GetBoundsOfParameter(arg2: [Dimension](#py_monitoring_kernel.Dimension)) → object`
-- <a id="py_monitoring_kernel.MonitoringData.GetCriteriaNames"></a>`GetCriteriaNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get criteria names.
-- <a id="py_monitoring_kernel.MonitoringData.GetDesignSets"></a>`GetDesignSets() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get the names of available design sets.
-- <a id="py_monitoring_kernel.MonitoringData.GetNominalDesign"></a>`GetNominalDesign() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`<br>
-  Get the nominal design if available.
-- <a id="py_monitoring_kernel.MonitoringData.GetObjectiveNames"></a>`GetObjectiveNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get objective names.
-- <a id="py_monitoring_kernel.MonitoringData.GetOriginalDesigns"></a>`GetOriginalDesigns() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)`<br>
-  Get the original design container. Design deactivation states are not considered.
-- <a id="py_monitoring_kernel.MonitoringData.GetParameterNames"></a>`GetParameterNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get parameter names.
-- <a id="py_monitoring_kernel.MonitoringData.GetReferenceDesign"></a>`GetReferenceDesign() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`<br>
-  Get the reference design if available.
-- <a id="py_monitoring_kernel.MonitoringData.GetResponseNames"></a>`GetResponseNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get response names.
-- <a id="py_monitoring_kernel.MonitoringData.GetSurrogateByName"></a>`GetSurrogateByName(arg2: str) → object`<br>
-  Get a certain actual surrogate model.
-- <a id="py_monitoring_kernel.MonitoringData.GetSurrogateNamesSortedByCoP"></a>`GetSurrogateNamesSortedByCoP() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get surrogate model names, sorted descending by their CoP.
-- <a id="py_monitoring_kernel.MonitoringData.__init__"></a>`__init__()`
-- `__init__(arg2: [Id](#py_monitoring_kernel.Id))`
-- <a id="py_monitoring_kernel.MonitoringData.get_algorithm_info"></a>`get_algorithm_info() → [AlgorithmInfo](py_algorithm_info.md#py_algorithm_info.AlgorithmInfo)`<br>
-  Get structure providing information about the underlying algorithm that lead to the results.
-- <a id="py_monitoring_kernel.MonitoringData.get_best_design_ids"></a>`get_best_design_ids() → [SignalDesignList](py_monitoring_gui.md#py_monitoring_gui.Visuals.SignalDesignList)`<br>
-  Returns a container of design IDs from the best active designs.
-- <a id="py_monitoring_kernel.MonitoringData.get_bounds_of_parameter"></a>`get_bounds_of_parameter(arg2: [Dimension](#py_monitoring_kernel.Dimension)) → object`
-- <a id="py_monitoring_kernel.MonitoringData.get_criteria_names"></a>`get_criteria_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get criteria names.
-- <a id="py_monitoring_kernel.MonitoringData.get_design_sets"></a>`get_design_sets() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get the names of available design sets.
-- <a id="py_monitoring_kernel.MonitoringData.get_nominal_design"></a>`get_nominal_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`<br>
-  Get the nominal design if available.
-- <a id="py_monitoring_kernel.MonitoringData.get_objective_names"></a>`get_objective_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get objective names.
-- <a id="py_monitoring_kernel.MonitoringData.get_original_designs"></a>`get_original_designs() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)`<br>
-  Get the original design container. Design deactivation states are not considered.
-- <a id="py_monitoring_kernel.MonitoringData.get_original_parameter_manager"></a>`get_original_parameter_manager() → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)`<br>
-  Get the original parameter manager. Parameter deactivation states are not considered.
-- <a id="py_monitoring_kernel.MonitoringData.get_parameter_names"></a>`get_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get parameter names.
-- <a id="py_monitoring_kernel.MonitoringData.get_reference_design"></a>`get_reference_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`<br>
-  Get the reference design if available.
-- <a id="py_monitoring_kernel.MonitoringData.get_response_names"></a>`get_response_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get response names.
-- <a id="py_monitoring_kernel.MonitoringData.get_signal_names"></a>`get_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get signal names.
-- <a id="py_monitoring_kernel.MonitoringData.get_surrogate_by_name"></a>`get_surrogate_by_name(arg2: str) → object`<br>
-  Get a certain actual surrogate model.
-- <a id="py_monitoring_kernel.MonitoringData.get_surrogate_names_sorted_by_cop"></a>`get_surrogate_names_sorted_by_cop() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`<br>
-  Get surrogate model names, sorted descending by their CoP.
-- <a id="py_monitoring_kernel.MonitoringData.get_surrogates"></a>`get_surrogates() → list`<br>
-  Get all surrogate models.
-- <a id="py_monitoring_kernel.MonitoringData.has_embedded_user_settings"></a>`has_embedded_user_settings() → bool`<br>
-  Returns whether data container has embedded user settings.
-- <a id="py_monitoring_kernel.MonitoringData.id"></a>*property* `id`<br>
-  The identifier of the data object.
+<a id="py_monitoring_kernel.MonitoringData.GetAlgorithmInfo"></a>
+
+#### GetAlgorithmInfo() → [AlgorithmInfo](py_algorithm_info.md#py_algorithm_info.AlgorithmInfo)
+
+Get structure providing information about the underlying algorithm that lead to the results.
+
+<a id="py_monitoring_kernel.MonitoringData.GetBoundsOfParameter"></a>
+
+#### GetBoundsOfParameter(arg2: [Dimension](#py_monitoring_kernel.Dimension)) → object
+
+<a id="py_monitoring_kernel.MonitoringData.GetCriteriaNames"></a>
+
+#### GetCriteriaNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get criteria names.
+
+<a id="py_monitoring_kernel.MonitoringData.GetDesignSets"></a>
+
+#### GetDesignSets() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get the names of available design sets.
+
+<a id="py_monitoring_kernel.MonitoringData.GetNominalDesign"></a>
+
+#### GetNominalDesign() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+Get the nominal design if available.
+
+<a id="py_monitoring_kernel.MonitoringData.GetObjectiveNames"></a>
+
+#### GetObjectiveNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get objective names.
+
+<a id="py_monitoring_kernel.MonitoringData.GetOriginalDesigns"></a>
+
+#### GetOriginalDesigns() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
+
+Get the original design container. Design deactivation states are not considered.
+
+<a id="py_monitoring_kernel.MonitoringData.GetParameterNames"></a>
+
+#### GetParameterNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get parameter names.
+
+<a id="py_monitoring_kernel.MonitoringData.GetReferenceDesign"></a>
+
+#### GetReferenceDesign() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+Get the reference design if available.
+
+<a id="py_monitoring_kernel.MonitoringData.GetResponseNames"></a>
+
+#### GetResponseNames() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get response names.
+
+<a id="py_monitoring_kernel.MonitoringData.GetSurrogateByName"></a>
+
+#### GetSurrogateByName(arg2: str) → object
+
+Get a certain actual surrogate model.
+
+<a id="py_monitoring_kernel.MonitoringData.GetSurrogateNamesSortedByCoP"></a>
+
+#### GetSurrogateNamesSortedByCoP() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get surrogate model names, sorted descending by their CoP.
+
+<a id="py_monitoring_kernel.MonitoringData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Id](#py_monitoring_kernel.Id))
+
+<a id="py_monitoring_kernel.MonitoringData.get_algorithm_info"></a>
+
+#### get_algorithm_info() → [AlgorithmInfo](py_algorithm_info.md#py_algorithm_info.AlgorithmInfo)
+
+Get structure providing information about the underlying algorithm that lead to the results.
+
+<a id="py_monitoring_kernel.MonitoringData.get_best_design_ids"></a>
+
+#### get_best_design_ids() → [SignalDesignList](py_monitoring_gui.md#py_monitoring_gui.Visuals.SignalDesignList)
+
+Returns a container of design IDs from the best active designs.
+
+<a id="py_monitoring_kernel.MonitoringData.get_bounds_of_parameter"></a>
+
+#### get_bounds_of_parameter(arg2: [Dimension](#py_monitoring_kernel.Dimension)) → object
+
+<a id="py_monitoring_kernel.MonitoringData.get_criteria_names"></a>
+
+#### get_criteria_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get criteria names.
+
+<a id="py_monitoring_kernel.MonitoringData.get_design_sets"></a>
+
+#### get_design_sets() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get the names of available design sets.
+
+<a id="py_monitoring_kernel.MonitoringData.get_nominal_design"></a>
+
+#### get_nominal_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+Get the nominal design if available.
+
+<a id="py_monitoring_kernel.MonitoringData.get_objective_names"></a>
+
+#### get_objective_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get objective names.
+
+<a id="py_monitoring_kernel.MonitoringData.get_original_designs"></a>
+
+#### get_original_designs() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
+
+Get the original design container. Design deactivation states are not considered.
+
+<a id="py_monitoring_kernel.MonitoringData.get_original_parameter_manager"></a>
+
+#### get_original_parameter_manager() → [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager)
+
+Get the original parameter manager. Parameter deactivation states are not considered.
+
+<a id="py_monitoring_kernel.MonitoringData.get_parameter_names"></a>
+
+#### get_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get parameter names.
+
+<a id="py_monitoring_kernel.MonitoringData.get_reference_design"></a>
+
+#### get_reference_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+Get the reference design if available.
+
+<a id="py_monitoring_kernel.MonitoringData.get_response_names"></a>
+
+#### get_response_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get response names.
+
+<a id="py_monitoring_kernel.MonitoringData.get_signal_names"></a>
+
+#### get_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get signal names.
+
+<a id="py_monitoring_kernel.MonitoringData.get_surrogate_by_name"></a>
+
+#### get_surrogate_by_name(arg2: str) → object
+
+Get a certain actual surrogate model.
+
+<a id="py_monitoring_kernel.MonitoringData.get_surrogate_names_sorted_by_cop"></a>
+
+#### get_surrogate_names_sorted_by_cop() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+Get surrogate model names, sorted descending by their CoP.
+
+<a id="py_monitoring_kernel.MonitoringData.get_surrogates"></a>
+
+#### get_surrogates() → list
+
+Get all surrogate models.
+
+<a id="py_monitoring_kernel.MonitoringData.has_embedded_user_settings"></a>
+
+#### has_embedded_user_settings() → bool
+
+Returns whether data container has embedded user settings.
+
+<a id="py_monitoring_kernel.MonitoringData.id"></a>
+
+#### *property* id
+
+The identifier of the data object.
 
 <a id="py_monitoring_kernel.PaletteColor"></a>
 
@@ -406,11 +1009,23 @@ Encapsulates a block of data to be monitored.
 
 Color object which holds value, value_type and color. PALETTE_VALUE_MINIMUM and PALETTE_VALUE_MAXIMUM should only occur once because they define the colors below and above of the value range.
 
-- <a id="py_monitoring_kernel.PaletteColor.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_monitoring_kernel.PaletteColor.color"></a>*property* `color`
-- <a id="py_monitoring_kernel.PaletteColor.value"></a>*property* `value`
-- <a id="py_monitoring_kernel.PaletteColor.value_type"></a>*property* `value_type`
+<a id="py_monitoring_kernel.PaletteColor.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.PaletteColor.color"></a>
+
+#### *property* color
+
+<a id="py_monitoring_kernel.PaletteColor.value"></a>
+
+#### *property* value
+
+<a id="py_monitoring_kernel.PaletteColor.value_type"></a>
+
+#### *property* value_type
 
 <a id="py_monitoring_kernel.PaletteColorData"></a>
 
@@ -418,11 +1033,23 @@ Color object which holds value, value_type and color. PALETTE_VALUE_MINIMUM and 
 
 Color data object which holds PaletteColors, gradient and value type.
 
-- <a id="py_monitoring_kernel.PaletteColorData.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_monitoring_kernel.PaletteColorData.color_vec"></a>*property* `color_vec`
-- <a id="py_monitoring_kernel.PaletteColorData.gradient"></a>*property* `gradient`
-- <a id="py_monitoring_kernel.PaletteColorData.value_type"></a>*property* `value_type`
+<a id="py_monitoring_kernel.PaletteColorData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.PaletteColorData.color_vec"></a>
+
+#### *property* color_vec
+
+<a id="py_monitoring_kernel.PaletteColorData.gradient"></a>
+
+#### *property* gradient
+
+<a id="py_monitoring_kernel.PaletteColorData.value_type"></a>
+
+#### *property* value_type
 
 <a id="py_monitoring_kernel.PaletteColorValueType"></a>
 
@@ -432,26 +1059,67 @@ Color data object which holds PaletteColors, gradient and value type.
 
 Enumerates available palette_colore value types. Default is PALETTE_VALUE_CUSTOM
 
-- <a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_CUSTOM"></a>`PALETTE_VALUE_CUSTOM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_CUSTOM*`
-- <a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MAXIMUM"></a>`PALETTE_VALUE_MAXIMUM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MAXIMUM*`
-- <a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MINIMUM"></a>`PALETTE_VALUE_MINIMUM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MINIMUM*`
+<a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_CUSTOM"></a>
+
+#### PALETTE_VALUE_CUSTOM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_CUSTOM*
+
+<a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MAXIMUM"></a>
+
+#### PALETTE_VALUE_MAXIMUM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MAXIMUM*
+
+<a id="py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MINIMUM"></a>
+
+#### PALETTE_VALUE_MINIMUM *= py_monitoring_kernel.PaletteColorValueType.PALETTE_VALUE_MINIMUM*
 
 <a id="py_monitoring_kernel.PaletteColorVector"></a>
 
 ## *class* py_monitoring_kernel.PaletteColorVector
 
-- <a id="py_monitoring_kernel.PaletteColorVector.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_monitoring_kernel.PaletteColorVector.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_monitoring_kernel.PaletteColorVector.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_monitoring_kernel.PaletteColorVector.__init__"></a>`__init__()`
-- <a id="py_monitoring_kernel.PaletteColorVector.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_monitoring_kernel.PaletteColorVector.__len__"></a>`__len__() → int`
-- <a id="py_monitoring_kernel.PaletteColorVector.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_monitoring_kernel.PaletteColorVector.append"></a>`append(arg2: object)`
-- <a id="py_monitoring_kernel.PaletteColorVector.extend"></a>`extend(arg2: object)`
-- <a id="py_monitoring_kernel.PaletteColorVector.push_back"></a>`push_back(arg2: [PaletteColor](#py_monitoring_kernel.PaletteColor))`
-- <a id="py_monitoring_kernel.PaletteColorVector.size"></a>`size() → int`
+<a id="py_monitoring_kernel.PaletteColorVector.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_monitoring_kernel.PaletteColorVector.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_monitoring_kernel.PaletteColorVector.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_monitoring_kernel.PaletteColorVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.PaletteColorVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_kernel.PaletteColorVector.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_monitoring_kernel.PaletteColorVector.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_monitoring_kernel.PaletteColorVector.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_monitoring_kernel.PaletteColorVector.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_monitoring_kernel.PaletteColorVector.push_back"></a>
+
+#### push_back(arg2: [PaletteColor](#py_monitoring_kernel.PaletteColor))
+
+<a id="py_monitoring_kernel.PaletteColorVector.size"></a>
+
+#### size() → int
 
 <a id="py_monitoring_kernel.PaletteData"></a>
 
@@ -459,12 +1127,27 @@ Enumerates available palette_colore value types. Default is PALETTE_VALUE_CUSTOM
 
 Data object which contains name, is_default, save_in_file and PaletteColorData.
 
-- <a id="py_monitoring_kernel.PaletteData.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_monitoring_kernel.PaletteData.color_data"></a>*property* `color_data`
-- <a id="py_monitoring_kernel.PaletteData.default"></a>*property* `default`
-- <a id="py_monitoring_kernel.PaletteData.name"></a>*property* `name`
-- <a id="py_monitoring_kernel.PaletteData.save_in_file"></a>*property* `save_in_file`
+<a id="py_monitoring_kernel.PaletteData.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.PaletteData.color_data"></a>
+
+#### *property* color_data
+
+<a id="py_monitoring_kernel.PaletteData.default"></a>
+
+#### *property* default
+
+<a id="py_monitoring_kernel.PaletteData.name"></a>
+
+#### *property* name
+
+<a id="py_monitoring_kernel.PaletteData.save_in_file"></a>
+
+#### *property* save_in_file
 
 <a id="py_monitoring_kernel.PaletteGradient"></a>
 
@@ -474,8 +1157,13 @@ Data object which contains name, is_default, save_in_file and PaletteColorData.
 
 Enumerates color gradient types. Default is PALETTE_GRADIENT_INTERPOLATING.
 
-- <a id="py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_Discrete"></a>`PALETTE_GRADIENT_Discrete *= py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_Discrete*`
-- <a id="py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_INTERPOLATING"></a>`PALETTE_GRADIENT_INTERPOLATING *= py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_INTERPOLATING*`
+<a id="py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_Discrete"></a>
+
+#### PALETTE_GRADIENT_Discrete *= py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_Discrete*
+
+<a id="py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_INTERPOLATING"></a>
+
+#### PALETTE_GRADIENT_INTERPOLATING *= py_monitoring_kernel.PaletteGradient.PALETTE_GRADIENT_INTERPOLATING*
 
 <a id="py_monitoring_kernel.PaletteValueType"></a>
 
@@ -485,8 +1173,13 @@ Enumerates color gradient types. Default is PALETTE_GRADIENT_INTERPOLATING.
 
 Enumerates value_types. Default is PALETTE_GRADIENT_INTERPOLATING.
 
-- <a id="py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_ABSOLUTE"></a>`PALETTE_VALUE_TYPE_ABSOLUTE *= py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_ABSOLUTE*`
-- <a id="py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_PERCENTUAL"></a>`PALETTE_VALUE_TYPE_PERCENTUAL *= py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_PERCENTUAL*`
+<a id="py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_ABSOLUTE"></a>
+
+#### PALETTE_VALUE_TYPE_ABSOLUTE *= py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_ABSOLUTE*
+
+<a id="py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_PERCENTUAL"></a>
+
+#### PALETTE_VALUE_TYPE_PERCENTUAL *= py_monitoring_kernel.PaletteValueType.PALETTE_VALUE_TYPE_PERCENTUAL*
 
 <a id="py_monitoring_kernel.PredefinedColor"></a>
 
@@ -496,17 +1189,49 @@ Enumerates value_types. Default is PALETTE_GRADIENT_INTERPOLATING.
 
 Enumerates predefined colors.
 
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_BLACK"></a>`COLOR_BLACK *= py_monitoring_kernel.PredefinedColor.COLOR_BLACK*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_BLUE"></a>`COLOR_BLUE *= py_monitoring_kernel.PredefinedColor.COLOR_BLUE*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_CYAN"></a>`COLOR_CYAN *= py_monitoring_kernel.PredefinedColor.COLOR_CYAN*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_DEFAULT"></a>`COLOR_DEFAULT *= py_monitoring_kernel.PredefinedColor.COLOR_DEFAULT*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_GREEN"></a>`COLOR_GREEN *= py_monitoring_kernel.PredefinedColor.COLOR_GREEN*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_MAGENTA"></a>`COLOR_MAGENTA *= py_monitoring_kernel.PredefinedColor.COLOR_MAGENTA*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_ORANGE"></a>`COLOR_ORANGE *= py_monitoring_kernel.PredefinedColor.COLOR_ORANGE*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_PINK"></a>`COLOR_PINK *= py_monitoring_kernel.PredefinedColor.COLOR_PINK*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_RED"></a>`COLOR_RED *= py_monitoring_kernel.PredefinedColor.COLOR_RED*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_VIOLET"></a>`COLOR_VIOLET *= py_monitoring_kernel.PredefinedColor.COLOR_VIOLET*`
-- <a id="py_monitoring_kernel.PredefinedColor.COLOR_YELLOW"></a>`COLOR_YELLOW *= py_monitoring_kernel.PredefinedColor.COLOR_YELLOW*`
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_BLACK"></a>
+
+#### COLOR_BLACK *= py_monitoring_kernel.PredefinedColor.COLOR_BLACK*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_BLUE"></a>
+
+#### COLOR_BLUE *= py_monitoring_kernel.PredefinedColor.COLOR_BLUE*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_CYAN"></a>
+
+#### COLOR_CYAN *= py_monitoring_kernel.PredefinedColor.COLOR_CYAN*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_DEFAULT"></a>
+
+#### COLOR_DEFAULT *= py_monitoring_kernel.PredefinedColor.COLOR_DEFAULT*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_GREEN"></a>
+
+#### COLOR_GREEN *= py_monitoring_kernel.PredefinedColor.COLOR_GREEN*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_MAGENTA"></a>
+
+#### COLOR_MAGENTA *= py_monitoring_kernel.PredefinedColor.COLOR_MAGENTA*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_ORANGE"></a>
+
+#### COLOR_ORANGE *= py_monitoring_kernel.PredefinedColor.COLOR_ORANGE*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_PINK"></a>
+
+#### COLOR_PINK *= py_monitoring_kernel.PredefinedColor.COLOR_PINK*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_RED"></a>
+
+#### COLOR_RED *= py_monitoring_kernel.PredefinedColor.COLOR_RED*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_VIOLET"></a>
+
+#### COLOR_VIOLET *= py_monitoring_kernel.PredefinedColor.COLOR_VIOLET*
+
+<a id="py_monitoring_kernel.PredefinedColor.COLOR_YELLOW"></a>
+
+#### COLOR_YELLOW *= py_monitoring_kernel.PredefinedColor.COLOR_YELLOW*
 
 <a id="py_monitoring_kernel.PredefinedStipple"></a>
 
@@ -516,10 +1241,21 @@ Enumerates predefined colors.
 
 Enumerates available style stipplings.
 
-- <a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_DASHED"></a>`STIPPLE_DASHED *= py_monitoring_kernel.PredefinedStipple.STIPPLE_DASHED*`
-- <a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_DOTTED"></a>`STIPPLE_DOTTED *= py_monitoring_kernel.PredefinedStipple.STIPPLE_DOTTED*`
-- <a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_NONE"></a>`STIPPLE_NONE *= py_monitoring_kernel.PredefinedStipple.STIPPLE_NONE*`
-- <a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_SOLID"></a>`STIPPLE_SOLID *= py_monitoring_kernel.PredefinedStipple.STIPPLE_SOLID*`
+<a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_DASHED"></a>
+
+#### STIPPLE_DASHED *= py_monitoring_kernel.PredefinedStipple.STIPPLE_DASHED*
+
+<a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_DOTTED"></a>
+
+#### STIPPLE_DOTTED *= py_monitoring_kernel.PredefinedStipple.STIPPLE_DOTTED*
+
+<a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_NONE"></a>
+
+#### STIPPLE_NONE *= py_monitoring_kernel.PredefinedStipple.STIPPLE_NONE*
+
+<a id="py_monitoring_kernel.PredefinedStipple.STIPPLE_SOLID"></a>
+
+#### STIPPLE_SOLID *= py_monitoring_kernel.PredefinedStipple.STIPPLE_SOLID*
 
 <a id="py_monitoring_kernel.PredefinedSymbol"></a>
 
@@ -529,11 +1265,25 @@ Enumerates available style stipplings.
 
 Enumerates available style symbols.
 
-- <a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_CIRCLE"></a>`SYMBOL_CIRCLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_CIRCLE*`
-- <a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_DIAMOND"></a>`SYMBOL_DIAMOND *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_DIAMOND*`
-- <a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_NONE"></a>`SYMBOL_NONE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_NONE*`
-- <a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_RECTANGLE"></a>`SYMBOL_RECTANGLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_RECTANGLE*`
-- <a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_TRIANGLE"></a>`SYMBOL_TRIANGLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_TRIANGLE*`
+<a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_CIRCLE"></a>
+
+#### SYMBOL_CIRCLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_CIRCLE*
+
+<a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_DIAMOND"></a>
+
+#### SYMBOL_DIAMOND *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_DIAMOND*
+
+<a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_NONE"></a>
+
+#### SYMBOL_NONE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_NONE*
+
+<a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_RECTANGLE"></a>
+
+#### SYMBOL_RECTANGLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_RECTANGLE*
+
+<a id="py_monitoring_kernel.PredefinedSymbol.SYMBOL_TRIANGLE"></a>
+
+#### SYMBOL_TRIANGLE *= py_monitoring_kernel.PredefinedSymbol.SYMBOL_TRIANGLE*
 
 <a id="py_monitoring_kernel.PyControlContainer"></a>
 
@@ -541,24 +1291,64 @@ Enumerates available style symbols.
 
 A (visual) container object, managing and displaying controls.
 
-- <a id="py_monitoring_kernel.PyControlContainer.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_monitoring_kernel.PyControlContainer.__iter__"></a>`__iter__() → object`
-- <a id="py_monitoring_kernel.PyControlContainer.__len__"></a>`__len__() → int`
-- <a id="py_monitoring_kernel.PyControlContainer.add_control"></a>`add_control(arg2: ControlInterface)`
-- <a id="py_monitoring_kernel.PyControlContainer.find_control_by_name"></a>`find_control_by_name(arg2: str) → [ControlInterface](#py_monitoring_kernel.ControlInterface)`<br>
-  Find control by name
-- <a id="py_monitoring_kernel.PyControlContainer.get_control"></a>`get_control(arg2: [Id](#py_monitoring_kernel.Id)) → [ControlInterface](#py_monitoring_kernel.ControlInterface)`<br>
-  Get control by ID
-- <a id="py_monitoring_kernel.PyControlContainer.open"></a>`open(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Open a monitoring database
-- <a id="py_monitoring_kernel.PyControlContainer.remove_all_controls"></a>`remove_all_controls()`<br>
-  Remove all controls from the container
-- <a id="py_monitoring_kernel.PyControlContainer.remove_control"></a>`remove_control(arg2: [Id](#py_monitoring_kernel.Id))`<br>
-  Remove a control from the container
-- <a id="py_monitoring_kernel.PyControlContainer.set_control_visible"></a>`set_control_visible(arg2: [Id](#py_monitoring_kernel.Id), arg3: bool)`<br>
-  Show/Hide a control
-- <a id="py_monitoring_kernel.PyControlContainer.set_positioning"></a>`set_positioning(arg2: Id)`
+<a id="py_monitoring_kernel.PyControlContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_monitoring_kernel.PyControlContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_kernel.PyControlContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_monitoring_kernel.PyControlContainer.add_control"></a>
+
+#### add_control(arg2: ControlInterface)
+
+<a id="py_monitoring_kernel.PyControlContainer.find_control_by_name"></a>
+
+#### find_control_by_name(arg2: str) → [ControlInterface](#py_monitoring_kernel.ControlInterface)
+
+Find control by name
+
+<a id="py_monitoring_kernel.PyControlContainer.get_control"></a>
+
+#### get_control(arg2: [Id](#py_monitoring_kernel.Id)) → [ControlInterface](#py_monitoring_kernel.ControlInterface)
+
+Get control by ID
+
+<a id="py_monitoring_kernel.PyControlContainer.open"></a>
+
+#### open(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Open a monitoring database
+
+<a id="py_monitoring_kernel.PyControlContainer.remove_all_controls"></a>
+
+#### remove_all_controls()
+
+Remove all controls from the container
+
+<a id="py_monitoring_kernel.PyControlContainer.remove_control"></a>
+
+#### remove_control(arg2: [Id](#py_monitoring_kernel.Id))
+
+Remove a control from the container
+
+<a id="py_monitoring_kernel.PyControlContainer.set_control_visible"></a>
+
+#### set_control_visible(arg2: [Id](#py_monitoring_kernel.Id), arg3: bool)
+
+Show/Hide a control
+
+<a id="py_monitoring_kernel.PyControlContainer.set_positioning"></a>
+
+#### set_positioning(arg2: Id)
 
 <a id="py_monitoring_kernel.Stipple"></a>
 
@@ -566,10 +1356,17 @@ A (visual) container object, managing and displaying controls.
 
 Stipple object used to style designs.
 
-- <a id="py_monitoring_kernel.Stipple.__init__"></a>`__init__()`
-- `__init__(arg2: [PredefinedStipple](#py_monitoring_kernel.PredefinedStipple), arg3: float)`
-- <a id="py_monitoring_kernel.Stipple.stipple"></a>*property* `stipple`<br>
-  The actual stipple id.
+<a id="py_monitoring_kernel.Stipple.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [PredefinedStipple](#py_monitoring_kernel.PredefinedStipple), arg3: float)
+
+<a id="py_monitoring_kernel.Stipple.stipple"></a>
+
+#### *property* stipple
+
+The actual stipple id.
 
 <a id="py_monitoring_kernel.Style"></a>
 
@@ -577,26 +1374,57 @@ Stipple object used to style designs.
 
 Style object used to style designs.
 
-- <a id="py_monitoring_kernel.Style.__init__"></a>`__init__()`
-- `__init__(arg2: [Color](#py_monitoring_kernel.Color))`
-- `__init__(arg2: [Color](#py_monitoring_kernel.Color), arg3: [Symbol](#py_monitoring_kernel.Symbol))`
-- `__init__(arg2: [Color](#py_monitoring_kernel.Color), arg3: [Symbol](#py_monitoring_kernel.Symbol), arg4: [Stipple](#py_monitoring_kernel.Stipple))`
-- <a id="py_monitoring_kernel.Style.color"></a>*property* `color`<br>
-  The color of the style.
-- <a id="py_monitoring_kernel.Style.stipple"></a>*property* `stipple`<br>
-  The stipple of the style.
-- <a id="py_monitoring_kernel.Style.symbol"></a>*property* `symbol`<br>
-  The symbol of the style.
+<a id="py_monitoring_kernel.Style.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Color](#py_monitoring_kernel.Color))
+
+#### \_\_init_\_(arg2: [Color](#py_monitoring_kernel.Color), arg3: [Symbol](#py_monitoring_kernel.Symbol))
+
+#### \_\_init_\_(arg2: [Color](#py_monitoring_kernel.Color), arg3: [Symbol](#py_monitoring_kernel.Symbol), arg4: [Stipple](#py_monitoring_kernel.Stipple))
+
+<a id="py_monitoring_kernel.Style.color"></a>
+
+#### *property* color
+
+The color of the style.
+
+<a id="py_monitoring_kernel.Style.stipple"></a>
+
+#### *property* stipple
+
+The stipple of the style.
+
+<a id="py_monitoring_kernel.Style.symbol"></a>
+
+#### *property* symbol
+
+The symbol of the style.
 
 <a id="py_monitoring_kernel.StyleList"></a>
 
 ## *class* py_monitoring_kernel.StyleList
 
-- <a id="py_monitoring_kernel.StyleList.__init__"></a>`__init__()`
-- <a id="py_monitoring_kernel.StyleList.__iter__"></a>`__iter__() → object`
-- <a id="py_monitoring_kernel.StyleList.push_back"></a>`push_back(arg2: [Style](#py_monitoring_kernel.Style))`
-- <a id="py_monitoring_kernel.StyleList.size"></a>`size() → int`
-- <a id="py_monitoring_kernel.StyleList.style_export_list"></a>`style_export_list() → [StyleList](#py_monitoring_kernel.StyleList)`
+<a id="py_monitoring_kernel.StyleList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_monitoring_kernel.StyleList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_monitoring_kernel.StyleList.push_back"></a>
+
+#### push_back(arg2: [Style](#py_monitoring_kernel.Style))
+
+<a id="py_monitoring_kernel.StyleList.size"></a>
+
+#### size() → int
+
+<a id="py_monitoring_kernel.StyleList.style_export_list"></a>
+
+#### style_export_list() → [StyleList](#py_monitoring_kernel.StyleList)
 
 <a id="py_monitoring_kernel.Symbol"></a>
 
@@ -604,10 +1432,17 @@ Style object used to style designs.
 
 Symbol object used to style designs.
 
-- <a id="py_monitoring_kernel.Symbol.__init__"></a>`__init__()`
-- `__init__(arg2: [PredefinedSymbol](#py_monitoring_kernel.PredefinedSymbol), arg3: float)`
-- <a id="py_monitoring_kernel.Symbol.symbol"></a>*property* `symbol`<br>
-  The actual symbol id.
+<a id="py_monitoring_kernel.Symbol.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [PredefinedSymbol](#py_monitoring_kernel.PredefinedSymbol), arg3: float)
+
+<a id="py_monitoring_kernel.Symbol.symbol"></a>
+
+#### *property* symbol
+
+The actual symbol id.
 
 <a id="py_monitoring_kernel.default_style"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_mop_fmu_export.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_mop_fmu_export.md
@@ -6,9 +6,17 @@
 
 **Enumeration**
 
-- <a id="py_mop_fmu_export.activation_option.always"></a>`always *= py_mop_fmu_export.activation_option.always*`
-- <a id="py_mop_fmu_export.activation_option.never"></a>`never *= py_mop_fmu_export.activation_option.never*`
-- <a id="py_mop_fmu_export.activation_option.pin_decides"></a>`pin_decides *= py_mop_fmu_export.activation_option.pin_decides*`
+<a id="py_mop_fmu_export.activation_option.always"></a>
+
+#### always *= py_mop_fmu_export.activation_option.always*
+
+<a id="py_mop_fmu_export.activation_option.never"></a>
+
+#### never *= py_mop_fmu_export.activation_option.never*
+
+<a id="py_mop_fmu_export.activation_option.pin_decides"></a>
+
+#### pin_decides *= py_mop_fmu_export.activation_option.pin_decides*
 
 <a id="py_mop_fmu_export.create_mop_fmu"></a>
 
@@ -20,8 +28,22 @@ creates FMU file from OMDB
 
 ## *class* py_mop_fmu_export.mop_fmu_export_options
 
-- <a id="py_mop_fmu_export.mop_fmu_export_options.enable_criteria"></a>*property* `enable_criteria`
-- <a id="py_mop_fmu_export.mop_fmu_export_options.enable_densities"></a>*property* `enable_densities`
-- <a id="py_mop_fmu_export.mop_fmu_export_options.enable_error_values"></a>*property* `enable_error_values`
-- <a id="py_mop_fmu_export.mop_fmu_export_options.enable_extrapolation"></a>*property* `enable_extrapolation`
-- <a id="py_mop_fmu_export.mop_fmu_export_options.enable_gradients"></a>*property* `enable_gradients`
+<a id="py_mop_fmu_export.mop_fmu_export_options.enable_criteria"></a>
+
+#### *property* enable_criteria
+
+<a id="py_mop_fmu_export.mop_fmu_export_options.enable_densities"></a>
+
+#### *property* enable_densities
+
+<a id="py_mop_fmu_export.mop_fmu_export_options.enable_error_values"></a>
+
+#### *property* enable_error_values
+
+<a id="py_mop_fmu_export.mop_fmu_export_options.enable_extrapolation"></a>
+
+#### *property* enable_extrapolation
+
+<a id="py_mop_fmu_export.mop_fmu_export_options.enable_gradients"></a>
+
+#### *property* enable_gradients

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_omdb.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_omdb.md
@@ -20,96 +20,273 @@ for best_design in omdb.get_best_designs():
 
 ## *class* py_omdb.AttachedPath
 
-- <a id="py_omdb.AttachedPath.__init__"></a>`__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="py_omdb.AttachedPath.auto_insert_placeholders"></a>*property* `auto_insert_placeholders`<br>
-  Automatically detect the design directory format and replace it by a placeholder.
-- <a id="py_omdb.AttachedPath.path"></a>*property* `path`<br>
-  Path to an external file.
-- <a id="py_omdb.AttachedPath.title"></a>*property* `title`<br>
-  User-defined title.
+<a id="py_omdb.AttachedPath.__init__"></a>
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="py_omdb.AttachedPath.auto_insert_placeholders"></a>
+
+#### *property* auto_insert_placeholders
+
+Automatically detect the design directory format and replace it by a placeholder.
+
+<a id="py_omdb.AttachedPath.path"></a>
+
+#### *property* path
+
+Path to an external file.
+
+<a id="py_omdb.AttachedPath.title"></a>
+
+#### *property* title
+
+User-defined title.
 
 <a id="py_omdb.PyOMDB"></a>
 
 ## *class* py_omdb.PyOMDB
 
-- <a id="py_omdb.PyOMDB.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- `__init__(arg2: str)`
-- <a id="py_omdb.PyOMDB.algorithm_info"></a>*property* `algorithm_info`<br>
-  Structure providing information about the underlying algorithm that lead to the results.
-- <a id="py_omdb.PyOMDB.attach_file_path"></a>`attach_file_path(file: [AttachedPath](#py_omdb.AttachedPath))`<br>
-  [0] Attach a path to an external file. [1] Attach a path to an external file by id.
-- `attach_file_path(id: [UUID](id.md#id.UUID), file: [AttachedPath](#py_omdb.AttachedPath))`
-- <a id="py_omdb.PyOMDB.check_consistency"></a>`check_consistency()`<br>
-  Must be called after changes to OMDB.
-- <a id="py_omdb.PyOMDB.clear_meta_data"></a>`clear_meta_data()`<br>
-  Clear the monitoring meta data.
-- <a id="py_omdb.PyOMDB.criteria"></a>*property* `criteria`<br>
-  Criteria contained in monitoring database
-- <a id="py_omdb.PyOMDB.design_container"></a>*property* `design_container`<br>
-  Design container contained in monitoring database
-- <a id="py_omdb.PyOMDB.extract_important_parameter_name_list"></a>`extract_important_parameter_name_list(, design_set: str]) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PyOMDB.get_attached_file_paths"></a>`get_attached_file_paths() → dict`<br>
-  Return a dictionay with ids as keys and attached paths as values.
-- <a id="py_omdb.PyOMDB.get_best_designs"></a>`get_best_designs() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)`<br>
-  Get the best designs. Takes design activation state into account.
-- <a id="py_omdb.PyOMDB.get_best_subspaces"></a>`get_best_subspaces(, design_set: str]) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="py_omdb.PyOMDB.get_build_date"></a>`get_build_date() → str`<br>
-  Return the build date of the application this database file has been created with.
-- <a id="py_omdb.PyOMDB.get_design_duplication"></a>`get_design_duplication(arg2: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → object`
-- `get_design_duplication(arg2: [HID](id.md#id.HID)) → object`
-- <a id="py_omdb.PyOMDB.get_nominal_design"></a>`get_nominal_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`
-- <a id="py_omdb.PyOMDB.get_parameter_names"></a>`get_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PyOMDB.get_reference_design"></a>`get_reference_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)`
-- <a id="py_omdb.PyOMDB.get_response_names"></a>`get_response_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PyOMDB.get_signal_names"></a>`get_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PyOMDB.get_surrogate_info"></a>`get_surrogate_info(, design_set: str]) → [SurrogateInfoContainerList](#py_omdb.SurrogateInfoContainerList)`
-- <a id="py_omdb.PyOMDB.get_surrogate_info_names"></a>`get_surrogate_info_names(, design_set: str]) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PyOMDB.get_version"></a>`get_version() → int`<br>
-  Return the version of the application this database file has been created with in the format 0xMMNNPP (MM = major, NN = minor, PP = maintenance).
-- <a id="py_omdb.PyOMDB.get_version_str"></a>`get_version_str() → str`<br>
-  Return the version of the application this database file has been created with.
-- <a id="py_omdb.PyOMDB.get_version_suffix"></a>`get_version_suffix() → str`<br>
-  Return the version suffix of the application this database file has been created with.
-- <a id="py_omdb.PyOMDB.is_design_active"></a>`is_design_active(design: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → bool`<br>
-  [0] Returns whether a design is active. [1] Returns whether a design is active.
-- `is_design_active(design: [HID](id.md#id.HID)) → bool`
-- <a id="py_omdb.PyOMDB.parameter_manager"></a>*property* `parameter_manager`<br>
-  Parameter manager contained in monitoring database
-- <a id="py_omdb.PyOMDB.remove_file_path"></a>`remove_file_path(id: [UUID](id.md#id.UUID))`<br>
-  Remove attached file path by id.
-- <a id="py_omdb.PyOMDB.save_to_file"></a>`save_to_file(output: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
+<a id="py_omdb.PyOMDB.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: str)
+
+<a id="py_omdb.PyOMDB.algorithm_info"></a>
+
+#### *property* algorithm_info
+
+Structure providing information about the underlying algorithm that lead to the results.
+
+<a id="py_omdb.PyOMDB.attach_file_path"></a>
+
+#### attach_file_path(file: [AttachedPath](#py_omdb.AttachedPath))
+
+#### attach_file_path(id: [UUID](id.md#id.UUID), file: [AttachedPath](#py_omdb.AttachedPath))
+
+[0] Attach a path to an external file.
+
+[1] Attach a path to an external file by id.
+
+<a id="py_omdb.PyOMDB.check_consistency"></a>
+
+#### check_consistency()
+
+Must be called after changes to OMDB.
+
+<a id="py_omdb.PyOMDB.clear_meta_data"></a>
+
+#### clear_meta_data()
+
+Clear the monitoring meta data.
+
+<a id="py_omdb.PyOMDB.criteria"></a>
+
+#### *property* criteria
+
+Criteria contained in monitoring database
+
+<a id="py_omdb.PyOMDB.design_container"></a>
+
+#### *property* design_container
+
+Design container contained in monitoring database
+
+<a id="py_omdb.PyOMDB.extract_important_parameter_name_list"></a>
+
+#### extract_important_parameter_name_list(, design_set: str]) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PyOMDB.get_attached_file_paths"></a>
+
+#### get_attached_file_paths() → dict
+
+Return a dictionay with ids as keys and attached paths as values.
+
+<a id="py_omdb.PyOMDB.get_best_designs"></a>
+
+#### get_best_designs() → [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer)
+
+Get the best designs. Takes design activation state into account.
+
+<a id="py_omdb.PyOMDB.get_best_subspaces"></a>
+
+#### get_best_subspaces(, design_set: str]) → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="py_omdb.PyOMDB.get_build_date"></a>
+
+#### get_build_date() → str
+
+Return the build date of the application this database file has been created with.
+
+<a id="py_omdb.PyOMDB.get_design_duplication"></a>
+
+#### get_design_duplication(arg2: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → object
+
+#### get_design_duplication(arg2: [HID](id.md#id.HID)) → object
+
+<a id="py_omdb.PyOMDB.get_nominal_design"></a>
+
+#### get_nominal_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+<a id="py_omdb.PyOMDB.get_parameter_names"></a>
+
+#### get_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PyOMDB.get_reference_design"></a>
+
+#### get_reference_design() → [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)
+
+<a id="py_omdb.PyOMDB.get_response_names"></a>
+
+#### get_response_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PyOMDB.get_signal_names"></a>
+
+#### get_signal_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PyOMDB.get_surrogate_info"></a>
+
+#### get_surrogate_info(, design_set: str]) → [SurrogateInfoContainerList](#py_omdb.SurrogateInfoContainerList)
+
+<a id="py_omdb.PyOMDB.get_surrogate_info_names"></a>
+
+#### get_surrogate_info_names(, design_set: str]) → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PyOMDB.get_version"></a>
+
+#### get_version() → int
+
+Return the version of the application this database file has been created with in the format 0xMMNNPP (MM = major, NN = minor, PP = maintenance).
+
+<a id="py_omdb.PyOMDB.get_version_str"></a>
+
+#### get_version_str() → str
+
+Return the version of the application this database file has been created with.
+
+<a id="py_omdb.PyOMDB.get_version_suffix"></a>
+
+#### get_version_suffix() → str
+
+Return the version suffix of the application this database file has been created with.
+
+<a id="py_omdb.PyOMDB.is_design_active"></a>
+
+#### is_design_active(design: [PyOSDesign](py_os_design.md#py_os_design.PyOSDesign)) → bool
+
+#### is_design_active(design: [HID](id.md#id.HID)) → bool
+
+[0] Returns whether a design is active.
+
+[1] Returns whether a design is active.
+
+<a id="py_omdb.PyOMDB.parameter_manager"></a>
+
+#### *property* parameter_manager
+
+Parameter manager contained in monitoring database
+
+<a id="py_omdb.PyOMDB.remove_file_path"></a>
+
+#### remove_file_path(id: [UUID](id.md#id.UUID))
+
+Remove attached file path by id.
+
+<a id="py_omdb.PyOMDB.save_to_file"></a>
+
+#### save_to_file(output: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
 
 <a id="py_omdb.PySurrogateInfo"></a>
 
 ## *class* py_omdb.PySurrogateInfo
 
-- <a id="py_omdb.PySurrogateInfo.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_omdb.PySurrogateInfo.get_cop"></a>`get_cop() → float`
-- <a id="py_omdb.PySurrogateInfo.get_important_parameter_names"></a>`get_important_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PySurrogateInfo.get_name"></a>`get_name() → str`
-- <a id="py_omdb.PySurrogateInfo.get_params_sorted_by_cop"></a>`get_params_sorted_by_cop() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)`
-- <a id="py_omdb.PySurrogateInfo.get_response_component_name"></a>`get_response_component_name() → str`
-- <a id="py_omdb.PySurrogateInfo.get_single_cop"></a>`get_single_cop(parameter_name: str) → float`
-- <a id="py_omdb.PySurrogateInfo.get_testing_type"></a>`get_testing_type() → [TestingType](#py_omdb.TestingType)`
-- <a id="py_omdb.PySurrogateInfo.has_cop"></a>`has_cop() → bool`
-- <a id="py_omdb.PySurrogateInfo.has_single_cop"></a>`has_single_cop(parameter_name: str) → bool`
+<a id="py_omdb.PySurrogateInfo.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_omdb.PySurrogateInfo.get_cop"></a>
+
+#### get_cop() → float
+
+<a id="py_omdb.PySurrogateInfo.get_important_parameter_names"></a>
+
+#### get_important_parameter_names() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PySurrogateInfo.get_name"></a>
+
+#### get_name() → str
+
+<a id="py_omdb.PySurrogateInfo.get_params_sorted_by_cop"></a>
+
+#### get_params_sorted_by_cop() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
+
+<a id="py_omdb.PySurrogateInfo.get_response_component_name"></a>
+
+#### get_response_component_name() → str
+
+<a id="py_omdb.PySurrogateInfo.get_single_cop"></a>
+
+#### get_single_cop(parameter_name: str) → float
+
+<a id="py_omdb.PySurrogateInfo.get_testing_type"></a>
+
+#### get_testing_type() → [TestingType](#py_omdb.TestingType)
+
+<a id="py_omdb.PySurrogateInfo.has_cop"></a>
+
+#### has_cop() → bool
+
+<a id="py_omdb.PySurrogateInfo.has_single_cop"></a>
+
+#### has_single_cop(parameter_name: str) → bool
 
 <a id="py_omdb.SurrogateInfoContainerList"></a>
 
 ## *class* py_omdb.SurrogateInfoContainerList
 
-- <a id="py_omdb.SurrogateInfoContainerList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_omdb.SurrogateInfoContainerList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_omdb.SurrogateInfoContainerList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_omdb.SurrogateInfoContainerList.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="py_omdb.SurrogateInfoContainerList.__iter__"></a>`__iter__() → object`
-- <a id="py_omdb.SurrogateInfoContainerList.__len__"></a>`__len__() → int`
-- <a id="py_omdb.SurrogateInfoContainerList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_omdb.SurrogateInfoContainerList.append"></a>`append(arg2: object)`
-- <a id="py_omdb.SurrogateInfoContainerList.extend"></a>`extend(arg2: object)`
+<a id="py_omdb.SurrogateInfoContainerList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_omdb.SurrogateInfoContainerList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_omdb.SurrogateInfoContainerList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_omdb.SurrogateInfoContainerList.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="py_omdb.SurrogateInfoContainerList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_omdb.SurrogateInfoContainerList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_omdb.SurrogateInfoContainerList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_omdb.SurrogateInfoContainerList.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_omdb.SurrogateInfoContainerList.extend"></a>
+
+#### extend(arg2: object)
 
 <a id="py_omdb.TestingType"></a>
 
@@ -117,8 +294,13 @@ for best_design in omdb.get_best_designs():
 
 **Enumeration**
 
-- <a id="py_omdb.TestingType.CROSSVALIDATION"></a>`CROSSVALIDATION *= py_omdb.TestingType.CROSSVALIDATION*`
-- <a id="py_omdb.TestingType.LEAVEONEOUT"></a>`LEAVEONEOUT *= py_omdb.TestingType.LEAVEONEOUT*`
+<a id="py_omdb.TestingType.CROSSVALIDATION"></a>
+
+#### CROSSVALIDATION *= py_omdb.TestingType.CROSSVALIDATION*
+
+<a id="py_omdb.TestingType.LEAVEONEOUT"></a>
+
+#### LEAVEONEOUT *= py_omdb.TestingType.LEAVEONEOUT*
 
 <a id="py_omdb.write_cop_matrix_to_file"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_criterion.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_criterion.md
@@ -29,54 +29,168 @@ print(crit_names)
 
 **Enumeration**
 
-- <a id="py_os_criterion.DesignStatus.EQUAL"></a>`EQUAL *= py_os_criterion.DesignStatus.EQUAL*`
-- <a id="py_os_criterion.DesignStatus.GREATEREQUAL"></a>`GREATEREQUAL *= py_os_criterion.DesignStatus.GREATEREQUAL*`
-- <a id="py_os_criterion.DesignStatus.GREATERLIMITSTATE"></a>`GREATERLIMITSTATE *= py_os_criterion.DesignStatus.GREATERLIMITSTATE*`
-- <a id="py_os_criterion.DesignStatus.IGNORE"></a>`IGNORE *= py_os_criterion.DesignStatus.IGNORE*`
-- <a id="py_os_criterion.DesignStatus.LESSEQUAL"></a>`LESSEQUAL *= py_os_criterion.DesignStatus.LESSEQUAL*`
-- <a id="py_os_criterion.DesignStatus.LESSLIMITSTATE"></a>`LESSLIMITSTATE *= py_os_criterion.DesignStatus.LESSLIMITSTATE*`
-- <a id="py_os_criterion.DesignStatus.MAX"></a>`MAX *= py_os_criterion.DesignStatus.MAX*`
-- <a id="py_os_criterion.DesignStatus.MIN"></a>`MIN *= py_os_criterion.DesignStatus.MIN*`
+<a id="py_os_criterion.DesignStatus.EQUAL"></a>
+
+#### EQUAL *= py_os_criterion.DesignStatus.EQUAL*
+
+<a id="py_os_criterion.DesignStatus.GREATEREQUAL"></a>
+
+#### GREATEREQUAL *= py_os_criterion.DesignStatus.GREATEREQUAL*
+
+<a id="py_os_criterion.DesignStatus.GREATERLIMITSTATE"></a>
+
+#### GREATERLIMITSTATE *= py_os_criterion.DesignStatus.GREATERLIMITSTATE*
+
+<a id="py_os_criterion.DesignStatus.IGNORE"></a>
+
+#### IGNORE *= py_os_criterion.DesignStatus.IGNORE*
+
+<a id="py_os_criterion.DesignStatus.LESSEQUAL"></a>
+
+#### LESSEQUAL *= py_os_criterion.DesignStatus.LESSEQUAL*
+
+<a id="py_os_criterion.DesignStatus.LESSLIMITSTATE"></a>
+
+#### LESSLIMITSTATE *= py_os_criterion.DesignStatus.LESSLIMITSTATE*
+
+<a id="py_os_criterion.DesignStatus.MAX"></a>
+
+#### MAX *= py_os_criterion.DesignStatus.MAX*
+
+<a id="py_os_criterion.DesignStatus.MIN"></a>
+
+#### MIN *= py_os_criterion.DesignStatus.MIN*
 
 <a id="py_os_criterion.PyOSCriterion"></a>
 
 ## *class* py_os_criterion.PyOSCriterion
 
-- <a id="py_os_criterion.PyOSCriterion.__init__"></a>`__init__()`
-- `__init__(arg2: [DesignStatus](#py_os_criterion.DesignStatus), arg3: str)`
-- `__init__(arg2: [DesignStatus](#py_os_criterion.DesignStatus), arg3: str, arg4: str)`
-- <a id="py_os_criterion.PyOSCriterion.get_expression"></a>`get_expression() → str`
-- <a id="py_os_criterion.PyOSCriterion.get_float_value"></a>`get_float_value() → float`
-- <a id="py_os_criterion.PyOSCriterion.get_left_expression"></a>`get_left_expression() → str`
-- <a id="py_os_criterion.PyOSCriterion.get_right_expression"></a>`get_right_expression() → str`
-- <a id="py_os_criterion.PyOSCriterion.get_type"></a>`get_type() → [DesignStatus](#py_os_criterion.DesignStatus)`
-- <a id="py_os_criterion.PyOSCriterion.get_value"></a>`get_value() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_criterion.PyOSCriterion.is_constraint"></a>`is_constraint() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_equal_zero"></a>`is_equal_zero() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_equality_constraint"></a>`is_equality_constraint() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_equality_constraint_violated"></a>`is_equality_constraint_violated() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_inequality_constraint"></a>`is_inequality_constraint() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_inequality_constraint_violated"></a>`is_inequality_constraint_violated() → bool`
-- <a id="py_os_criterion.PyOSCriterion.is_objective"></a>`is_objective() → bool`
-- <a id="py_os_criterion.PyOSCriterion.needs_eval"></a>`needs_eval() → bool`
-- <a id="py_os_criterion.PyOSCriterion.set_constraint"></a>`set_constraint(type: [DesignStatus](#py_os_criterion.DesignStatus), expression_left: str, expression_right: str)`
-- <a id="py_os_criterion.PyOSCriterion.set_left"></a>`set_left(expression: str)`
-- <a id="py_os_criterion.PyOSCriterion.set_objective"></a>`set_objective(type: [DesignStatus](#py_os_criterion.DesignStatus), expression: str)`
-- <a id="py_os_criterion.PyOSCriterion.set_right"></a>`set_right(expression: str)`
-- <a id="py_os_criterion.PyOSCriterion.set_type"></a>`set_type(type: [DesignStatus](#py_os_criterion.DesignStatus))`
-- <a id="py_os_criterion.PyOSCriterion.set_value"></a>`set_value(value: float)`
-- `set_value(value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`
+<a id="py_os_criterion.PyOSCriterion.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [DesignStatus](#py_os_criterion.DesignStatus), arg3: str)
+
+#### \_\_init_\_(arg2: [DesignStatus](#py_os_criterion.DesignStatus), arg3: str, arg4: str)
+
+<a id="py_os_criterion.PyOSCriterion.get_expression"></a>
+
+#### get_expression() → str
+
+<a id="py_os_criterion.PyOSCriterion.get_float_value"></a>
+
+#### get_float_value() → float
+
+<a id="py_os_criterion.PyOSCriterion.get_left_expression"></a>
+
+#### get_left_expression() → str
+
+<a id="py_os_criterion.PyOSCriterion.get_right_expression"></a>
+
+#### get_right_expression() → str
+
+<a id="py_os_criterion.PyOSCriterion.get_type"></a>
+
+#### get_type() → [DesignStatus](#py_os_criterion.DesignStatus)
+
+<a id="py_os_criterion.PyOSCriterion.get_value"></a>
+
+#### get_value() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_criterion.PyOSCriterion.is_constraint"></a>
+
+#### is_constraint() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_equal_zero"></a>
+
+#### is_equal_zero() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_equality_constraint"></a>
+
+#### is_equality_constraint() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_equality_constraint_violated"></a>
+
+#### is_equality_constraint_violated() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_inequality_constraint"></a>
+
+#### is_inequality_constraint() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_inequality_constraint_violated"></a>
+
+#### is_inequality_constraint_violated() → bool
+
+<a id="py_os_criterion.PyOSCriterion.is_objective"></a>
+
+#### is_objective() → bool
+
+<a id="py_os_criterion.PyOSCriterion.needs_eval"></a>
+
+#### needs_eval() → bool
+
+<a id="py_os_criterion.PyOSCriterion.set_constraint"></a>
+
+#### set_constraint(type: [DesignStatus](#py_os_criterion.DesignStatus), expression_left: str, expression_right: str)
+
+<a id="py_os_criterion.PyOSCriterion.set_left"></a>
+
+#### set_left(expression: str)
+
+<a id="py_os_criterion.PyOSCriterion.set_objective"></a>
+
+#### set_objective(type: [DesignStatus](#py_os_criterion.DesignStatus), expression: str)
+
+<a id="py_os_criterion.PyOSCriterion.set_right"></a>
+
+#### set_right(expression: str)
+
+<a id="py_os_criterion.PyOSCriterion.set_type"></a>
+
+#### set_type(type: [DesignStatus](#py_os_criterion.DesignStatus))
+
+<a id="py_os_criterion.PyOSCriterion.set_value"></a>
+
+#### set_value(value: float)
+
+#### set_value(value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
 
 <a id="py_os_criterion.PyOSCriterionContainer"></a>
 
 ## *class* py_os_criterion.PyOSCriterionContainer
 
-- <a id="py_os_criterion.PyOSCriterionContainer.__getitem__"></a>`__getitem__(arg2: str) → [PyOSCriterion](#py_os_criterion.PyOSCriterion)`
-- <a id="py_os_criterion.PyOSCriterionContainer.__init__"></a>`__init__()`
-- <a id="py_os_criterion.PyOSCriterionContainer.__iter__"></a>`__iter__() → object`
-- <a id="py_os_criterion.PyOSCriterionContainer.__len__"></a>`__len__() → int`
-- <a id="py_os_criterion.PyOSCriterionContainer.__setitem__"></a>`__setitem__(arg2: str) → [PyOSCriterion](#py_os_criterion.PyOSCriterion)`
-- <a id="py_os_criterion.PyOSCriterionContainer.add"></a>`add(name: str, value: [PyOSCriterion](#py_os_criterion.PyOSCriterion))`
-- <a id="py_os_criterion.PyOSCriterionContainer.add_expression"></a>`add_expression(name: str, value: [PyOSCriterion](#py_os_criterion.PyOSCriterion))`
-- <a id="py_os_criterion.PyOSCriterionContainer.remove"></a>`remove(name: str)`
-- <a id="py_os_criterion.PyOSCriterionContainer.remove_expression"></a>`remove_expression(name: str)`
+<a id="py_os_criterion.PyOSCriterionContainer.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: str) → [PyOSCriterion](#py_os_criterion.PyOSCriterion)
+
+<a id="py_os_criterion.PyOSCriterionContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_criterion.PyOSCriterionContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_criterion.PyOSCriterionContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_criterion.PyOSCriterionContainer.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: str) → [PyOSCriterion](#py_os_criterion.PyOSCriterion)
+
+<a id="py_os_criterion.PyOSCriterionContainer.add"></a>
+
+#### add(name: str, value: [PyOSCriterion](#py_os_criterion.PyOSCriterion))
+
+<a id="py_os_criterion.PyOSCriterionContainer.add_expression"></a>
+
+#### add_expression(name: str, value: [PyOSCriterion](#py_os_criterion.PyOSCriterion))
+
+<a id="py_os_criterion.PyOSCriterionContainer.remove"></a>
+
+#### remove(name: str)
+
+<a id="py_os_criterion.PyOSCriterionContainer.remove_expression"></a>
+
+#### remove_expression(name: str)

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_design.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_design.md
@@ -88,55 +88,83 @@ db_file.save_to_file(os.path.join(OSL_PROJECT_DIR, 'my_design_data.omdb')
 
 ## *class* py_os_design.DesignExporterCSV
 
-- <a id="py_os_design.DesignExporterCSV.__init__"></a>`__init__()`
+<a id="py_os_design.DesignExporterCSV.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignExporterGeneric"></a>
 
 ## *class* py_os_design.DesignExporterGeneric
 
-- <a id="py_os_design.DesignExporterGeneric.__call__"></a>`__call__(path: [PyOSDesign](#py_os_design.PyOSDesign), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool`
-- `__call__(path: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool`
-- <a id="py_os_design.DesignExporterGeneric.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="py_os_design.DesignExporterGeneric.__call__"></a>
+
+#### \_\_call_\_(path: [PyOSDesign](#py_os_design.PyOSDesign), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
+
+#### \_\_call_\_(path: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
+
+<a id="py_os_design.DesignExporterGeneric.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="py_os_design.DesignExporterJson"></a>
 
 ## *class* py_os_design.DesignExporterJson
 
-- <a id="py_os_design.DesignExporterJson.__init__"></a>`__init__()`
+<a id="py_os_design.DesignExporterJson.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignExporterOIA"></a>
 
 ## *class* py_os_design.DesignExporterOIA
 
-- <a id="py_os_design.DesignExporterOIA.__init__"></a>`__init__()`
+<a id="py_os_design.DesignExporterOIA.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignImporterCSV"></a>
 
 ## *class* py_os_design.DesignImporterCSV
 
-- <a id="py_os_design.DesignImporterCSV.__init__"></a>`__init__()`
+<a id="py_os_design.DesignImporterCSV.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignImporterGeneric"></a>
 
 ## *class* py_os_design.DesignImporterGeneric
 
-- <a id="py_os_design.DesignImporterGeneric.__call__"></a>`__call__(inputs: [PyOSDesign](#py_os_design.PyOSDesign), criteria: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint), path: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool`
-- `__call__(inputs: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer), criteria: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint), path: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool`
-- <a id="py_os_design.DesignImporterGeneric.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
+<a id="py_os_design.DesignImporterGeneric.__call__"></a>
+
+#### \_\_call_\_(inputs: [PyOSDesign](#py_os_design.PyOSDesign), criteria: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint), path: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
+
+#### \_\_call_\_(inputs: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer), criteria: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint), path: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer), logger: [Path](stdcpp_python_export.md#stdcpp_python_export.Path)) → bool
+
+<a id="py_os_design.DesignImporterGeneric.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
 
 <a id="py_os_design.DesignImporterJson"></a>
 
 ## *class* py_os_design.DesignImporterJson
 
-- <a id="py_os_design.DesignImporterJson.__init__"></a>`__init__()`
+<a id="py_os_design.DesignImporterJson.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignImporterOIA"></a>
 
 ## *class* py_os_design.DesignImporterOIA
 
-- <a id="py_os_design.DesignImporterOIA.__init__"></a>`__init__()`
+<a id="py_os_design.DesignImporterOIA.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.DesignRunStatus"></a>
 
@@ -144,9 +172,17 @@ db_file.save_to_file(os.path.join(OSL_PROJECT_DIR, 'my_design_data.omdb')
 
 **Enumeration**
 
-- <a id="py_os_design.DesignRunStatus.AWAITING"></a>`AWAITING *= py_os_design.DesignRunStatus.AWAITING*`
-- <a id="py_os_design.DesignRunStatus.DONE"></a>`DONE *= py_os_design.DesignRunStatus.DONE*`
-- <a id="py_os_design.DesignRunStatus.INPROCESS"></a>`INPROCESS *= py_os_design.DesignRunStatus.INPROCESS*`
+<a id="py_os_design.DesignRunStatus.AWAITING"></a>
+
+#### AWAITING *= py_os_design.DesignRunStatus.AWAITING*
+
+<a id="py_os_design.DesignRunStatus.DONE"></a>
+
+#### DONE *= py_os_design.DesignRunStatus.DONE*
+
+<a id="py_os_design.DesignRunStatus.INPROCESS"></a>
+
+#### INPROCESS *= py_os_design.DesignRunStatus.INPROCESS*
 
 <a id="py_os_design.DesignStatus"></a>
 
@@ -154,11 +190,25 @@ db_file.save_to_file(os.path.join(OSL_PROJECT_DIR, 'my_design_data.omdb')
 
 **Enumeration**
 
-- <a id="py_os_design.DesignStatus.CRITERIA_FAIL"></a>`CRITERIA_FAIL *= py_os_design.DesignStatus.CRITERIA_FAIL*`
-- <a id="py_os_design.DesignStatus.NO_FAIL"></a>`NO_FAIL *= py_os_design.DesignStatus.NO_FAIL*`
-- <a id="py_os_design.DesignStatus.NO_SOLVER_FAIL"></a>`NO_SOLVER_FAIL *= py_os_design.DesignStatus.NO_SOLVER_FAIL*`
-- <a id="py_os_design.DesignStatus.RESPONSE_NAN"></a>`RESPONSE_NAN *= py_os_design.DesignStatus.RESPONSE_NAN*`
-- <a id="py_os_design.DesignStatus.SOLVER_FAIL"></a>`SOLVER_FAIL *= py_os_design.DesignStatus.SOLVER_FAIL*`
+<a id="py_os_design.DesignStatus.CRITERIA_FAIL"></a>
+
+#### CRITERIA_FAIL *= py_os_design.DesignStatus.CRITERIA_FAIL*
+
+<a id="py_os_design.DesignStatus.NO_FAIL"></a>
+
+#### NO_FAIL *= py_os_design.DesignStatus.NO_FAIL*
+
+<a id="py_os_design.DesignStatus.NO_SOLVER_FAIL"></a>
+
+#### NO_SOLVER_FAIL *= py_os_design.DesignStatus.NO_SOLVER_FAIL*
+
+<a id="py_os_design.DesignStatus.RESPONSE_NAN"></a>
+
+#### RESPONSE_NAN *= py_os_design.DesignStatus.RESPONSE_NAN*
+
+<a id="py_os_design.DesignStatus.SOLVER_FAIL"></a>
+
+#### SOLVER_FAIL *= py_os_design.DesignStatus.SOLVER_FAIL*
 
 <a id="py_os_design.EntryType"></a>
 
@@ -166,12 +216,29 @@ db_file.save_to_file(os.path.join(OSL_PROJECT_DIR, 'my_design_data.omdb')
 
 **Enumeration**
 
-- <a id="py_os_design.EntryType.BOOL"></a>`BOOL *= py_os_design.EntryType.BOOL*`
-- <a id="py_os_design.EntryType.INTEGER"></a>`INTEGER *= py_os_design.EntryType.INTEGER*`
-- <a id="py_os_design.EntryType.REAL"></a>`REAL *= py_os_design.EntryType.REAL*`
-- <a id="py_os_design.EntryType.STRING"></a>`STRING *= py_os_design.EntryType.STRING*`
-- <a id="py_os_design.EntryType.UNINITIALIZED"></a>`UNINITIALIZED *= py_os_design.EntryType.UNINITIALIZED*`
-- <a id="py_os_design.EntryType.VARIANT"></a>`VARIANT *= py_os_design.EntryType.VARIANT*`
+<a id="py_os_design.EntryType.BOOL"></a>
+
+#### BOOL *= py_os_design.EntryType.BOOL*
+
+<a id="py_os_design.EntryType.INTEGER"></a>
+
+#### INTEGER *= py_os_design.EntryType.INTEGER*
+
+<a id="py_os_design.EntryType.REAL"></a>
+
+#### REAL *= py_os_design.EntryType.REAL*
+
+<a id="py_os_design.EntryType.STRING"></a>
+
+#### STRING *= py_os_design.EntryType.STRING*
+
+<a id="py_os_design.EntryType.UNINITIALIZED"></a>
+
+#### UNINITIALIZED *= py_os_design.EntryType.UNINITIALIZED*
+
+<a id="py_os_design.EntryType.VARIANT"></a>
+
+#### VARIANT *= py_os_design.EntryType.VARIANT*
 
 <a id="py_os_design.PyOSDesign"></a>
 
@@ -179,54 +246,191 @@ db_file.save_to_file(os.path.join(OSL_PROJECT_DIR, 'my_design_data.omdb')
 
 Represents a single design in a DOE. Usually consists of parameters, responses, criteria and additional status information.
 
-- <a id="py_os_design.PyOSDesign.IsDuplicated"></a>`IsDuplicated() → bool`
-- <a id="py_os_design.PyOSDesign.__init__"></a>`__init__()`
-- <a id="py_os_design.PyOSDesign.add_missing_criteria"></a>`add_missing_criteria(reference: [PyOSDesign](#py_os_design.PyOSDesign))`<br>
-  Add criteria from reference that are not defined in self.
-- <a id="py_os_design.PyOSDesign.add_missing_parameters"></a>`add_missing_parameters(reference: [PyOSDesign](#py_os_design.PyOSDesign))`<br>
-  Add parameters from reference that are not defined in self.
-- <a id="py_os_design.PyOSDesign.add_missing_responses"></a>`add_missing_responses(reference: [PyOSDesign](#py_os_design.PyOSDesign))`<br>
-  Add responses from reference that are not defined in self.
-- <a id="py_os_design.PyOSDesign.add_status"></a>`add_status(status: [RunInfoMeta](#py_os_design.RunInfoMeta))`
-- <a id="py_os_design.PyOSDesign.dominates"></a>`dominates(design: [PyOSDesign](#py_os_design.PyOSDesign)) → bool`<br>
-  Whether the provided design dominates this design regarding fulfilment of criteria.
-- <a id="py_os_design.PyOSDesign.get_algorithm_iteration"></a>`get_algorithm_iteration() → int`
-- <a id="py_os_design.PyOSDesign.get_criteria"></a>`get_criteria() → [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)`
-- <a id="py_os_design.PyOSDesign.get_design_leaf_number"></a>`get_design_leaf_number() → int`<br>
-  Return the leaf number of the design’s ID.
-- <a id="py_os_design.PyOSDesign.get_design_type"></a>`get_design_type() → [DesignTypes](dynardo_py_algorithms.md#dynardo_py_algorithms.DesignTypes)`
-- <a id="py_os_design.PyOSDesign.get_id"></a>`get_id() → [HID](id.md#id.HID)`
-- <a id="py_os_design.PyOSDesign.get_parameters"></a>`get_parameters() → [PyOSDesignPoint](#py_os_design.PyOSDesignPoint)`<br>
-  ```python for name, value in design.get_parameters(): print(name, value.get()) ```
-- <a id="py_os_design.PyOSDesign.get_responses"></a>`get_responses() → [PyOSDesignPoint](#py_os_design.PyOSDesignPoint)`<br>
-  ```python for name, value in design.get_responses(): print(name, value.get_scalar()) ```
-- <a id="py_os_design.PyOSDesign.get_run_status"></a>`get_run_status() → [DesignRunStatus](#py_os_design.DesignRunStatus)`
-- <a id="py_os_design.PyOSDesign.get_status"></a>`get_status() → [RunInfoContainer](#py_os_design.RunInfoContainer)`
-- <a id="py_os_design.PyOSDesign.get_workflow_id"></a>`get_workflow_id() → [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms)`
-- <a id="py_os_design.PyOSDesign.has_error_state"></a>`has_error_state() → bool`
-- <a id="py_os_design.PyOSDesign.is_active"></a>`is_active() → bool`
-- <a id="py_os_design.PyOSDesign.is_awaiting"></a>`is_awaiting() → bool`
-- <a id="py_os_design.PyOSDesign.is_done"></a>`is_done() → bool`
-- <a id="py_os_design.PyOSDesign.is_failed"></a>`is_failed() → bool`
-- <a id="py_os_design.PyOSDesign.is_feasible"></a>`is_feasible() → object`<br>
-  Return True if the design is feasible. Return False if it is not. Return None if feasibility is unknown.
-- <a id="py_os_design.PyOSDesign.is_incomplete"></a>`is_incomplete() → bool`
-- <a id="py_os_design.PyOSDesign.is_succeeded"></a>`is_succeeded() → bool`
-- <a id="py_os_design.PyOSDesign.is_violated"></a>`is_violated() → bool`
-- <a id="py_os_design.PyOSDesign.needs_reevaluation"></a>`needs_reevaluation() → bool`
-- <a id="py_os_design.PyOSDesign.set_awaiting"></a>`set_awaiting()`
-- <a id="py_os_design.PyOSDesign.set_criteria"></a>`set_criteria(criteria: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer))`
-- <a id="py_os_design.PyOSDesign.set_design_type"></a>`set_design_type(type: [DesignTypes](dynardo_py_algorithms.md#dynardo_py_algorithms.DesignTypes))`
-- <a id="py_os_design.PyOSDesign.set_duplication"></a>`set_duplication(id: [HID](id.md#id.HID))`<br>
-  Specifiy a duplicate of this design.
-- <a id="py_os_design.PyOSDesign.set_id"></a>`set_id(id: [HID](id.md#id.HID))`
-- <a id="py_os_design.PyOSDesign.set_number"></a>`set_number(number: int)`
-- <a id="py_os_design.PyOSDesign.set_parameters"></a>`set_parameters(parameters: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))`<br>
-  ```python design = PyOSDesign() params = PyOSDesignPoint() params.add("input", 5) design.set_parameters(params) ```
-- <a id="py_os_design.PyOSDesign.set_responses"></a>`set_responses(responses: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))`<br>
-  ```python design = PyOSDesign() responses = PyOSDesignPoint() responses.add("output", 200) design.set_responses(responses) ```
-- <a id="py_os_design.PyOSDesign.set_run_status"></a>`set_run_status(status: [DesignRunStatus](#py_os_design.DesignRunStatus))`
-- <a id="py_os_design.PyOSDesign.set_workflow_id"></a>`set_workflow_id(id: [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms))`
+<a id="py_os_design.PyOSDesign.IsDuplicated"></a>
+
+#### IsDuplicated() → bool
+
+<a id="py_os_design.PyOSDesign.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.PyOSDesign.add_missing_criteria"></a>
+
+#### add_missing_criteria(reference: [PyOSDesign](#py_os_design.PyOSDesign))
+
+Add criteria from reference that are not defined in self.
+
+<a id="py_os_design.PyOSDesign.add_missing_parameters"></a>
+
+#### add_missing_parameters(reference: [PyOSDesign](#py_os_design.PyOSDesign))
+
+Add parameters from reference that are not defined in self.
+
+<a id="py_os_design.PyOSDesign.add_missing_responses"></a>
+
+#### add_missing_responses(reference: [PyOSDesign](#py_os_design.PyOSDesign))
+
+Add responses from reference that are not defined in self.
+
+<a id="py_os_design.PyOSDesign.add_status"></a>
+
+#### add_status(status: [RunInfoMeta](#py_os_design.RunInfoMeta))
+
+<a id="py_os_design.PyOSDesign.dominates"></a>
+
+#### dominates(design: [PyOSDesign](#py_os_design.PyOSDesign)) → bool
+
+Whether the provided design dominates this design regarding fulfilment of criteria.
+
+<a id="py_os_design.PyOSDesign.get_algorithm_iteration"></a>
+
+#### get_algorithm_iteration() → int
+
+<a id="py_os_design.PyOSDesign.get_criteria"></a>
+
+#### get_criteria() → [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer)
+
+<a id="py_os_design.PyOSDesign.get_design_leaf_number"></a>
+
+#### get_design_leaf_number() → int
+
+Return the leaf number of the design’s ID.
+
+<a id="py_os_design.PyOSDesign.get_design_type"></a>
+
+#### get_design_type() → [DesignTypes](dynardo_py_algorithms.md#dynardo_py_algorithms.DesignTypes)
+
+<a id="py_os_design.PyOSDesign.get_id"></a>
+
+#### get_id() → [HID](id.md#id.HID)
+
+<a id="py_os_design.PyOSDesign.get_parameters"></a>
+
+#### get_parameters() → [PyOSDesignPoint](#py_os_design.PyOSDesignPoint)
+
+```python
+for name, value in design.get_parameters():
+    print(name, value.get())
+```
+
+<a id="py_os_design.PyOSDesign.get_responses"></a>
+
+#### get_responses() → [PyOSDesignPoint](#py_os_design.PyOSDesignPoint)
+
+```python
+for name, value in design.get_responses():
+    print(name, value.get_scalar())
+```
+
+<a id="py_os_design.PyOSDesign.get_run_status"></a>
+
+#### get_run_status() → [DesignRunStatus](#py_os_design.DesignRunStatus)
+
+<a id="py_os_design.PyOSDesign.get_status"></a>
+
+#### get_status() → [RunInfoContainer](#py_os_design.RunInfoContainer)
+
+<a id="py_os_design.PyOSDesign.get_workflow_id"></a>
+
+#### get_workflow_id() → [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms)
+
+<a id="py_os_design.PyOSDesign.has_error_state"></a>
+
+#### has_error_state() → bool
+
+<a id="py_os_design.PyOSDesign.is_active"></a>
+
+#### is_active() → bool
+
+<a id="py_os_design.PyOSDesign.is_awaiting"></a>
+
+#### is_awaiting() → bool
+
+<a id="py_os_design.PyOSDesign.is_done"></a>
+
+#### is_done() → bool
+
+<a id="py_os_design.PyOSDesign.is_failed"></a>
+
+#### is_failed() → bool
+
+<a id="py_os_design.PyOSDesign.is_feasible"></a>
+
+#### is_feasible() → object
+
+Return True if the design is feasible. Return False if it is not. Return None if feasibility is unknown.
+
+<a id="py_os_design.PyOSDesign.is_incomplete"></a>
+
+#### is_incomplete() → bool
+
+<a id="py_os_design.PyOSDesign.is_succeeded"></a>
+
+#### is_succeeded() → bool
+
+<a id="py_os_design.PyOSDesign.is_violated"></a>
+
+#### is_violated() → bool
+
+<a id="py_os_design.PyOSDesign.needs_reevaluation"></a>
+
+#### needs_reevaluation() → bool
+
+<a id="py_os_design.PyOSDesign.set_awaiting"></a>
+
+#### set_awaiting()
+
+<a id="py_os_design.PyOSDesign.set_criteria"></a>
+
+#### set_criteria(criteria: [PyOSCriterionContainer](py_os_criterion.md#py_os_criterion.PyOSCriterionContainer))
+
+<a id="py_os_design.PyOSDesign.set_design_type"></a>
+
+#### set_design_type(type: [DesignTypes](dynardo_py_algorithms.md#dynardo_py_algorithms.DesignTypes))
+
+<a id="py_os_design.PyOSDesign.set_duplication"></a>
+
+#### set_duplication(id: [HID](id.md#id.HID))
+
+Specifiy a duplicate of this design.
+
+<a id="py_os_design.PyOSDesign.set_id"></a>
+
+#### set_id(id: [HID](id.md#id.HID))
+
+<a id="py_os_design.PyOSDesign.set_number"></a>
+
+#### set_number(number: int)
+
+<a id="py_os_design.PyOSDesign.set_parameters"></a>
+
+#### set_parameters(parameters: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))
+
+```python
+design = PyOSDesign()
+params = PyOSDesignPoint()
+params.add("input", 5)
+design.set_parameters(params)
+```
+
+<a id="py_os_design.PyOSDesign.set_responses"></a>
+
+#### set_responses(responses: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))
+
+```python
+design = PyOSDesign()
+responses = PyOSDesignPoint()
+responses.add("output", 200)
+design.set_responses(responses)
+```
+
+<a id="py_os_design.PyOSDesign.set_run_status"></a>
+
+#### set_run_status(status: [DesignRunStatus](#py_os_design.DesignRunStatus))
+
+<a id="py_os_design.PyOSDesign.set_workflow_id"></a>
+
+#### set_workflow_id(id: [SupportedAlgorithms](dynardo_py_algorithms.md#dynardo_py_algorithms.SupportedAlgorithms))
 
 <a id="py_os_design.PyOSDesignContainer"></a>
 
@@ -239,18 +443,53 @@ for des in design_container:
     print(des.is_succeeded())
 ```
 
-- <a id="py_os_design.PyOSDesignContainer.__init__"></a>`__init__()`
-- <a id="py_os_design.PyOSDesignContainer.__iter__"></a>`__iter__() → object`
-- <a id="py_os_design.PyOSDesignContainer.__len__"></a>`__len__() → int`
-- <a id="py_os_design.PyOSDesignContainer.append_designs"></a>`append_designs(designs: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer))`
-- <a id="py_os_design.PyOSDesignContainer.get_best_designs"></a>`get_best_designs() → [PyOSDesignContainer](#py_os_design.PyOSDesignContainer)`
-- <a id="py_os_design.PyOSDesignContainer.get_design"></a>`get_design(id: HID) → [PyOSDesign](#py_os_design.PyOSDesign)`
-- <a id="py_os_design.PyOSDesignContainer.has_design"></a>`has_design(id: HID) → bool`
-- <a id="py_os_design.PyOSDesignContainer.push_back"></a>`push_back(design: [PyOSDesign](#py_os_design.PyOSDesign))`
-- <a id="py_os_design.PyOSDesignContainer.rename_parameter"></a>`rename_parameter(from: str, to: str, adapt_criteria: bool)`
-- <a id="py_os_design.PyOSDesignContainer.rename_response"></a>`rename_response(from: str, to: str, adapt_criteria: bool)`
-- <a id="py_os_design.PyOSDesignContainer.set_design_awaiting"></a>`set_design_awaiting(id: [HID](id.md#id.HID))`
-- <a id="py_os_design.PyOSDesignContainer.set_designs_done"></a>`set_designs_done(, force: bool=False])`
+<a id="py_os_design.PyOSDesignContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.PyOSDesignContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.PyOSDesignContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.PyOSDesignContainer.append_designs"></a>
+
+#### append_designs(designs: [PyOSDesignContainer](#py_os_design.PyOSDesignContainer))
+
+<a id="py_os_design.PyOSDesignContainer.get_best_designs"></a>
+
+#### get_best_designs() → [PyOSDesignContainer](#py_os_design.PyOSDesignContainer)
+
+<a id="py_os_design.PyOSDesignContainer.get_design"></a>
+
+#### get_design(id: HID) → [PyOSDesign](#py_os_design.PyOSDesign)
+
+<a id="py_os_design.PyOSDesignContainer.has_design"></a>
+
+#### has_design(id: HID) → bool
+
+<a id="py_os_design.PyOSDesignContainer.push_back"></a>
+
+#### push_back(design: [PyOSDesign](#py_os_design.PyOSDesign))
+
+<a id="py_os_design.PyOSDesignContainer.rename_parameter"></a>
+
+#### rename_parameter(from: str, to: str, adapt_criteria: bool)
+
+<a id="py_os_design.PyOSDesignContainer.rename_response"></a>
+
+#### rename_response(from: str, to: str, adapt_criteria: bool)
+
+<a id="py_os_design.PyOSDesignContainer.set_design_awaiting"></a>
+
+#### set_design_awaiting(id: [HID](id.md#id.HID))
+
+<a id="py_os_design.PyOSDesignContainer.set_designs_done"></a>
+
+#### set_designs_done(, force: bool=False])
 
 <a id="py_os_design.PyOSDesignEntry"></a>
 
@@ -263,29 +502,71 @@ entry = PyOSDesignEntry(3.5)
 entry.get_scalar().real
 ```
 
-- <a id="py_os_design.PyOSDesignEntry.__init__"></a>`__init__()`<br>
-  [1] Create a design entry by passing a builtin Python type. Accepted types are str, int, bool and float.
-- `__init__(arg2: object) → object`
-- `__init__(arg2: [UninitializedType](#py_os_design.UninitializedType))`
-- `__init__(arg2: [VariantD](pyvariant.md#pyvariant.VariantD))`
-- <a id="py_os_design.PyOSDesignEntry.get"></a>`get() → object`<br>
-  Extract as Python bultin type.
-- <a id="py_os_design.PyOSDesignEntry.get_domain_type"></a>`get_domain_type() → [EntryType](#py_os_design.EntryType)`<br>
-  Get the entry’s domain type.
-- <a id="py_os_design.PyOSDesignEntry.get_scalar"></a>`get_scalar() → complex`<br>
-  Try to extract as scalar.
-- <a id="py_os_design.PyOSDesignEntry.get_variant"></a>`get_variant() → [VariantD](pyvariant.md#pyvariant.VariantD)`<br>
-  Try to extract as variant.
-- <a id="py_os_design.PyOSDesignEntry.is_inf"></a>`is_inf() → bool`<br>
-  Whether the value is infinity.
-- <a id="py_os_design.PyOSDesignEntry.is_nan"></a>`is_nan() → bool`<br>
-  Whether the value is NaN.
-- <a id="py_os_design.PyOSDesignEntry.is_scalar"></a>`is_scalar() → bool`<br>
-  Whether entry is scalar.
-- <a id="py_os_design.PyOSDesignEntry.is_uninitialized"></a>`is_uninitialized() → bool`<br>
-  Whether the entry is not initialized with a value.
-- <a id="py_os_design.PyOSDesignEntry.size"></a>`size() → int`<br>
-  Get the entry’s size in case it is non-scalar.
+<a id="py_os_design.PyOSDesignEntry.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: object) → object
+
+#### \_\_init_\_(arg2: [UninitializedType](#py_os_design.UninitializedType))
+
+#### \_\_init_\_(arg2: [VariantD](pyvariant.md#pyvariant.VariantD))
+
+[1] Create a design entry by passing a builtin Python type. Accepted types are str, int, bool and float.
+
+<a id="py_os_design.PyOSDesignEntry.get"></a>
+
+#### get() → object
+
+Extract as Python bultin type.
+
+<a id="py_os_design.PyOSDesignEntry.get_domain_type"></a>
+
+#### get_domain_type() → [EntryType](#py_os_design.EntryType)
+
+Get the entry’s domain type.
+
+<a id="py_os_design.PyOSDesignEntry.get_scalar"></a>
+
+#### get_scalar() → complex
+
+Try to extract as scalar.
+
+<a id="py_os_design.PyOSDesignEntry.get_variant"></a>
+
+#### get_variant() → [VariantD](pyvariant.md#pyvariant.VariantD)
+
+Try to extract as variant.
+
+<a id="py_os_design.PyOSDesignEntry.is_inf"></a>
+
+#### is_inf() → bool
+
+Whether the value is infinity.
+
+<a id="py_os_design.PyOSDesignEntry.is_nan"></a>
+
+#### is_nan() → bool
+
+Whether the value is NaN.
+
+<a id="py_os_design.PyOSDesignEntry.is_scalar"></a>
+
+#### is_scalar() → bool
+
+Whether entry is scalar.
+
+<a id="py_os_design.PyOSDesignEntry.is_uninitialized"></a>
+
+#### is_uninitialized() → bool
+
+Whether the entry is not initialized with a value.
+
+<a id="py_os_design.PyOSDesignEntry.size"></a>
+
+#### size() → int
+
+Get the entry’s size in case it is non-scalar.
 
 <a id="py_os_design.PyOSDesignEntryVec"></a>
 
@@ -293,17 +574,49 @@ entry.get_scalar().real
 
 Array of design entries.
 
-- <a id="py_os_design.PyOSDesignEntryVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_os_design.PyOSDesignEntryVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_os_design.PyOSDesignEntryVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_os_design.PyOSDesignEntryVec.__init__"></a>`__init__()`
-- <a id="py_os_design.PyOSDesignEntryVec.__iter__"></a>`__iter__() → object`
-- <a id="py_os_design.PyOSDesignEntryVec.__len__"></a>`__len__() → int`
-- <a id="py_os_design.PyOSDesignEntryVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_os_design.PyOSDesignEntryVec.append"></a>`append(arg2: object)`
-- <a id="py_os_design.PyOSDesignEntryVec.extend"></a>`extend(arg2: object)`
-- <a id="py_os_design.PyOSDesignEntryVec.push_back"></a>`push_back(arg2: [PyOSDesignEntry](#py_os_design.PyOSDesignEntry))`
-- <a id="py_os_design.PyOSDesignEntryVec.size"></a>`size() → int`
+<a id="py_os_design.PyOSDesignEntryVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_os_design.PyOSDesignEntryVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_os_design.PyOSDesignEntryVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_os_design.PyOSDesignEntryVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.PyOSDesignEntryVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.PyOSDesignEntryVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.PyOSDesignEntryVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_os_design.PyOSDesignEntryVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_os_design.PyOSDesignEntryVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_os_design.PyOSDesignEntryVec.push_back"></a>
+
+#### push_back(arg2: [PyOSDesignEntry](#py_os_design.PyOSDesignEntry))
+
+<a id="py_os_design.PyOSDesignEntryVec.size"></a>
+
+#### size() → int
 
 <a id="py_os_design.PyOSDesignPoint"></a>
 
@@ -317,15 +630,39 @@ dp.add("param_01", 3.5)
 dp.add("param_02", PyOSDesignEntry(4.5))
 ```
 
-- <a id="py_os_design.PyOSDesignPoint.__getitem__"></a>`__getitem__(arg2: str) → [PyOSDesignEntry](#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_design.PyOSDesignPoint.__init__"></a>`__init__()`
-- <a id="py_os_design.PyOSDesignPoint.__iter__"></a>`__iter__() → object`
-- <a id="py_os_design.PyOSDesignPoint.__len__"></a>`__len__() → int`
-- <a id="py_os_design.PyOSDesignPoint.__setitem__"></a>`__setitem__(arg2: str) → [PyOSDesignEntry](#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_design.PyOSDesignPoint.add"></a>`add(name: str, value: object)`<br>
-  [0] Extend design point using a Python builtin type. Accepted types are str, int, bool and float. [1] Extend design point using an optiSLang variant. [2] Extend design point using a design entry.
-- `add(name: str, value: [VariantD](pyvariant.md#pyvariant.VariantD))`
-- `add(name: str, value: [PyOSDesignEntry](#py_os_design.PyOSDesignEntry))`
+<a id="py_os_design.PyOSDesignPoint.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: str) → [PyOSDesignEntry](#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_design.PyOSDesignPoint.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.PyOSDesignPoint.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.PyOSDesignPoint.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.PyOSDesignPoint.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: str) → [PyOSDesignEntry](#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_design.PyOSDesignPoint.add"></a>
+
+#### add(name: str, value: object)
+
+#### add(name: str, value: [VariantD](pyvariant.md#pyvariant.VariantD))
+
+#### add(name: str, value: [PyOSDesignEntry](#py_os_design.PyOSDesignEntry))
+
+[0] Extend design point using a Python builtin type. Accepted types are str, int, bool and float.
+
+[1] Extend design point using an optiSLang variant.
+
+[2] Extend design point using a design entry.
 
 <a id="py_os_design.PyOSDesignPointContainer"></a>
 
@@ -333,10 +670,21 @@ dp.add("param_02", PyOSDesignEntry(4.5))
 
 Array of design points.
 
-- <a id="py_os_design.PyOSDesignPointContainer.__init__"></a>`__init__()`
-- <a id="py_os_design.PyOSDesignPointContainer.__iter__"></a>`__iter__() → object`
-- <a id="py_os_design.PyOSDesignPointContainer.__len__"></a>`__len__() → int`
-- <a id="py_os_design.PyOSDesignPointContainer.push_back"></a>`push_back(arg2: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))`
+<a id="py_os_design.PyOSDesignPointContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.PyOSDesignPointContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.PyOSDesignPointContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.PyOSDesignPointContainer.push_back"></a>
+
+#### push_back(arg2: [PyOSDesignPoint](#py_os_design.PyOSDesignPoint))
 
 <a id="py_os_design.PyParameters"></a>
 
@@ -354,17 +702,33 @@ alias of [`PyOSDesignPoint`](#py_os_design.PyOSDesignPoint)
 
 ## *class* py_os_design.RunInfoContainer
 
-- <a id="py_os_design.RunInfoContainer.__init__"></a>`__init__()`
-- <a id="py_os_design.RunInfoContainer.__iter__"></a>`__iter__() → object`
-- <a id="py_os_design.RunInfoContainer.__len__"></a>`__len__() → int`
-- <a id="py_os_design.RunInfoContainer.add_run_info"></a>`add_run_info(arg2: [RunInfoMeta](#py_os_design.RunInfoMeta))`
-- <a id="py_os_design.RunInfoContainer.succeeded"></a>`succeeded() → bool`
+<a id="py_os_design.RunInfoContainer.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.RunInfoContainer.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.RunInfoContainer.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.RunInfoContainer.add_run_info"></a>
+
+#### add_run_info(arg2: [RunInfoMeta](#py_os_design.RunInfoMeta))
+
+<a id="py_os_design.RunInfoContainer.succeeded"></a>
+
+#### succeeded() → bool
 
 <a id="py_os_design.RunInfoMeta"></a>
 
 ## *class* py_os_design.RunInfoMeta
 
-- <a id="py_os_design.RunInfoMeta.__init__"></a>`__init__(arg2: [DesignStatus](#py_os_design.DesignStatus))`
+<a id="py_os_design.RunInfoMeta.__init__"></a>
+
+#### \_\_init_\_(arg2: [DesignStatus](#py_os_design.DesignStatus))
 
 <a id="py_os_design.TextImportAdditionalDimension"></a>
 
@@ -372,29 +736,73 @@ alias of [`PyOSDesignPoint`](#py_os_design.PyOSDesignPoint)
 
 Additional dimension item.
 
-- <a id="py_os_design.TextImportAdditionalDimension.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_os_design.TextImportAdditionalDimension.expression"></a>*property* `expression`<br>
-  Expression for the additional dimension.
-- <a id="py_os_design.TextImportAdditionalDimension.name"></a>*property* `name`<br>
-  Name of the dimension to be added.
+<a id="py_os_design.TextImportAdditionalDimension.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportAdditionalDimension.expression"></a>
+
+#### *property* expression
+
+Expression for the additional dimension.
+
+<a id="py_os_design.TextImportAdditionalDimension.name"></a>
+
+#### *property* name
+
+Name of the dimension to be added.
 
 <a id="py_os_design.TextImportAdditionalDimensionVector"></a>
 
 ## *class* py_os_design.TextImportAdditionalDimensionVector
 
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__init__"></a>`__init__()`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__len__"></a>`__len__() → int`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.append"></a>`append(arg2: object)`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.extend"></a>`extend(arg2: object)`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.push_back"></a>`push_back(arg2: [TextImportAdditionalDimension](#py_os_design.TextImportAdditionalDimension))`
-- <a id="py_os_design.TextImportAdditionalDimensionVector.size"></a>`size() → int`
+<a id="py_os_design.TextImportAdditionalDimensionVector.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.push_back"></a>
+
+#### push_back(arg2: [TextImportAdditionalDimension](#py_os_design.TextImportAdditionalDimension))
+
+<a id="py_os_design.TextImportAdditionalDimensionVector.size"></a>
+
+#### size() → int
 
 <a id="py_os_design.TextImportDataType"></a>
 
@@ -402,11 +810,25 @@ Additional dimension item.
 
 **Enumeration**
 
-- <a id="py_os_design.TextImportDataType.AutoDetect"></a>`AutoDetect *= py_os_design.TextImportDataType.AutoDetect*`
-- <a id="py_os_design.TextImportDataType.Bool"></a>`Bool *= py_os_design.TextImportDataType.Bool*`
-- <a id="py_os_design.TextImportDataType.Integer"></a>`Integer *= py_os_design.TextImportDataType.Integer*`
-- <a id="py_os_design.TextImportDataType.Real"></a>`Real *= py_os_design.TextImportDataType.Real*`
-- <a id="py_os_design.TextImportDataType.String"></a>`String *= py_os_design.TextImportDataType.String*`
+<a id="py_os_design.TextImportDataType.AutoDetect"></a>
+
+#### AutoDetect *= py_os_design.TextImportDataType.AutoDetect*
+
+<a id="py_os_design.TextImportDataType.Bool"></a>
+
+#### Bool *= py_os_design.TextImportDataType.Bool*
+
+<a id="py_os_design.TextImportDataType.Integer"></a>
+
+#### Integer *= py_os_design.TextImportDataType.Integer*
+
+<a id="py_os_design.TextImportDataType.Real"></a>
+
+#### Real *= py_os_design.TextImportDataType.Real*
+
+<a id="py_os_design.TextImportDataType.String"></a>
+
+#### String *= py_os_design.TextImportDataType.String*
 
 <a id="py_os_design.TextImportDesignFilterType"></a>
 
@@ -414,9 +836,17 @@ Additional dimension item.
 
 **Enumeration**
 
-- <a id="py_os_design.TextImportDesignFilterType.DontImport"></a>`DontImport *= py_os_design.TextImportDesignFilterType.DontImport*`
-- <a id="py_os_design.TextImportDesignFilterType.ImportAsActivated"></a>`ImportAsActivated *= py_os_design.TextImportDesignFilterType.ImportAsActivated*`
-- <a id="py_os_design.TextImportDesignFilterType.ImportAsDeactivated"></a>`ImportAsDeactivated *= py_os_design.TextImportDesignFilterType.ImportAsDeactivated*`
+<a id="py_os_design.TextImportDesignFilterType.DontImport"></a>
+
+#### DontImport *= py_os_design.TextImportDesignFilterType.DontImport*
+
+<a id="py_os_design.TextImportDesignFilterType.ImportAsActivated"></a>
+
+#### ImportAsActivated *= py_os_design.TextImportDesignFilterType.ImportAsActivated*
+
+<a id="py_os_design.TextImportDesignFilterType.ImportAsDeactivated"></a>
+
+#### ImportAsDeactivated *= py_os_design.TextImportDesignFilterType.ImportAsDeactivated*
 
 <a id="py_os_design.TextImportDimensionSettings"></a>
 
@@ -424,37 +854,97 @@ Additional dimension item.
 
 Dimension settings item.
 
-- <a id="py_os_design.TextImportDimensionSettings.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_os_design.TextImportDimensionSettings.alias"></a>*property* `alias`<br>
-  Alternative name of the dimension.
-- <a id="py_os_design.TextImportDimensionSettings.data_index"></a>*property* `data_index`<br>
-  Index where the dimension is located in data set (header line).
-- <a id="py_os_design.TextImportDimensionSettings.data_type"></a>*property* `data_type`<br>
-  Data type: either AutoDetect (wathever data fits best), String, Bool, Integer or Real.
-- <a id="py_os_design.TextImportDimensionSettings.dimension_type"></a>*property* `dimension_type`<br>
-  Dimension type: either Parameter, Response, DesignId or DontImport.
-- <a id="py_os_design.TextImportDimensionSettings.name"></a>*property* `name`<br>
-  Name of the dimension.
-- <a id="py_os_design.TextImportDimensionSettings.vector_size"></a>*property* `vector_size`<br>
-  Vector size, when this is a vector response.
+<a id="py_os_design.TextImportDimensionSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportDimensionSettings.alias"></a>
+
+#### *property* alias
+
+Alternative name of the dimension.
+
+<a id="py_os_design.TextImportDimensionSettings.data_index"></a>
+
+#### *property* data_index
+
+Index where the dimension is located in data set (header line).
+
+<a id="py_os_design.TextImportDimensionSettings.data_type"></a>
+
+#### *property* data_type
+
+Data type: either AutoDetect (wathever data fits best), String, Bool, Integer or Real.
+
+<a id="py_os_design.TextImportDimensionSettings.dimension_type"></a>
+
+#### *property* dimension_type
+
+Dimension type: either Parameter, Response, DesignId or DontImport.
+
+<a id="py_os_design.TextImportDimensionSettings.name"></a>
+
+#### *property* name
+
+Name of the dimension.
+
+<a id="py_os_design.TextImportDimensionSettings.vector_size"></a>
+
+#### *property* vector_size
+
+Vector size, when this is a vector response.
 
 <a id="py_os_design.TextImportDimensionSettingsVector"></a>
 
 ## *class* py_os_design.TextImportDimensionSettingsVector
 
-- <a id="py_os_design.TextImportDimensionSettingsVector.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__init__"></a>`__init__()`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__len__"></a>`__len__() → int`
-- <a id="py_os_design.TextImportDimensionSettingsVector.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_os_design.TextImportDimensionSettingsVector.append"></a>`append(arg2: object)`
-- <a id="py_os_design.TextImportDimensionSettingsVector.extend"></a>`extend(arg2: object)`
-- <a id="py_os_design.TextImportDimensionSettingsVector.push_back"></a>`push_back(arg2: [TextImportDimensionSettings](#py_os_design.TextImportDimensionSettings))`
-- <a id="py_os_design.TextImportDimensionSettingsVector.size"></a>`size() → int`
+<a id="py_os_design.TextImportDimensionSettingsVector.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.TextImportDimensionSettingsVector.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_os_design.TextImportDimensionSettingsVector.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_os_design.TextImportDimensionSettingsVector.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_os_design.TextImportDimensionSettingsVector.push_back"></a>
+
+#### push_back(arg2: [TextImportDimensionSettings](#py_os_design.TextImportDimensionSettings))
+
+<a id="py_os_design.TextImportDimensionSettingsVector.size"></a>
+
+#### size() → int
 
 <a id="py_os_design.TextImportDimensionType"></a>
 
@@ -462,10 +952,21 @@ Dimension settings item.
 
 **Enumeration**
 
-- <a id="py_os_design.TextImportDimensionType.DesignId"></a>`DesignId *= py_os_design.TextImportDimensionType.DesignId*`
-- <a id="py_os_design.TextImportDimensionType.DontImport"></a>`DontImport *= py_os_design.TextImportDimensionType.DontImport*`
-- <a id="py_os_design.TextImportDimensionType.Parameter"></a>`Parameter *= py_os_design.TextImportDimensionType.Parameter*`
-- <a id="py_os_design.TextImportDimensionType.Response"></a>`Response *= py_os_design.TextImportDimensionType.Response*`
+<a id="py_os_design.TextImportDimensionType.DesignId"></a>
+
+#### DesignId *= py_os_design.TextImportDimensionType.DesignId*
+
+<a id="py_os_design.TextImportDimensionType.DontImport"></a>
+
+#### DontImport *= py_os_design.TextImportDimensionType.DontImport*
+
+<a id="py_os_design.TextImportDimensionType.Parameter"></a>
+
+#### Parameter *= py_os_design.TextImportDimensionType.Parameter*
+
+<a id="py_os_design.TextImportDimensionType.Response"></a>
+
+#### Response *= py_os_design.TextImportDimensionType.Response*
 
 <a id="py_os_design.TextImportReplaceValues"></a>
 
@@ -473,33 +974,85 @@ Dimension settings item.
 
 Replace text item.
 
-- <a id="py_os_design.TextImportReplaceValues.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_os_design.TextImportReplaceValues.complete"></a>*property* `complete`<br>
-  Value has to fit complete if True, else also wordparts will be replaced.
-- <a id="py_os_design.TextImportReplaceValues.dimension"></a>*property* `dimension`<br>
-  When replacement should only be done in one column, put dimension name in here, else leave empty for replacement in all dimensions.
-- <a id="py_os_design.TextImportReplaceValues.replacement"></a>*property* `replacement`<br>
-  Replacement text.
-- <a id="py_os_design.TextImportReplaceValues.text"></a>*property* `text`<br>
-  Text to be replaced.
+<a id="py_os_design.TextImportReplaceValues.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportReplaceValues.complete"></a>
+
+#### *property* complete
+
+Value has to fit complete if True, else also wordparts will be replaced.
+
+<a id="py_os_design.TextImportReplaceValues.dimension"></a>
+
+#### *property* dimension
+
+When replacement should only be done in one column, put dimension name in here, else leave empty for replacement in all dimensions.
+
+<a id="py_os_design.TextImportReplaceValues.replacement"></a>
+
+#### *property* replacement
+
+Replacement text.
+
+<a id="py_os_design.TextImportReplaceValues.text"></a>
+
+#### *property* text
+
+Text to be replaced.
 
 <a id="py_os_design.TextImportReplaceValuesVector"></a>
 
 ## *class* py_os_design.TextImportReplaceValuesVector
 
-- <a id="py_os_design.TextImportReplaceValuesVector.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="py_os_design.TextImportReplaceValuesVector.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="py_os_design.TextImportReplaceValuesVector.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="py_os_design.TextImportReplaceValuesVector.__init__"></a>`__init__()`
-- <a id="py_os_design.TextImportReplaceValuesVector.__iter__"></a>`__iter__() → object`
-- `__iter__() → object`
-- <a id="py_os_design.TextImportReplaceValuesVector.__len__"></a>`__len__() → int`
-- <a id="py_os_design.TextImportReplaceValuesVector.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="py_os_design.TextImportReplaceValuesVector.append"></a>`append(arg2: object)`
-- <a id="py_os_design.TextImportReplaceValuesVector.extend"></a>`extend(arg2: object)`
-- <a id="py_os_design.TextImportReplaceValuesVector.push_back"></a>`push_back(arg2: [TextImportReplaceValues](#py_os_design.TextImportReplaceValues))`
-- <a id="py_os_design.TextImportReplaceValuesVector.size"></a>`size() → int`
+<a id="py_os_design.TextImportReplaceValuesVector.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="py_os_design.TextImportReplaceValuesVector.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="py_os_design.TextImportReplaceValuesVector.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="py_os_design.TextImportReplaceValuesVector.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportReplaceValuesVector.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_design.TextImportReplaceValuesVector.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_design.TextImportReplaceValuesVector.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="py_os_design.TextImportReplaceValuesVector.append"></a>
+
+#### append(arg2: object)
+
+<a id="py_os_design.TextImportReplaceValuesVector.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="py_os_design.TextImportReplaceValuesVector.push_back"></a>
+
+#### push_back(arg2: [TextImportReplaceValues](#py_os_design.TextImportReplaceValues))
+
+<a id="py_os_design.TextImportReplaceValuesVector.size"></a>
+
+#### size() → int
 
 <a id="py_os_design.TextImportSettings"></a>
 
@@ -507,68 +1060,181 @@ Replace text item.
 
 Settings object for determining settings for text import.
 
-- <a id="py_os_design.TextImportSettings.__init__"></a>`__init__()`
-- `__init__()`
-- <a id="py_os_design.TextImportSettings.additional_columns"></a>*property* `additional_columns`<br>
-  Vector with additional dimensions, defined by name and expression.
-- <a id="py_os_design.TextImportSettings.assume_has_header"></a>*property* `assume_has_header`<br>
-  Determine the existance of a header line.
-- <a id="py_os_design.TextImportSettings.automatically_indentify_vector_responses"></a>*property* `automatically_indentify_vector_responses`<br>
-  Dimension names e.g. “response_name[%d]” will be grouped together as one vector response “response_name”.
-- <a id="py_os_design.TextImportSettings.column_exclude"></a>*property* `column_exclude`<br>
-  Columns to exclude.
-- <a id="py_os_design.TextImportSettings.column_include"></a>*property* `column_include`<br>
-  Columns to include.
-- <a id="py_os_design.TextImportSettings.column_increment"></a>*property* `column_increment`<br>
-  Import every nth column - has to be strictly positive.
-- <a id="py_os_design.TextImportSettings.column_maximum"></a>*property* `column_maximum`<br>
-  The last column to be read.
-- <a id="py_os_design.TextImportSettings.delimiters"></a>*property* `delimiters`<br>
-  Delimiters to split the lines.
-- <a id="py_os_design.TextImportSettings.design_layout_horizontal"></a>*property* `design_layout_horizontal`<br>
-  Set True for horizontal layout. Else False.
-- <a id="py_os_design.TextImportSettings.dimension_settings"></a>*property* `dimension_settings`<br>
-  Define the dimensions.
-- <a id="py_os_design.TextImportSettings.export_settings"></a>`export_settings(path_to_settings_file: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Export text import settings to file.
-- <a id="py_os_design.TextImportSettings.header_line"></a>*property* `header_line`<br>
-  Line number of header line.
-- <a id="py_os_design.TextImportSettings.import_deactivated_designs"></a>*property* `import_deactivated_designs`<br>
-  Import deactivated designs, or not.
-- <a id="py_os_design.TextImportSettings.import_designs_with_infinity_as"></a>*property* `import_designs_with_infinity_as`<br>
-  Designs containing infinity values will be imported either as activated or deactivated, or won’t be imported.
-- <a id="py_os_design.TextImportSettings.import_designs_with_nan_as"></a>*property* `import_designs_with_nan_as`<br>
-  Designs containing nan values will be imported either as activated or deactivated, or won’t be imported.
-- <a id="py_os_design.TextImportSettings.import_duplicated_designs"></a>*property* `import_duplicated_designs`<br>
-  Import duplicated designs, or not.
-- <a id="py_os_design.TextImportSettings.import_incomplete_designs_as"></a>*property* `import_incomplete_designs_as`<br>
-  Incomplete designs will be imported either as activated or deactivated, or won’t be imported.
-- <a id="py_os_design.TextImportSettings.import_settings"></a>`import_settings(path_to_settings_file: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Import text import settings from file.
-- <a id="py_os_design.TextImportSettings.is_read_from_line_offset"></a>*property* `is_read_from_line_offset`<br>
-  Read the text file from line is active.
-- <a id="py_os_design.TextImportSettings.is_read_from_marker"></a>*property* `is_read_from_marker`<br>
-  Read the text file from marker is active.
-- <a id="py_os_design.TextImportSettings.lines"></a>*property* `lines`<br>
-  Lines to include.
-- <a id="py_os_design.TextImportSettings.read_from_beginning"></a>*property* `read_from_beginning`<br>
-  Read the text file from beginning.
-- <a id="py_os_design.TextImportSettings.read_from_line_offset"></a>*property* `read_from_line_offset`<br>
-  Read the text file from given line.
-- <a id="py_os_design.TextImportSettings.read_from_marker"></a>*property* `read_from_marker`<br>
-  Read the text file from marker.
-- <a id="py_os_design.TextImportSettings.replace_entries"></a>*property* `replace_entries`<br>
-  Vector with entries for replacing text entries.
-- <a id="py_os_design.TextImportSettings.row_increment"></a>*property* `row_increment`<br>
-  Import every nth line - has to be strictly positive.
-- <a id="py_os_design.TextImportSettings.start_design_id_numbering_with"></a>*property* `start_design_id_numbering_with`<br>
-  When no design id dimension is chosen, design numbering starts with this id.
+<a id="py_os_design.TextImportSettings.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_()
+
+<a id="py_os_design.TextImportSettings.additional_columns"></a>
+
+#### *property* additional_columns
+
+Vector with additional dimensions, defined by name and expression.
+
+<a id="py_os_design.TextImportSettings.assume_has_header"></a>
+
+#### *property* assume_has_header
+
+Determine the existance of a header line.
+
+<a id="py_os_design.TextImportSettings.automatically_indentify_vector_responses"></a>
+
+#### *property* automatically_indentify_vector_responses
+
+Dimension names e.g. “response_name[%d]” will be grouped together as one vector response “response_name”.
+
+<a id="py_os_design.TextImportSettings.column_exclude"></a>
+
+#### *property* column_exclude
+
+Columns to exclude.
+
+<a id="py_os_design.TextImportSettings.column_include"></a>
+
+#### *property* column_include
+
+Columns to include.
+
+<a id="py_os_design.TextImportSettings.column_increment"></a>
+
+#### *property* column_increment
+
+Import every nth column - has to be strictly positive.
+
+<a id="py_os_design.TextImportSettings.column_maximum"></a>
+
+#### *property* column_maximum
+
+The last column to be read.
+
+<a id="py_os_design.TextImportSettings.delimiters"></a>
+
+#### *property* delimiters
+
+Delimiters to split the lines.
+
+<a id="py_os_design.TextImportSettings.design_layout_horizontal"></a>
+
+#### *property* design_layout_horizontal
+
+Set True for horizontal layout. Else False.
+
+<a id="py_os_design.TextImportSettings.dimension_settings"></a>
+
+#### *property* dimension_settings
+
+Define the dimensions.
+
+<a id="py_os_design.TextImportSettings.export_settings"></a>
+
+#### export_settings(path_to_settings_file: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Export text import settings to file.
+
+<a id="py_os_design.TextImportSettings.header_line"></a>
+
+#### *property* header_line
+
+Line number of header line.
+
+<a id="py_os_design.TextImportSettings.import_deactivated_designs"></a>
+
+#### *property* import_deactivated_designs
+
+Import deactivated designs, or not.
+
+<a id="py_os_design.TextImportSettings.import_designs_with_infinity_as"></a>
+
+#### *property* import_designs_with_infinity_as
+
+Designs containing infinity values will be imported either as activated or deactivated, or won’t be imported.
+
+<a id="py_os_design.TextImportSettings.import_designs_with_nan_as"></a>
+
+#### *property* import_designs_with_nan_as
+
+Designs containing nan values will be imported either as activated or deactivated, or won’t be imported.
+
+<a id="py_os_design.TextImportSettings.import_duplicated_designs"></a>
+
+#### *property* import_duplicated_designs
+
+Import duplicated designs, or not.
+
+<a id="py_os_design.TextImportSettings.import_incomplete_designs_as"></a>
+
+#### *property* import_incomplete_designs_as
+
+Incomplete designs will be imported either as activated or deactivated, or won’t be imported.
+
+<a id="py_os_design.TextImportSettings.import_settings"></a>
+
+#### import_settings(path_to_settings_file: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Import text import settings from file.
+
+<a id="py_os_design.TextImportSettings.is_read_from_line_offset"></a>
+
+#### *property* is_read_from_line_offset
+
+Read the text file from line is active.
+
+<a id="py_os_design.TextImportSettings.is_read_from_marker"></a>
+
+#### *property* is_read_from_marker
+
+Read the text file from marker is active.
+
+<a id="py_os_design.TextImportSettings.lines"></a>
+
+#### *property* lines
+
+Lines to include.
+
+<a id="py_os_design.TextImportSettings.read_from_beginning"></a>
+
+#### *property* read_from_beginning
+
+Read the text file from beginning.
+
+<a id="py_os_design.TextImportSettings.read_from_line_offset"></a>
+
+#### *property* read_from_line_offset
+
+Read the text file from given line.
+
+<a id="py_os_design.TextImportSettings.read_from_marker"></a>
+
+#### *property* read_from_marker
+
+Read the text file from marker.
+
+<a id="py_os_design.TextImportSettings.replace_entries"></a>
+
+#### *property* replace_entries
+
+Vector with entries for replacing text entries.
+
+<a id="py_os_design.TextImportSettings.row_increment"></a>
+
+#### *property* row_increment
+
+Import every nth line - has to be strictly positive.
+
+<a id="py_os_design.TextImportSettings.start_design_id_numbering_with"></a>
+
+#### *property* start_design_id_numbering_with
+
+When no design id dimension is chosen, design numbering starts with this id.
 
 <a id="py_os_design.UninitializedType"></a>
 
 ## *class* py_os_design.UninitializedType
 
-- <a id="py_os_design.UninitializedType.__init__"></a>`__init__()`
+<a id="py_os_design.UninitializedType.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_design.calculate_criteria"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_parameter.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_os_parameter.md
@@ -4,212 +4,679 @@
 
 ## *class* py_os_parameter.DProp
 
-- <a id="py_os_parameter.DProp.__init__"></a>`__init__()`
+<a id="py_os_parameter.DProp.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_parameter.DPropList"></a>
 
 ## *class* py_os_parameter.DPropList
 
-- <a id="py_os_parameter.DPropList.__init__"></a>`__init__()`
-- <a id="py_os_parameter.DPropList.__iter__"></a>`__iter__() → object`
-- <a id="py_os_parameter.DPropList.dprop_export_list"></a>`dprop_export_list() → [DPropList](#py_os_parameter.DPropList)`
-- <a id="py_os_parameter.DPropList.push_back"></a>`push_back(arg2: [DPropPair](#py_os_parameter.DPropPair))`
-- <a id="py_os_parameter.DPropList.size"></a>`size() → int`
+<a id="py_os_parameter.DPropList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.DPropList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_parameter.DPropList.dprop_export_list"></a>
+
+#### dprop_export_list() → [DPropList](#py_os_parameter.DPropList)
+
+<a id="py_os_parameter.DPropList.push_back"></a>
+
+#### push_back(arg2: [DPropPair](#py_os_parameter.DPropPair))
+
+<a id="py_os_parameter.DPropList.size"></a>
+
+#### size() → int
 
 <a id="py_os_parameter.DPropPair"></a>
 
 ## *class* py_os_parameter.DPropPair
 
-- <a id="py_os_parameter.DPropPair.__init__"></a>`__init__()`
-- <a id="py_os_parameter.DPropPair.first"></a>*property* `first`
-- <a id="py_os_parameter.DPropPair.second"></a>*property* `second`
+<a id="py_os_parameter.DPropPair.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.DPropPair.first"></a>
+
+#### *property* first
+
+<a id="py_os_parameter.DPropPair.second"></a>
+
+#### *property* second
 
 <a id="py_os_parameter.ParameterList"></a>
 
 ## *class* py_os_parameter.ParameterList
 
-- <a id="py_os_parameter.ParameterList.__init__"></a>`__init__()`
-- <a id="py_os_parameter.ParameterList.__iter__"></a>`__iter__() → object`
-- <a id="py_os_parameter.ParameterList.param_export_list"></a>`param_export_list() → [ParameterList](#py_os_parameter.ParameterList)`
-- <a id="py_os_parameter.ParameterList.push_back"></a>`push_back(arg2: [PyParameter](#py_os_parameter.PyParameter))`
-- <a id="py_os_parameter.ParameterList.size"></a>`size() → int`
+<a id="py_os_parameter.ParameterList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.ParameterList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_parameter.ParameterList.param_export_list"></a>
+
+#### param_export_list() → [ParameterList](#py_os_parameter.ParameterList)
+
+<a id="py_os_parameter.ParameterList.push_back"></a>
+
+#### push_back(arg2: [PyParameter](#py_os_parameter.PyParameter))
+
+<a id="py_os_parameter.ParameterList.size"></a>
+
+#### size() → int
 
 <a id="py_os_parameter.PyParameter"></a>
 
 ## *class* py_os_parameter.PyParameter
 
-- <a id="py_os_parameter.PyParameter.__eq__"></a>`__eq__(arg2: PyParameter) → bool`
-- <a id="py_os_parameter.PyParameter.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: float, arg4: float, arg5: float, arg6: int)`
-- `__init__(arg2: str, arg3: float, arg4: float, arg5: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), arg6: int)`
-- `__init__(arg2: str, arg3: [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec), arg4: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))`
-- `__init__(arg2: str, arg3: str)`
-- `__init__(arg2: str, arg3: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType), arg4: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind), arg5: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`
-- <a id="py_os_parameter.PyParameter.__is_equal__"></a>`__is_equal__(arg2: PyParameter) → bool`
-- <a id="py_os_parameter.PyParameter.__is_not_equal__"></a>`__is_not_equal__(arg2: [PyParameter](#py_os_parameter.PyParameter)) → bool`
-- <a id="py_os_parameter.PyParameter.__ne__"></a>`__ne__(arg2: [PyParameter](#py_os_parameter.PyParameter)) → bool`
-- <a id="py_os_parameter.PyParameter.erase_det_prop"></a>`erase_det_prop(name: str)`
-- <a id="py_os_parameter.PyParameter.get_dependency_expression"></a>`get_dependency_expression() → str`
-- <a id="py_os_parameter.PyParameter.get_det_discrete_states"></a>`get_det_discrete_states() → [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec)`
-- <a id="py_os_parameter.PyParameter.get_det_kind"></a>`get_det_kind() → [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType)`
-- <a id="py_os_parameter.PyParameter.get_det_prop_by_index"></a>`get_det_prop_by_index(index: int) → [DProp](#py_os_parameter.DProp)`
-- <a id="py_os_parameter.PyParameter.get_det_prop_name"></a>`get_det_prop_name(index: int) → object`
-- <a id="py_os_parameter.PyParameter.get_det_props"></a>`get_det_props() → [DPropList](#py_os_parameter.DPropList)`
-- <a id="py_os_parameter.PyParameter.get_det_type"></a>`get_det_type() → [EntryType](py_os_design.md#py_os_design.EntryType)`
-- <a id="py_os_parameter.PyParameter.get_id"></a>`get_id() → [UUID](id.md#id.UUID)`
-- <a id="py_os_parameter.PyParameter.get_lower_bound"></a>`get_lower_bound() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.get_mutable_map"></a>`get_mutable_map() → object`
-- <a id="py_os_parameter.PyParameter.get_name"></a>`get_name() → str`
-- <a id="py_os_parameter.PyParameter.get_parameter_type"></a>`get_parameter_type() → [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType)`
-- <a id="py_os_parameter.PyParameter.get_ran_cov"></a>`get_ran_cov() → float`
-- <a id="py_os_parameter.PyParameter.get_ran_kind"></a>`get_ran_kind() → [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind)`
-- <a id="py_os_parameter.PyParameter.get_ran_parameters"></a>`get_ran_parameters() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="py_os_parameter.PyParameter.get_ran_prop"></a>`get_ran_prop() → [RanProp](#py_os_parameter.RanProp)`
-- <a id="py_os_parameter.PyParameter.get_ran_statistical_moments"></a>`get_ran_statistical_moments() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)`
-- <a id="py_os_parameter.PyParameter.get_ran_type"></a>`get_ran_type() → [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType)`
-- <a id="py_os_parameter.PyParameter.get_reference_value"></a>`get_reference_value() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.get_upper_bound"></a>`get_upper_bound() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.has_continuous_distribution"></a>`has_continuous_distribution() → bool`
-- <a id="py_os_parameter.PyParameter.has_marginal_distribution"></a>`has_marginal_distribution() → bool`
-- <a id="py_os_parameter.PyParameter.has_set_ran_cov"></a>`has_set_ran_cov() → bool`
-- <a id="py_os_parameter.PyParameter.has_set_ran_parameters"></a>`has_set_ran_parameters() → bool`
-- <a id="py_os_parameter.PyParameter.has_set_ran_statistical_moments"></a>`has_set_ran_statistical_moments() → bool`
-- <a id="py_os_parameter.PyParameter.is_active"></a>`is_active() → bool`
-- <a id="py_os_parameter.PyParameter.is_const"></a>`is_const() → bool`
-- <a id="py_os_parameter.PyParameter.is_continuous"></a>`is_continuous() → bool`
-- <a id="py_os_parameter.PyParameter.is_dependent"></a>`is_dependent() → bool`
-- <a id="py_os_parameter.PyParameter.is_empirical"></a>`is_empirical() → bool`
-- <a id="py_os_parameter.PyParameter.is_mixed"></a>`is_mixed() → bool`
-- <a id="py_os_parameter.PyParameter.is_modifiable"></a>`is_modifiable() → bool`
-- <a id="py_os_parameter.PyParameter.is_mutable"></a>`is_mutable(member: object) → bool`
-- <a id="py_os_parameter.PyParameter.is_optimization"></a>`is_optimization() → bool`
-- <a id="py_os_parameter.PyParameter.is_pure_optimization"></a>`is_pure_optimization() → bool`
-- <a id="py_os_parameter.PyParameter.is_pure_stochastic"></a>`is_pure_stochastic() → bool`
-- <a id="py_os_parameter.PyParameter.is_ran_prop_validated"></a>`is_ran_prop_validated() → bool`
-- <a id="py_os_parameter.PyParameter.is_stochastic"></a>`is_stochastic() → bool`
-- <a id="py_os_parameter.PyParameter.rename_det_prop"></a>`rename_det_prop(arg2: str)`
-- `rename_det_prop(arg2: str, to: str)`
-- <a id="py_os_parameter.PyParameter.rename_parameter"></a>`rename_parameter(to: str)`
-- <a id="py_os_parameter.PyParameter.set_active"></a>`set_active(active: bool)`
-- <a id="py_os_parameter.PyParameter.set_bounds"></a>`set_bounds(lower_bound: PyOSDesignEntry, upper_bound: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.set_const"></a>`set_const(constant: bool)`
-- <a id="py_os_parameter.PyParameter.set_dependent"></a>`set_dependent(expression: str)`
-- <a id="py_os_parameter.PyParameter.set_det_prop_by_index"></a>`set_det_prop_by_index(value: [DProp](#py_os_parameter.DProp), index: int)`
-- <a id="py_os_parameter.PyParameter.set_discrete_states"></a>`set_discrete_states(states: PyOSDesignEntryVec)`
-- <a id="py_os_parameter.PyParameter.set_kind"></a>`set_kind(kind: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))`
-- <a id="py_os_parameter.PyParameter.set_lower_bound"></a>`set_lower_bound(value: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.set_modifiable"></a>`set_modifiable(arg2: bool)`
-- <a id="py_os_parameter.PyParameter.set_mutable"></a>`set_mutable(member: object, state: bool)`
-- <a id="py_os_parameter.PyParameter.set_mutable_map"></a>`set_mutable_map(arg2: object)`
-- <a id="py_os_parameter.PyParameter.set_parameter_type"></a>`set_parameter_type(type: [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType))`
-- <a id="py_os_parameter.PyParameter.set_ran_cov"></a>`set_ran_cov(cov: float) → float`
-- <a id="py_os_parameter.PyParameter.set_ran_kind"></a>`set_ran_kind(kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind))`
-- <a id="py_os_parameter.PyParameter.set_ran_parameters"></a>`set_ran_parameters(parameters: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="py_os_parameter.PyParameter.set_ran_prop_validated"></a>`set_ran_prop_validated(arg2: bool)`
-- <a id="py_os_parameter.PyParameter.set_ran_statistical_moments"></a>`set_ran_statistical_moments(moments: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="py_os_parameter.PyParameter.set_ran_type"></a>`set_ran_type(type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))`
-- <a id="py_os_parameter.PyParameter.set_reference_value"></a>`set_reference_value(value: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameter.set_type"></a>`set_type(type: [EntryType](py_os_design.md#py_os_design.EntryType))`
-- <a id="py_os_parameter.PyParameter.set_upper_bound"></a>`set_upper_bound(value: PyOSDesignEntry)`
+<a id="py_os_parameter.PyParameter.__eq__"></a>
+
+#### \_\_eq_\_(arg2: PyParameter) → bool
+
+<a id="py_os_parameter.PyParameter.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: float, arg4: float, arg5: float, arg6: int)
+
+#### \_\_init_\_(arg2: str, arg3: float, arg4: float, arg5: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), arg6: int)
+
+#### \_\_init_\_(arg2: str, arg3: [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec), arg4: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+#### \_\_init_\_(arg2: str, arg3: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType), arg4: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind), arg5: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
+
+<a id="py_os_parameter.PyParameter.__is_equal__"></a>
+
+#### \_\_is_equal_\_(arg2: PyParameter) → bool
+
+<a id="py_os_parameter.PyParameter.__is_not_equal__"></a>
+
+#### \_\_is_not_equal_\_(arg2: [PyParameter](#py_os_parameter.PyParameter)) → bool
+
+<a id="py_os_parameter.PyParameter.__ne__"></a>
+
+#### \_\_ne_\_(arg2: [PyParameter](#py_os_parameter.PyParameter)) → bool
+
+<a id="py_os_parameter.PyParameter.erase_det_prop"></a>
+
+#### erase_det_prop(name: str)
+
+<a id="py_os_parameter.PyParameter.get_dependency_expression"></a>
+
+#### get_dependency_expression() → str
+
+<a id="py_os_parameter.PyParameter.get_det_discrete_states"></a>
+
+#### get_det_discrete_states() → [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec)
+
+<a id="py_os_parameter.PyParameter.get_det_kind"></a>
+
+#### get_det_kind() → [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType)
+
+<a id="py_os_parameter.PyParameter.get_det_prop_by_index"></a>
+
+#### get_det_prop_by_index(index: int) → [DProp](#py_os_parameter.DProp)
+
+<a id="py_os_parameter.PyParameter.get_det_prop_name"></a>
+
+#### get_det_prop_name(index: int) → object
+
+<a id="py_os_parameter.PyParameter.get_det_props"></a>
+
+#### get_det_props() → [DPropList](#py_os_parameter.DPropList)
+
+<a id="py_os_parameter.PyParameter.get_det_type"></a>
+
+#### get_det_type() → [EntryType](py_os_design.md#py_os_design.EntryType)
+
+<a id="py_os_parameter.PyParameter.get_id"></a>
+
+#### get_id() → [UUID](id.md#id.UUID)
+
+<a id="py_os_parameter.PyParameter.get_lower_bound"></a>
+
+#### get_lower_bound() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.get_mutable_map"></a>
+
+#### get_mutable_map() → object
+
+<a id="py_os_parameter.PyParameter.get_name"></a>
+
+#### get_name() → str
+
+<a id="py_os_parameter.PyParameter.get_parameter_type"></a>
+
+#### get_parameter_type() → [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType)
+
+<a id="py_os_parameter.PyParameter.get_ran_cov"></a>
+
+#### get_ran_cov() → float
+
+<a id="py_os_parameter.PyParameter.get_ran_kind"></a>
+
+#### get_ran_kind() → [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind)
+
+<a id="py_os_parameter.PyParameter.get_ran_parameters"></a>
+
+#### get_ran_parameters() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="py_os_parameter.PyParameter.get_ran_prop"></a>
+
+#### get_ran_prop() → [RanProp](#py_os_parameter.RanProp)
+
+<a id="py_os_parameter.PyParameter.get_ran_statistical_moments"></a>
+
+#### get_ran_statistical_moments() → [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec)
+
+<a id="py_os_parameter.PyParameter.get_ran_type"></a>
+
+#### get_ran_type() → [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType)
+
+<a id="py_os_parameter.PyParameter.get_reference_value"></a>
+
+#### get_reference_value() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.get_upper_bound"></a>
+
+#### get_upper_bound() → [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.has_continuous_distribution"></a>
+
+#### has_continuous_distribution() → bool
+
+<a id="py_os_parameter.PyParameter.has_marginal_distribution"></a>
+
+#### has_marginal_distribution() → bool
+
+<a id="py_os_parameter.PyParameter.has_set_ran_cov"></a>
+
+#### has_set_ran_cov() → bool
+
+<a id="py_os_parameter.PyParameter.has_set_ran_parameters"></a>
+
+#### has_set_ran_parameters() → bool
+
+<a id="py_os_parameter.PyParameter.has_set_ran_statistical_moments"></a>
+
+#### has_set_ran_statistical_moments() → bool
+
+<a id="py_os_parameter.PyParameter.is_active"></a>
+
+#### is_active() → bool
+
+<a id="py_os_parameter.PyParameter.is_const"></a>
+
+#### is_const() → bool
+
+<a id="py_os_parameter.PyParameter.is_continuous"></a>
+
+#### is_continuous() → bool
+
+<a id="py_os_parameter.PyParameter.is_dependent"></a>
+
+#### is_dependent() → bool
+
+<a id="py_os_parameter.PyParameter.is_empirical"></a>
+
+#### is_empirical() → bool
+
+<a id="py_os_parameter.PyParameter.is_mixed"></a>
+
+#### is_mixed() → bool
+
+<a id="py_os_parameter.PyParameter.is_modifiable"></a>
+
+#### is_modifiable() → bool
+
+<a id="py_os_parameter.PyParameter.is_mutable"></a>
+
+#### is_mutable(member: object) → bool
+
+<a id="py_os_parameter.PyParameter.is_optimization"></a>
+
+#### is_optimization() → bool
+
+<a id="py_os_parameter.PyParameter.is_pure_optimization"></a>
+
+#### is_pure_optimization() → bool
+
+<a id="py_os_parameter.PyParameter.is_pure_stochastic"></a>
+
+#### is_pure_stochastic() → bool
+
+<a id="py_os_parameter.PyParameter.is_ran_prop_validated"></a>
+
+#### is_ran_prop_validated() → bool
+
+<a id="py_os_parameter.PyParameter.is_stochastic"></a>
+
+#### is_stochastic() → bool
+
+<a id="py_os_parameter.PyParameter.rename_det_prop"></a>
+
+#### rename_det_prop(arg2: str)
+
+#### rename_det_prop(arg2: str, to: str)
+
+<a id="py_os_parameter.PyParameter.rename_parameter"></a>
+
+#### rename_parameter(to: str)
+
+<a id="py_os_parameter.PyParameter.set_active"></a>
+
+#### set_active(active: bool)
+
+<a id="py_os_parameter.PyParameter.set_bounds"></a>
+
+#### set_bounds(lower_bound: PyOSDesignEntry, upper_bound: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.set_const"></a>
+
+#### set_const(constant: bool)
+
+<a id="py_os_parameter.PyParameter.set_dependent"></a>
+
+#### set_dependent(expression: str)
+
+<a id="py_os_parameter.PyParameter.set_det_prop_by_index"></a>
+
+#### set_det_prop_by_index(value: [DProp](#py_os_parameter.DProp), index: int)
+
+<a id="py_os_parameter.PyParameter.set_discrete_states"></a>
+
+#### set_discrete_states(states: PyOSDesignEntryVec)
+
+<a id="py_os_parameter.PyParameter.set_kind"></a>
+
+#### set_kind(kind: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))
+
+<a id="py_os_parameter.PyParameter.set_lower_bound"></a>
+
+#### set_lower_bound(value: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.set_modifiable"></a>
+
+#### set_modifiable(arg2: bool)
+
+<a id="py_os_parameter.PyParameter.set_mutable"></a>
+
+#### set_mutable(member: object, state: bool)
+
+<a id="py_os_parameter.PyParameter.set_mutable_map"></a>
+
+#### set_mutable_map(arg2: object)
+
+<a id="py_os_parameter.PyParameter.set_parameter_type"></a>
+
+#### set_parameter_type(type: [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType))
+
+<a id="py_os_parameter.PyParameter.set_ran_cov"></a>
+
+#### set_ran_cov(cov: float) → float
+
+<a id="py_os_parameter.PyParameter.set_ran_kind"></a>
+
+#### set_ran_kind(kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind))
+
+<a id="py_os_parameter.PyParameter.set_ran_parameters"></a>
+
+#### set_ran_parameters(parameters: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="py_os_parameter.PyParameter.set_ran_prop_validated"></a>
+
+#### set_ran_prop_validated(arg2: bool)
+
+<a id="py_os_parameter.PyParameter.set_ran_statistical_moments"></a>
+
+#### set_ran_statistical_moments(moments: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="py_os_parameter.PyParameter.set_ran_type"></a>
+
+#### set_ran_type(type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))
+
+<a id="py_os_parameter.PyParameter.set_reference_value"></a>
+
+#### set_reference_value(value: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameter.set_type"></a>
+
+#### set_type(type: [EntryType](py_os_design.md#py_os_design.EntryType))
+
+<a id="py_os_parameter.PyParameter.set_upper_bound"></a>
+
+#### set_upper_bound(value: PyOSDesignEntry)
 
 <a id="py_os_parameter.PyParameterManager"></a>
 
 ## *class* py_os_parameter.PyParameterManager
 
-- <a id="py_os_parameter.PyParameterManager.__eq__"></a>`__eq__(arg2: PyParameterManager) → bool`
-- <a id="py_os_parameter.PyParameterManager.__init__"></a>`__init__()`
-- <a id="py_os_parameter.PyParameterManager.__is_equal__"></a>`__is_equal__(arg2: PyParameterManager) → bool`
-- <a id="py_os_parameter.PyParameterManager.__is_not_equal__"></a>`__is_not_equal__(arg2: [PyParameterManager](#py_os_parameter.PyParameterManager)) → bool`
-- <a id="py_os_parameter.PyParameterManager.__iter__"></a>`__iter__() → object`
-- <a id="py_os_parameter.PyParameterManager.__len__"></a>`__len__() → int`
-- <a id="py_os_parameter.PyParameterManager.__ne__"></a>`__ne__(arg2: [PyParameterManager](#py_os_parameter.PyParameterManager)) → bool`
-- <a id="py_os_parameter.PyParameterManager.add_dependent_parameter"></a>`add_dependent_parameter(parameter_name: str, expression: str)`
-- <a id="py_os_parameter.PyParameterManager.add_deterministic_continuous_parameter"></a>`add_deterministic_continuous_parameter(name: str, lower_bound: float, upper_bound: float, reference_value: float)`<br>
-  Add a new deterministic continuous parameter. A range_mode of 1 or 2 sets a relative lower respectively upper bound. A range_mode of 3 sets both bounds relative. ```python pm = PyParameterManager() pm.add_deterministic_continuous_parameter('a', 0., 3., 1.5) ```
-- <a id="py_os_parameter.PyParameterManager.add_parameter"></a>`add_parameter(name: str)`
-- <a id="py_os_parameter.PyParameterManager.add_stochastic_parameter"></a>`add_stochastic_parameter(name: str, type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType), kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind), reference_value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`<br>
-  Add a new stochastic parameter. It is required to set a parameter type and random parameters afterwards. ```python pm = PyParameterManager() pm.add_stochastic_parameter('s1', RandomVariableType.NORMAL, RandomVariableKind.DETERMINISTIC, PyOSDesignEntry(0.72)) pm.set_parameter_type('s1', ParameterType.STOCHASTIC) pm.set_ran_parameters('s1', double_list_to_vec([0.72, 0.3]))   # normal distribution: mu, sigmah ```
-- <a id="py_os_parameter.PyParameterManager.clear"></a>`clear()`
-- <a id="py_os_parameter.PyParameterManager.contains_parameter"></a>`contains_parameter(name: str) → bool`
-- `contains_parameter(id: [UUID](id.md#id.UUID)) → bool`
-- <a id="py_os_parameter.PyParameterManager.empty"></a>`empty() → bool`
-- <a id="py_os_parameter.PyParameterManager.erase_correlation"></a>`erase_correlation(arg2: str, parameter_name: str) → bool`
-- <a id="py_os_parameter.PyParameterManager.erase_correlations"></a>`erase_correlations(parameter_name_b: str) → bool`
-- <a id="py_os_parameter.PyParameterManager.erase_parameter"></a>`erase_parameter(parameter_name: str)`
-- <a id="py_os_parameter.PyParameterManager.get_bounds"></a>`get_bounds(parameter_name: str, lower_bound: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), upper_bound: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))`<br>
-  [0] Note, that lower_bound and upper_bound are output arguments. [1] Return a parameter’s boundaries as a tuple.
-- `get_bounds(parameter_name: str) → tuple`
-- <a id="py_os_parameter.PyParameterManager.get_det_props"></a>`get_det_props() → [DPropList](#py_os_parameter.DPropList)`
-- <a id="py_os_parameter.PyParameterManager.get_det_props_by_index"></a>`get_det_props_by_index(parameter_name: str, index: int) → [DProp](#py_os_parameter.DProp)`
-- <a id="py_os_parameter.PyParameterManager.get_parameter"></a>`get_parameter(parameter_name: str) → [PyParameter](#py_os_parameter.PyParameter)`
-- `get_parameter(parameter_id: [UUID](id.md#id.UUID)) → [PyParameter](#py_os_parameter.PyParameter)`
-- <a id="py_os_parameter.PyParameterManager.get_parameter_by_index"></a>`get_parameter_by_index(index: int) → [PyParameter](#py_os_parameter.PyParameter)`
-- <a id="py_os_parameter.PyParameterManager.get_parameters"></a>`get_parameters() → [ParameterList](#py_os_parameter.ParameterList)`
-- <a id="py_os_parameter.PyParameterManager.get_ran_prop"></a>`get_ran_prop(parameter_name: str) → [RanProp](#py_os_parameter.RanProp)`
-- <a id="py_os_parameter.PyParameterManager.get_ran_props"></a>`get_ran_props() → [RanPropList](#py_os_parameter.RanPropList)`
-- <a id="py_os_parameter.PyParameterManager.get_reference_design"></a>`get_reference_design() → [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec)`
-- <a id="py_os_parameter.PyParameterManager.get_reference_design_point"></a>`get_reference_design_point() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)`
-- <a id="py_os_parameter.PyParameterManager.get_size"></a>`get_size() → int`
-- <a id="py_os_parameter.PyParameterManager.get_unique_name"></a>`get_unique_name() → str`
-- <a id="py_os_parameter.PyParameterManager.import_from_csv"></a>`import_from_csv(csv: Path path)`<br>
-  Add parameters from csv to parameter manager.
-- <a id="py_os_parameter.PyParameterManager.import_from_json"></a>`import_from_json(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Add parameters from json to parameter manager.
-- <a id="py_os_parameter.PyParameterManager.import_from_json_string"></a>`import_from_json_string(content: str)`<br>
-  Add parameters from json string to parameter manager.
-- <a id="py_os_parameter.PyParameterManager.insert_parameter"></a>`insert_parameter(parameter: [PyParameter](#py_os_parameter.PyParameter))`
-- <a id="py_os_parameter.PyParameterManager.rename_det_prop"></a>`rename_det_prop(parameter_name: str, from: str, to: str)`
-- <a id="py_os_parameter.PyParameterManager.rename_parameter"></a>`rename_parameter(from: str, to: str)`
-- <a id="py_os_parameter.PyParameterManager.reset_correlations"></a>`reset_correlations()`
-- <a id="py_os_parameter.PyParameterManager.save_to_csv"></a>`save_to_csv(csv: Path path)`<br>
-  Save parameter manager to a csv file.
-- <a id="py_os_parameter.PyParameterManager.save_to_json"></a>`save_to_json(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`<br>
-  Save parameter manager to a json file.
-- <a id="py_os_parameter.PyParameterManager.set_active"></a>`set_active(parameter_name: str, active: bool)`
-- <a id="py_os_parameter.PyParameterManager.set_bounds"></a>`set_bounds(parameter_name: str, lower_bound: PyOSDesignEntry, upper_bound: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameterManager.set_const_all_in_list"></a>`set_const_all_in_list(names: WStrList) → [PyParameterManager](#py_os_parameter.PyParameterManager)`
-- <a id="py_os_parameter.PyParameterManager.set_const_flag"></a>`set_const_flag(parameter_name: str)`
-- <a id="py_os_parameter.PyParameterManager.set_correlation"></a>`set_correlation(parameter_name_a: str, parameter_name_b: str, value: float) → bool`
-- <a id="py_os_parameter.PyParameterManager.set_dependent"></a>`set_dependent(parameter_name: str, expression: str)`
-- <a id="py_os_parameter.PyParameterManager.set_discrete_states"></a>`set_discrete_states(parameter_name: str, discrete_states: [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec))`
-- <a id="py_os_parameter.PyParameterManager.set_kind"></a>`set_kind(parameter_name: str, kind: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))`
-- <a id="py_os_parameter.PyParameterManager.set_lower_bound"></a>`set_lower_bound(parameter_name: str, value: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameterManager.set_modifiable"></a>`set_modifiable(parameter_name: str, modifiable: bool)`
-- <a id="py_os_parameter.PyParameterManager.set_parameter_type"></a>`set_parameter_type(parameter_name: str, type: [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType))`
-- <a id="py_os_parameter.PyParameterManager.set_ran_cov"></a>`set_ran_cov(parameter_name: str, cov: float) → float`
-- <a id="py_os_parameter.PyParameterManager.set_ran_kind"></a>`set_ran_kind(parameter_name: str, kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind))`
-- <a id="py_os_parameter.PyParameterManager.set_ran_parameters"></a>`set_ran_parameters(parameter_name: str, parameters: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="py_os_parameter.PyParameterManager.set_ran_statistical_moments"></a>`set_ran_statistical_moments(parameter_name: str, moments: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))`
-- <a id="py_os_parameter.PyParameterManager.set_ran_type"></a>`set_ran_type(parameter_name: str, type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))`
-- <a id="py_os_parameter.PyParameterManager.set_reference_design_point"></a>`set_reference_design_point(design_point: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint))`
-- <a id="py_os_parameter.PyParameterManager.set_reference_value"></a>`set_reference_value(parameter_name: str, value: PyOSDesignEntry)`
-- <a id="py_os_parameter.PyParameterManager.set_type"></a>`set_type(parameter_name: str, type: [EntryType](py_os_design.md#py_os_design.EntryType))`
-- <a id="py_os_parameter.PyParameterManager.set_upper_bound"></a>`set_upper_bound(parameter_name: str, value: PyOSDesignEntry)`
+<a id="py_os_parameter.PyParameterManager.__eq__"></a>
+
+#### \_\_eq_\_(arg2: PyParameterManager) → bool
+
+<a id="py_os_parameter.PyParameterManager.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.PyParameterManager.__is_equal__"></a>
+
+#### \_\_is_equal_\_(arg2: PyParameterManager) → bool
+
+<a id="py_os_parameter.PyParameterManager.__is_not_equal__"></a>
+
+#### \_\_is_not_equal_\_(arg2: [PyParameterManager](#py_os_parameter.PyParameterManager)) → bool
+
+<a id="py_os_parameter.PyParameterManager.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_parameter.PyParameterManager.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="py_os_parameter.PyParameterManager.__ne__"></a>
+
+#### \_\_ne_\_(arg2: [PyParameterManager](#py_os_parameter.PyParameterManager)) → bool
+
+<a id="py_os_parameter.PyParameterManager.add_dependent_parameter"></a>
+
+#### add_dependent_parameter(parameter_name: str, expression: str)
+
+<a id="py_os_parameter.PyParameterManager.add_deterministic_continuous_parameter"></a>
+
+#### add_deterministic_continuous_parameter(name: str, lower_bound: float, upper_bound: float, reference_value: float)
+
+Add a new deterministic continuous parameter. A range_mode of 1 or 2 sets a relative lower respectively upper bound. A range_mode of 3 sets both bounds relative.
+
+```python
+pm = PyParameterManager()
+pm.add_deterministic_continuous_parameter('a', 0., 3., 1.5)
+```
+
+<a id="py_os_parameter.PyParameterManager.add_parameter"></a>
+
+#### add_parameter(name: str)
+
+<a id="py_os_parameter.PyParameterManager.add_stochastic_parameter"></a>
+
+#### add_stochastic_parameter(name: str, type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType), kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind), reference_value: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
+
+Add a new stochastic parameter. It is required to set a parameter type and random parameters afterwards.
+
+```python
+pm = PyParameterManager()
+pm.add_stochastic_parameter('s1', RandomVariableType.NORMAL, RandomVariableKind.DETERMINISTIC, PyOSDesignEntry(0.72))
+pm.set_parameter_type('s1', ParameterType.STOCHASTIC)
+pm.set_ran_parameters('s1', double_list_to_vec([0.72, 0.3]))   # normal distribution: mu, sigmah
+```
+
+<a id="py_os_parameter.PyParameterManager.clear"></a>
+
+#### clear()
+
+<a id="py_os_parameter.PyParameterManager.contains_parameter"></a>
+
+#### contains_parameter(name: str) → bool
+
+#### contains_parameter(id: [UUID](id.md#id.UUID)) → bool
+
+<a id="py_os_parameter.PyParameterManager.empty"></a>
+
+#### empty() → bool
+
+<a id="py_os_parameter.PyParameterManager.erase_correlation"></a>
+
+#### erase_correlation(arg2: str, parameter_name: str) → bool
+
+<a id="py_os_parameter.PyParameterManager.erase_correlations"></a>
+
+#### erase_correlations(parameter_name_b: str) → bool
+
+<a id="py_os_parameter.PyParameterManager.erase_parameter"></a>
+
+#### erase_parameter(parameter_name: str)
+
+<a id="py_os_parameter.PyParameterManager.get_bounds"></a>
+
+#### get_bounds(parameter_name: str, lower_bound: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry), upper_bound: [PyOSDesignEntry](py_os_design.md#py_os_design.PyOSDesignEntry))
+
+#### get_bounds(parameter_name: str) → tuple
+
+[0] Note, that lower_bound and upper_bound are output arguments.
+
+[1] Return a parameter’s boundaries as a tuple.
+
+<a id="py_os_parameter.PyParameterManager.get_det_props"></a>
+
+#### get_det_props() → [DPropList](#py_os_parameter.DPropList)
+
+<a id="py_os_parameter.PyParameterManager.get_det_props_by_index"></a>
+
+#### get_det_props_by_index(parameter_name: str, index: int) → [DProp](#py_os_parameter.DProp)
+
+<a id="py_os_parameter.PyParameterManager.get_parameter"></a>
+
+#### get_parameter(parameter_name: str) → [PyParameter](#py_os_parameter.PyParameter)
+
+#### get_parameter(parameter_id: [UUID](id.md#id.UUID)) → [PyParameter](#py_os_parameter.PyParameter)
+
+<a id="py_os_parameter.PyParameterManager.get_parameter_by_index"></a>
+
+#### get_parameter_by_index(index: int) → [PyParameter](#py_os_parameter.PyParameter)
+
+<a id="py_os_parameter.PyParameterManager.get_parameters"></a>
+
+#### get_parameters() → [ParameterList](#py_os_parameter.ParameterList)
+
+<a id="py_os_parameter.PyParameterManager.get_ran_prop"></a>
+
+#### get_ran_prop(parameter_name: str) → [RanProp](#py_os_parameter.RanProp)
+
+<a id="py_os_parameter.PyParameterManager.get_ran_props"></a>
+
+#### get_ran_props() → [RanPropList](#py_os_parameter.RanPropList)
+
+<a id="py_os_parameter.PyParameterManager.get_reference_design"></a>
+
+#### get_reference_design() → [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec)
+
+<a id="py_os_parameter.PyParameterManager.get_reference_design_point"></a>
+
+#### get_reference_design_point() → [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint)
+
+<a id="py_os_parameter.PyParameterManager.get_size"></a>
+
+#### get_size() → int
+
+<a id="py_os_parameter.PyParameterManager.get_unique_name"></a>
+
+#### get_unique_name() → str
+
+<a id="py_os_parameter.PyParameterManager.import_from_csv"></a>
+
+#### import_from_csv(csv: Path path)
+
+Add parameters from csv to parameter manager.
+
+<a id="py_os_parameter.PyParameterManager.import_from_json"></a>
+
+#### import_from_json(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Add parameters from json to parameter manager.
+
+<a id="py_os_parameter.PyParameterManager.import_from_json_string"></a>
+
+#### import_from_json_string(content: str)
+
+Add parameters from json string to parameter manager.
+
+<a id="py_os_parameter.PyParameterManager.insert_parameter"></a>
+
+#### insert_parameter(parameter: [PyParameter](#py_os_parameter.PyParameter))
+
+<a id="py_os_parameter.PyParameterManager.rename_det_prop"></a>
+
+#### rename_det_prop(parameter_name: str, from: str, to: str)
+
+<a id="py_os_parameter.PyParameterManager.rename_parameter"></a>
+
+#### rename_parameter(from: str, to: str)
+
+<a id="py_os_parameter.PyParameterManager.reset_correlations"></a>
+
+#### reset_correlations()
+
+<a id="py_os_parameter.PyParameterManager.save_to_csv"></a>
+
+#### save_to_csv(csv: Path path)
+
+Save parameter manager to a csv file.
+
+<a id="py_os_parameter.PyParameterManager.save_to_json"></a>
+
+#### save_to_json(path: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+Save parameter manager to a json file.
+
+<a id="py_os_parameter.PyParameterManager.set_active"></a>
+
+#### set_active(parameter_name: str, active: bool)
+
+<a id="py_os_parameter.PyParameterManager.set_bounds"></a>
+
+#### set_bounds(parameter_name: str, lower_bound: PyOSDesignEntry, upper_bound: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameterManager.set_const_all_in_list"></a>
+
+#### set_const_all_in_list(names: WStrList) → [PyParameterManager](#py_os_parameter.PyParameterManager)
+
+<a id="py_os_parameter.PyParameterManager.set_const_flag"></a>
+
+#### set_const_flag(parameter_name: str)
+
+<a id="py_os_parameter.PyParameterManager.set_correlation"></a>
+
+#### set_correlation(parameter_name_a: str, parameter_name_b: str, value: float) → bool
+
+<a id="py_os_parameter.PyParameterManager.set_dependent"></a>
+
+#### set_dependent(parameter_name: str, expression: str)
+
+<a id="py_os_parameter.PyParameterManager.set_discrete_states"></a>
+
+#### set_discrete_states(parameter_name: str, discrete_states: [PyOSDesignEntryVec](py_os_design.md#py_os_design.PyOSDesignEntryVec))
+
+<a id="py_os_parameter.PyParameterManager.set_kind"></a>
+
+#### set_kind(parameter_name: str, kind: [DeterministicType](dynardo_py_algorithms.md#dynardo_py_algorithms.DeterministicType))
+
+<a id="py_os_parameter.PyParameterManager.set_lower_bound"></a>
+
+#### set_lower_bound(parameter_name: str, value: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameterManager.set_modifiable"></a>
+
+#### set_modifiable(parameter_name: str, modifiable: bool)
+
+<a id="py_os_parameter.PyParameterManager.set_parameter_type"></a>
+
+#### set_parameter_type(parameter_name: str, type: [ParameterType](dynardo_py_algorithms.md#dynardo_py_algorithms.ParameterType))
+
+<a id="py_os_parameter.PyParameterManager.set_ran_cov"></a>
+
+#### set_ran_cov(parameter_name: str, cov: float) → float
+
+<a id="py_os_parameter.PyParameterManager.set_ran_kind"></a>
+
+#### set_ran_kind(parameter_name: str, kind: [RandomVariableKind](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableKind))
+
+<a id="py_os_parameter.PyParameterManager.set_ran_parameters"></a>
+
+#### set_ran_parameters(parameter_name: str, parameters: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="py_os_parameter.PyParameterManager.set_ran_statistical_moments"></a>
+
+#### set_ran_statistical_moments(parameter_name: str, moments: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec))
+
+<a id="py_os_parameter.PyParameterManager.set_ran_type"></a>
+
+#### set_ran_type(parameter_name: str, type: [RandomVariableType](dynardo_py_algorithms.md#dynardo_py_algorithms.RandomVariableType))
+
+<a id="py_os_parameter.PyParameterManager.set_reference_design_point"></a>
+
+#### set_reference_design_point(design_point: [PyOSDesignPoint](py_os_design.md#py_os_design.PyOSDesignPoint))
+
+<a id="py_os_parameter.PyParameterManager.set_reference_value"></a>
+
+#### set_reference_value(parameter_name: str, value: PyOSDesignEntry)
+
+<a id="py_os_parameter.PyParameterManager.set_type"></a>
+
+#### set_type(parameter_name: str, type: [EntryType](py_os_design.md#py_os_design.EntryType))
+
+<a id="py_os_parameter.PyParameterManager.set_upper_bound"></a>
+
+#### set_upper_bound(parameter_name: str, value: PyOSDesignEntry)
 
 <a id="py_os_parameter.RanProp"></a>
 
 ## *class* py_os_parameter.RanProp
 
-- <a id="py_os_parameter.RanProp.__init__"></a>`__init__()`
+<a id="py_os_parameter.RanProp.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_os_parameter.RanPropList"></a>
 
 ## *class* py_os_parameter.RanPropList
 
-- <a id="py_os_parameter.RanPropList.__init__"></a>`__init__()`
-- <a id="py_os_parameter.RanPropList.__iter__"></a>`__iter__() → object`
-- <a id="py_os_parameter.RanPropList.push_back"></a>`push_back(arg2: [RanPropPair](#py_os_parameter.RanPropPair))`
-- <a id="py_os_parameter.RanPropList.ran_prop_export_list"></a>`ran_prop_export_list() → [RanPropList](#py_os_parameter.RanPropList)`
-- <a id="py_os_parameter.RanPropList.size"></a>`size() → int`
+<a id="py_os_parameter.RanPropList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.RanPropList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="py_os_parameter.RanPropList.push_back"></a>
+
+#### push_back(arg2: [RanPropPair](#py_os_parameter.RanPropPair))
+
+<a id="py_os_parameter.RanPropList.ran_prop_export_list"></a>
+
+#### ran_prop_export_list() → [RanPropList](#py_os_parameter.RanPropList)
+
+<a id="py_os_parameter.RanPropList.size"></a>
+
+#### size() → int
 
 <a id="py_os_parameter.RanPropPair"></a>
 
 ## *class* py_os_parameter.RanPropPair
 
-- <a id="py_os_parameter.RanPropPair.__init__"></a>`__init__()`
-- <a id="py_os_parameter.RanPropPair.first"></a>*property* `first`
-- <a id="py_os_parameter.RanPropPair.second"></a>*property* `second`
+<a id="py_os_parameter.RanPropPair.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="py_os_parameter.RanPropPair.first"></a>
+
+#### *property* first
+
+<a id="py_os_parameter.RanPropPair.second"></a>
+
+#### *property* second
 
 <a id="py_os_parameter.get_const_parameter_names"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_osl3binfile.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_osl3binfile.md
@@ -8,21 +8,63 @@
 
 ## *class* py_osl3binfile.OSL3Binfile
 
-- <a id="py_osl3binfile.OSL3Binfile.AddRecalculatedBestDesignData"></a>`AddRecalculatedBestDesignData(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager), arg4: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer), arg5: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec), arg6: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec), arg7: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="py_osl3binfile.OSL3Binfile.ConvertBinFile"></a>`ConvertBinFile(, arg2: Path [, arg3: bool]]) → object`
-- <a id="py_osl3binfile.OSL3Binfile.WriteArsmBinfile"></a>`WriteArsmBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.WriteDOEBinfile"></a>`WriteDOEBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.WriteNLPQLBinfile"></a>`WriteNLPQLBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.WriteNOABinfile"></a>`WriteNOABinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.WriteRobustnessBinfile"></a>`WriteRobustnessBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: PyOSDesignPoint, arg5: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))`
-- <a id="py_osl3binfile.OSL3Binfile.convert_binfile"></a>`convert_binfile(, arg2: Path [, arg3: bool]]) → object`
-- <a id="py_osl3binfile.OSL3Binfile.write_arsm_binfile"></a>`write_arsm_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.write_doe_binfile"></a>`write_doe_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.write_nlpqlp_binfile"></a>`write_nlpqlp_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.write_noa_binfile"></a>`write_noa_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)`
-- <a id="py_osl3binfile.OSL3Binfile.write_robustness_binfile"></a>`write_robustness_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: PyOSDesignPoint, arg5: Path)`
+<a id="py_osl3binfile.OSL3Binfile.AddRecalculatedBestDesignData"></a>
+
+#### AddRecalculatedBestDesignData(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path), arg3: [PyParameterManager](py_os_parameter.md#py_os_parameter.PyParameterManager), arg4: [PyOSDesignContainer](py_os_design.md#py_os_design.PyOSDesignContainer), arg5: [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec), arg6: [doubleVec](stdcpp_python_export.md#stdcpp_python_export.doubleVec), arg7: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="py_osl3binfile.OSL3Binfile.ConvertBinFile"></a>
+
+#### ConvertBinFile(, arg2: Path [, arg3: bool]]) → object
+
+<a id="py_osl3binfile.OSL3Binfile.WriteArsmBinfile"></a>
+
+#### WriteArsmBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.WriteDOEBinfile"></a>
+
+#### WriteDOEBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.WriteNLPQLBinfile"></a>
+
+#### WriteNLPQLBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.WriteNOABinfile"></a>
+
+#### WriteNOABinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.WriteRobustnessBinfile"></a>
+
+#### WriteRobustnessBinfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: PyOSDesignPoint, arg5: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](stdcpp_python_export.md#stdcpp_python_export.Path))
+
+<a id="py_osl3binfile.OSL3Binfile.convert_binfile"></a>
+
+#### convert_binfile(, arg2: Path [, arg3: bool]]) → object
+
+<a id="py_osl3binfile.OSL3Binfile.write_arsm_binfile"></a>
+
+#### write_arsm_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.write_doe_binfile"></a>
+
+#### write_doe_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.write_nlpqlp_binfile"></a>
+
+#### write_nlpqlp_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.write_noa_binfile"></a>
+
+#### write_noa_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: object, arg5: Path)
+
+<a id="py_osl3binfile.OSL3Binfile.write_robustness_binfile"></a>
+
+#### write_robustness_binfile(arg2: PyParameterManager, arg3: PyOSDesignContainer, arg4: PyOSDesignPoint, arg5: Path)
 
 <a id="py_osl3binfile.calc_ran_parameters"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_project.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_project.md
@@ -46,13 +46,9 @@ project.set_placeholder( name = 'ParameterManager', overwrite = True, expression
 
 ## *class* py_project.OSLFileProvider
 
-
 <a id="py_project.OSLFileProvider.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
+#### \_\_init_\_()
 
 Raises an exception
 This class cannot be instantiated from Python
@@ -61,357 +57,318 @@ This class cannot be instantiated from Python
 
 ## *class* py_project.Project
 
-
 <a id="py_project.Project.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
+#### \_\_init_\_()
 
 Raises an exception
 This class cannot be instantiated from Python
 
-
 <a id="py_project.Project.assign_placeholder"></a>
 
-### assign_placeholder
-```python
-assign_placeholder(actor_uuid: [UUID](id.md#id.UUID), property_id: str, placeholder_id: str)
-```
+#### assign_placeholder(actor_uuid: [UUID](id.md#id.UUID), property_id: str, placeholder_id: str)
 
 Assign a placeholder in this project.
 
-**Parameters:**
-- `actor_uuid` - Unique id to the actor
-- `property_id` - Property ID.
-- `placeholder_id` - Placeholder ID.
+Parameters
 
-**Raises:**
-- `RuntimeError` - Raised when placeholder does not exist, or when property does not exist, or when placeholder type and property type does not match.
+actor_uuid
+: Unique id to the actor
 
+property_id
+: Property ID.
+
+placeholder_id
+: Placeholder ID.
+
+Raises
+
+RuntimeError
+: Raised when placeholder does not exist, or
+  when property does not exist, or
+  when placeholder type and property type does not match.
 
 <a id="py_project.Project.create_placeholder_from_actor_property"></a>
 
-### create_placeholder_from_actor_property
-```python
-create_placeholder_from_actor_property(actor_uuid: UUID, property_id: str) → str
-```
+#### create_placeholder_from_actor_property(actor_uuid: UUID, property_id: str) → str
 
 Create placeholder from actor property with new id if id already exist
 
-**Parameters:**
-- `actor_uuid` - Unique id to the actor.
-- `property_id` - Name of the actor property.
-- `create_as_expression` - Decide if the placeholder is created as value or as macro expression. False by default.
+Parameters
 
-**Returns:**
-- `str` - Actual ID of the generated placeholder.
+actor_uuid
+: Unique id to the actor.
 
-**Raises:**
-- `RuntimeError` - Raised when property id is not accessible at actor.
+property_id
+: Name of the actor property.
 
+create_as_expression
+: Decide if the placeholder is created as value or as macro expression. False by default.
+
+Returns
+
+str
+: Actual ID of the generated placeholder.
+
+Raises
+
+RuntimeError
+: Raised when property id is not accessible at actor.
 
 <a id="py_project.Project.get_actions"></a>
 
-### get_actions
-```python
-get_actions() → [ProjectActions](#py_project.ProjectActions)
-```
+#### get_actions() → [ProjectActions](#py_project.ProjectActions)
 
 Get defined actions for project.
 
-
 <a id="py_project.Project.get_file_provider"></a>
 
-### get_file_provider
-```python
-get_file_provider() → [OSLFileProvider](#py_project.OSLFileProvider)
-```
+#### get_file_provider() → [OSLFileProvider](#py_project.OSLFileProvider)
 
 Get central file registration for project.
 
-
 <a id="py_project.Project.get_maximum_threads"></a>
 
-### get_maximum_threads
-```python
-get_maximum_threads() → int
-```
+#### get_maximum_threads() → int
 
 Get the maximum number of threads used by this project.
-
 
 <a id="py_project.Project.get_placeholder"></a>
 
-### get_placeholder
-```python
-get_placeholder(placeholder_id: str) → dict
-```
+#### get_placeholder(placeholder_id: str) → dict
 
 Get placeholder by id from this project as dict.
 
-**Parameters:**
-- `placeholder_id` - Placeholder ID.
+Parameters
 
-**Returns:**
-- `dict` - 
-- `name : str` - Placeholder ID.
-- `user_level` - User level.
-- `description` - Placeholder description.
-- `range` - Placeholder range.
-- `value` - Placeholder value. Datatype should match with the type argument.
-- `type` - Placeholder type.
-- `expression` - Placeholder macro expression.
+placeholder_id
+: Placeholder ID.
 
-**Raises:**
-- `RuntimeError` - Raised when the placeholder does not exist.
+Returns
 
+dict
+name : str
+
+> Placeholder ID.
+
+user_level
+: User level.
+
+description
+: Placeholder description.
+
+range
+: Placeholder range.
+
+value
+: Placeholder value. Datatype should match with the type argument.
+
+type
+: Placeholder type.
+
+expression
+: Placeholder macro expression.
+
+Raises
+
+RuntimeError
+: Raised when the placeholder does not exist.
 
 <a id="py_project.Project.get_placeholder_ids"></a>
 
-### get_placeholder_ids
-```python
-get_placeholder_ids() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
-```
+#### get_placeholder_ids() → [WStrList](stdcpp_python_export.md#stdcpp_python_export.WStrList)
 
 Get placeholder ids from this project.
 
-**Returns:**
-- `list` - List of placeholder ids.
+Returns
 
+list
+: List of placeholder ids.
 
 <a id="py_project.Project.get_protocol_file_path"></a>
 
-### get_protocol_file_path
-```python
-get_protocol_file_path() → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
-```
+#### get_protocol_file_path() → [Path](stdcpp_python_export.md#stdcpp_python_export.Path)
 
 Get the path of the protocol file.
 
-
 <a id="py_project.Project.get_root_system"></a>
 
-### get_root_system
-```python
-get_root_system() → [RunnableSystem](_optiSLang_Actors.md#optiSLang_Actors.RunnableSystem)
-```
+#### get_root_system() → [RunnableSystem](_optiSLang_Actors.md#optiSLang_Actors.RunnableSystem)
 
 Get root system.
 
-
 <a id="py_project.Project.get_run_scenario"></a>
 
-### get_run_scenario
-```python
-get_run_scenario() → [ProjectRunScenario](#py_project.ProjectRunScenario)
-```
+#### get_run_scenario() → [ProjectRunScenario](#py_project.ProjectRunScenario)
 
 Get run scenario for project.
 
-
 <a id="py_project.Project.get_state"></a>
 
-### get_state
-```python
-get_state() → [ProjectStatus](#py_project.ProjectStatus)
-```
+#### get_state() → [ProjectStatus](#py_project.ProjectStatus)
 
 Get state of project.
 
-
 <a id="py_project.Project.name"></a>
 
-### *property* name
-```python
-name
-```
+#### *property* name
 
 The project’s name as displayed.
 
-
 <a id="py_project.Project.project_dir"></a>
 
-### *property* project_dir
-```python
-project_dir
-```
+#### *property* project_dir
 
 The project directory. Empty string if the project has not yet been saved.
 
-
 <a id="py_project.Project.project_path"></a>
 
-### *property* project_path
-```python
-project_path
-```
+#### *property* project_path
 
 The project file path. Empty string if the project has not yet been saved.
 
-
 <a id="py_project.Project.project_working_dir"></a>
 
-### *property* project_working_dir
-```python
-project_working_dir
-```
+#### *property* project_working_dir
 
 The project working dir path. Empty string if the project has not yet been saved.
 
-
 <a id="py_project.Project.reference_files_dir"></a>
 
-### *property* reference_files_dir
-```python
-reference_files_dir
-```
+#### *property* reference_files_dir
 
 The reference files directory path.
 
-
 <a id="py_project.Project.remove_placeholder"></a>
 
-### remove_placeholder
-```python
-remove_placeholder(placeholder_id: str)
-```
+#### remove_placeholder(placeholder_id: str)
 
 Remove a placeholder from this project.
 
-**Parameters:**
-- `placeholder_id` - Placeholder ID.
+Parameters
 
+placeholder_id
+: Placeholder ID.
 
 <a id="py_project.Project.rename_placeholder"></a>
 
-### rename_placeholder
-```python
-rename_placeholder(existing_placdeholder_id: str, new_placdeholder_id: str)
-```
+#### rename_placeholder(existing_placdeholder_id: str, new_placdeholder_id: str)
 
 Rename a placeholder in this project.
 
-**Parameters:**
-- `placeholder_id` - Placeholder ID.
-- `new_placeholder_id` - New placeholder ID.
+Parameters
 
-**Raises:**
-- `RuntimeError` - Raised when placeholder does not exist.
+placeholder_id
+: Placeholder ID.
 
+new_placeholder_id
+: New placeholder ID.
+
+Raises
+
+RuntimeError
+: Raised when placeholder does not exist.
 
 <a id="py_project.Project.set_actions"></a>
 
-### set_actions
-```python
-set_actions(actions: [ProjectActions](#py_project.ProjectActions))
-```
+#### set_actions(actions: [ProjectActions](#py_project.ProjectActions))
 
 Set defined actions for project.
 
-
 <a id="py_project.Project.set_maximum_threads"></a>
 
-### set_maximum_threads
-```python
-set_maximum_threads(num_threads: int)
-```
+#### set_maximum_threads(num_threads: int)
 
 Get the maximum number of threads used by this project.
 
-
 <a id="py_project.Project.set_placeholder"></a>
 
-### set_placeholder
-```python
-set_placeholder(, name: object=None [, user_level: object=None [, description: object=None [, range: object=None [, value: object=None [, value_type: object=None [, expression: object=None [, overwrite: bool=False]]]]]]]]) → str
-```
+#### set_placeholder(, name: object=None [, user_level: object=None [, description: object=None [, range: object=None [, value: object=None [, value_type: object=None [, expression: object=None [, overwrite: bool=False]]]]]]]]) → str
 
 Create a new placeholder or overwrite an existing one.
 
-**Parameters:**
-- `name : str, optional` - Placeholder ID. In case of creating a new placeholder, the ID may be adapted to maintain ID uniqueness. None by default.
-- `user_level` - User level. py_placeholder.PLACEHOLDER_USERLEVEL_FLOW_ENGINEER by default.
-- `description` - Placeholder description. None by default.
-- `range` - Placeholder range. None by default.
-- `value` - Placeholder value. Datatype should match with the type argument. Mutual exclusive with the expression argument. None by default
-- `type` - Placeholder type. py_placeholder.PLACEHOLDER_TYPE_RAW by default.
-- `expression` - Placeholder macro expression. Mutual exclusive with the value argument. None by default.
-- `overwrite` - In case overwrite is True and placeholder is found by name, specified attributes will be overwritten. A new placeholder is created otherwise. False by default.
+Parameters:
+name : str, optional
 
-**Returns:**
-- `str` - Actual ID of the generated/modified placeholder.
+> Placeholder ID. In case of creating a new placeholder, the ID may be adapted to maintain ID uniqueness. None by default.
 
-**Raises:**
-- `RuntimeError` - Raised when the placeholder cannot be created/modified.
+user_level
+: User level. py_placeholder.PLACEHOLDER_USERLEVEL_FLOW_ENGINEER by default.
 
+description
+: Placeholder description. None by default.
+
+range
+: Placeholder range. None by default.
+
+value
+: Placeholder value. Datatype should match with the type argument. Mutual exclusive with the expression argument. None by default
+
+type
+: Placeholder type. py_placeholder.PLACEHOLDER_TYPE_RAW by default.
+
+expression
+: Placeholder macro expression. Mutual exclusive with the value argument. None by default.
+
+overwrite
+: In case overwrite is True and placeholder is found by name, specified attributes will be overwritten. A new placeholder is created otherwise. False by default.
+
+Returns
+
+str
+: Actual ID of the generated/modified placeholder.
+
+Raises
+
+RuntimeError
+: Raised when the placeholder cannot be created/modified.
 
 <a id="py_project.Project.settings"></a>
 
-### *property* settings
-```python
-settings
-```
+#### *property* settings
 
 Project settings.
 
-
 <a id="py_project.Project.unassign_placeholder"></a>
 
-### unassign_placeholder
-```python
-unassign_placeholder(actor_uuid: UUID, placeholder: str id)
-```
+#### unassign_placeholder(actor_uuid: UUID, placeholder: str id)
 
 Remove a placeholder assignment in this project.
 
-**Parameters:**
-- `actor_uuid` - Unique id to the actor
-- `property_id` - Property ID.
+Parameters
+
+actor_uuid
+: Unique id to the actor
+
+property_id
+: Property ID.
 
 <a id="py_project.ProjectAction"></a>
 
 ## *class* py_project.ProjectAction
 
-
 <a id="py_project.ProjectAction.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
+#### \_\_init_\_()
 
 Raises an exception
 This class cannot be instantiated from Python
 
-
 <a id="py_project.ProjectAction.name"></a>
 
-### *property* name
-```python
-name
-```
+#### *property* name
 
 Action name.
 
-
 <a id="py_project.ProjectAction.point"></a>
 
-### *property* point
-```python
-point
-```
+#### *property* point
 
 Action point.
 
-
 <a id="py_project.ProjectAction.type"></a>
 
-### type
-```python
-type() → [ProjectActionType](#py_project.ProjectActionType)
-```
+#### type() → [ProjectActionType](#py_project.ProjectActionType)
 
 Action type.
 
@@ -419,93 +376,49 @@ Action type.
 
 ## *class* py_project.ProjectActionList
 
-
 <a id="py_project.ProjectActionList.__contains__"></a>
 
-### __contains__
-```python
-__contains__(arg2: object) → bool
-```
-
+#### \_\_contains_\_(arg2: object) → bool
 
 <a id="py_project.ProjectActionList.__delitem__"></a>
 
-### __delitem__
-```python
-__delitem__(arg2: object)
-```
-
+#### \_\_delitem_\_(arg2: object)
 
 <a id="py_project.ProjectActionList.__getitem__"></a>
 
-### __getitem__
-```python
-__getitem__(arg2: object) → object
-```
-
+#### \_\_getitem_\_(arg2: object) → object
 
 <a id="py_project.ProjectActionList.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
-
+#### \_\_init_\_()
 
 <a id="py_project.ProjectActionList.__iter__"></a>
 
-### __iter__
-```python
-__iter__() → object
-```
-
+#### \_\_iter_\_() → object
 
 <a id="py_project.ProjectActionList.__len__"></a>
 
-### __len__
-```python
-__len__() → int
-```
-
+#### \_\_len_\_() → int
 
 <a id="py_project.ProjectActionList.__setitem__"></a>
 
-### __setitem__
-```python
-__setitem__(arg2: object, arg3: object)
-```
-
+#### \_\_setitem_\_(arg2: object, arg3: object)
 
 <a id="py_project.ProjectActionList.append"></a>
 
-### append
-```python
-append(arg2: object)
-```
-
+#### append(arg2: object)
 
 <a id="py_project.ProjectActionList.extend"></a>
 
-### extend
-```python
-extend(arg2: object)
-```
-
+#### extend(arg2: object)
 
 <a id="py_project.ProjectActionList.push"></a>
 
-### push
-```python
-push(action: [ProjectAction](#py_project.ProjectAction))
-```
-
+#### push(action: [ProjectAction](#py_project.ProjectAction))
 
 <a id="py_project.ProjectActionList.size"></a>
 
-### size
-```python
-size() → int
-```
+#### size() → int
 
 <a id="py_project.ProjectActionPoint"></a>
 
@@ -515,37 +428,59 @@ size() → int
 
 Enumerates possible project action points.
 
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ANY"></a>`PROJECT_ACTION_POINT_ANY *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ANY*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_NONE"></a>`PROJECT_ACTION_POINT_NONE *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_NONE*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START"></a>`PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPEN"></a>`PROJECT_ACTION_POINT_ON_PROJECT_OPEN *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPEN*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPENED"></a>`PROJECT_ACTION_POINT_ON_PROJECT_OPENED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPENED*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVE"></a>`PROJECT_ACTION_POINT_ON_PROJECT_SAVE *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVE*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVED"></a>`PROJECT_ACTION_POINT_ON_PROJECT_SAVED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVED*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STARTED"></a>`PROJECT_ACTION_POINT_ON_PROJECT_STARTED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STARTED*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOPPED"></a>`PROJECT_ACTION_POINT_ON_PROJECT_STOPPED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOPPED*`
-- <a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED"></a>`PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED*`
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ANY"></a>
+
+#### PROJECT_ACTION_POINT_ANY *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ANY*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_NONE"></a>
+
+#### PROJECT_ACTION_POINT_NONE *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_NONE*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_ABOUT_TO_START*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPEN"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_OPEN *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPEN*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPENED"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_OPENED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_OPENED*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVE"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_SAVE *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVE*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVED"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_SAVED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_SAVED*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STARTED"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_STARTED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STARTED*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOPPED"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_STOPPED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOPPED*
+
+<a id="py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED"></a>
+
+#### PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED *= py_project.ProjectActionPoint.PROJECT_ACTION_POINT_ON_PROJECT_STOP_REQUESTED*
 
 <a id="py_project.ProjectActionRunScript"></a>
 
 ## *class* py_project.ProjectActionRunScript
 
-
 <a id="py_project.ProjectActionRunScript.__init__"></a>
 
-### __init__
-```python
-__init__()
-__init__(arg2: str, arg3: str, arg4: [ProjectActionPoint](#py_project.ProjectActionPoint))
-```
+#### \_\_init_\_()
 
+#### \_\_init_\_(arg2: str, arg3: str, arg4: [ProjectActionPoint](#py_project.ProjectActionPoint))
 
 <a id="py_project.ProjectActionRunScript.script"></a>
 
-### *property* script
-```python
-script
-```
+#### *property* script
 
 Script content to execute.
 
@@ -553,22 +488,15 @@ Script content to execute.
 
 ## *class* py_project.ProjectActionRunScriptFile
 
-
 <a id="py_project.ProjectActionRunScriptFile.__init__"></a>
 
-### __init__
-```python
-__init__()
-__init__(arg2: str, arg3: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath), arg4: [ProjectActionPoint](#py_project.ProjectActionPoint))
-```
+#### \_\_init_\_()
 
+#### \_\_init_\_(arg2: str, arg3: [ProvidedPath](py_file_access.md#py_file_access.ProvidedPath), arg4: [ProjectActionPoint](#py_project.ProjectActionPoint))
 
 <a id="py_project.ProjectActionRunScriptFile.script"></a>
 
-### *property* script
-```python
-script
-```
+#### *property* script
 
 Script file to execute.
 
@@ -580,68 +508,49 @@ Script file to execute.
 
 Enumerates possible project action types.
 
-- <a id="py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT"></a>`PROJECT_ACTION_RUN_SCRIPT *= py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT*`
-- <a id="py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT_FILE"></a>`PROJECT_ACTION_RUN_SCRIPT_FILE *= py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT_FILE*`
+<a id="py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT"></a>
+
+#### PROJECT_ACTION_RUN_SCRIPT *= py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT*
+
+<a id="py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT_FILE"></a>
+
+#### PROJECT_ACTION_RUN_SCRIPT_FILE *= py_project.ProjectActionType.PROJECT_ACTION_RUN_SCRIPT_FILE*
 
 <a id="py_project.ProjectActions"></a>
 
 ## *class* py_project.ProjectActions
 
-
 <a id="py_project.ProjectActions.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
-
+#### \_\_init_\_()
 
 <a id="py_project.ProjectActions.actions"></a>
 
-### *property* actions
-```python
-actions
-```
+#### *property* actions
 
 Actions container.
 
-
 <a id="py_project.ProjectActions.contains"></a>
 
-### contains
-```python
-contains(name: str) → bool
-```
+#### contains(name: str) → bool
 
 Test if action exists.
 
-
 <a id="py_project.ProjectActions.register"></a>
 
-### register
-```python
-register(action: [ProjectAction](#py_project.ProjectAction)) → bool
-```
+#### register(action: [ProjectAction](#py_project.ProjectAction)) → bool
 
 Register project action.
 
-
 <a id="py_project.ProjectActions.unique_name"></a>
 
-### unique_name
-```python
-unique_name(base: str) → str
-```
+#### unique_name(base: str) → str
 
 Get unique action name.
 
-
 <a id="py_project.ProjectActions.unregister"></a>
 
-### unregister
-```python
-unregister(name: str) → bool
-```
+#### unregister(name: str) → bool
 
 Unregister project action by name.
 
@@ -653,8 +562,13 @@ Unregister project action by name.
 
 Enumerates possible filename escape modes.
 
-- <a id="py_project.ProjectFilenameEscape.PROJECT_FE_FULL"></a>`PROJECT_FE_FULL *= py_project.ProjectFilenameEscape.PROJECT_FE_FULL*`
-- <a id="py_project.ProjectFilenameEscape.PROJECT_FE_RESERVED_ONLY"></a>`PROJECT_FE_RESERVED_ONLY *= py_project.ProjectFilenameEscape.PROJECT_FE_RESERVED_ONLY*`
+<a id="py_project.ProjectFilenameEscape.PROJECT_FE_FULL"></a>
+
+#### PROJECT_FE_FULL *= py_project.ProjectFilenameEscape.PROJECT_FE_FULL*
+
+<a id="py_project.ProjectFilenameEscape.PROJECT_FE_RESERVED_ONLY"></a>
+
+#### PROJECT_FE_RESERVED_ONLY *= py_project.ProjectFilenameEscape.PROJECT_FE_RESERVED_ONLY*
 
 <a id="py_project.ProjectRunScenario"></a>
 
@@ -664,243 +578,171 @@ Enumerates possible filename escape modes.
 
 Enumerates possible project run scenarios.
 
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_ABORTED"></a>`PROJECT_RUN_SCENARIO_ABORTED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_ABORTED*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_FINISHED"></a>`PROJECT_RUN_SCENARIO_FINISHED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_FINISHED*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_ALL"></a>`PROJECT_RUN_SCENARIO_MODIFIED_ALL *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_ALL*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_SOME"></a>`PROJECT_RUN_SCENARIO_MODIFIED_SOME *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_SOME*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PARTIAL"></a>`PROJECT_RUN_SCENARIO_PARTIAL *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PARTIAL*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PAUSED"></a>`PROJECT_RUN_SCENARIO_PAUSED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PAUSED*`
-- <a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PRISTINE"></a>`PROJECT_RUN_SCENARIO_PRISTINE *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PRISTINE*`
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_ABORTED"></a>
+
+#### PROJECT_RUN_SCENARIO_ABORTED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_ABORTED*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_FINISHED"></a>
+
+#### PROJECT_RUN_SCENARIO_FINISHED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_FINISHED*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_ALL"></a>
+
+#### PROJECT_RUN_SCENARIO_MODIFIED_ALL *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_ALL*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_SOME"></a>
+
+#### PROJECT_RUN_SCENARIO_MODIFIED_SOME *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_MODIFIED_SOME*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PARTIAL"></a>
+
+#### PROJECT_RUN_SCENARIO_PARTIAL *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PARTIAL*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PAUSED"></a>
+
+#### PROJECT_RUN_SCENARIO_PAUSED *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PAUSED*
+
+<a id="py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PRISTINE"></a>
+
+#### PROJECT_RUN_SCENARIO_PRISTINE *= py_project.ProjectRunScenario.PROJECT_RUN_SCENARIO_PRISTINE*
 
 <a id="py_project.ProjectSettings"></a>
 
 ## *class* py_project.ProjectSettings
 
-
 <a id="py_project.ProjectSettings.__init__"></a>
 
-### __init__
-```python
-__init__()
-```
-
+#### \_\_init_\_()
 
 <a id="py_project.ProjectSettings.actors_ignore_predecessor_failure"></a>
 
-### *property* actors_ignore_predecessor_failure
-```python
-actors_ignore_predecessor_failure
-```
+#### *property* actors_ignore_predecessor_failure
 
 Actors ignore predecessor failure flag.
 
-
 <a id="py_project.ProjectSettings.auto_save_enabled"></a>
 
-### *property* auto_save_enabled
-```python
-auto_save_enabled
-```
+#### *property* auto_save_enabled
 
 Auto save enabled flag.
 
-
 <a id="py_project.ProjectSettings.custom_location"></a>
 
-### *property* custom_location
-```python
-custom_location
-```
+#### *property* custom_location
 
 Custom working directory location.
 
-
 <a id="py_project.ProjectSettings.filename_escape_mode"></a>
 
-### *property* filename_escape_mode
-```python
-filename_escape_mode
-```
+#### *property* filename_escape_mode
 
 Filename escape mode.
 
-
 <a id="py_project.ProjectSettings.hide_number_of_message_queue_threads_warning"></a>
 
-### *property* hide_number_of_message_queue_threads_warning
-```python
-hide_number_of_message_queue_threads_warning
-```
+#### *property* hide_number_of_message_queue_threads_warning
 
 Hide number of message queue threads warning flag.
 
-
 <a id="py_project.ProjectSettings.maximum_auto_relocation_depth"></a>
 
-### *property* maximum_auto_relocation_depth
-```python
-maximum_auto_relocation_depth
-```
+#### *property* maximum_auto_relocation_depth
 
 Maximum auto relocation depth.
 
-
 <a id="py_project.ProjectSettings.number_of_message_queue_threads"></a>
 
-### *property* number_of_message_queue_threads
-```python
-number_of_message_queue_threads
-```
+#### *property* number_of_message_queue_threads
 
 Number of message queue threads.
 
-
 <a id="py_project.ProjectSettings.project_actions"></a>
 
-### *property* project_actions
-```python
-project_actions
-```
+#### *property* project_actions
 
 Project actions.
 
-
 <a id="py_project.ProjectSettings.project_id"></a>
 
-### *property* project_id
-```python
-project_id
-```
+#### *property* project_id
 
 Project id.
 
-
 <a id="py_project.ProjectSettings.project_manager_id"></a>
 
-### *property* project_manager_id
-```python
-project_manager_id
-```
+#### *property* project_manager_id
 
 Project manager id.
 
-
 <a id="py_project.ProjectSettings.purge_on_save"></a>
 
-### *property* purge_on_save
-```python
-purge_on_save
-```
+#### *property* purge_on_save
 
 Purge on save flag.
 
-
 <a id="py_project.ProjectSettings.reference_files_directory_name"></a>
 
-### *property* reference_files_directory_name
-```python
-reference_files_directory_name
-```
+#### *property* reference_files_directory_name
 
 Reference files directory name.
 
-
 <a id="py_project.ProjectSettings.remove_empty_directories_on_purge"></a>
 
-### *property* remove_empty_directories_on_purge
-```python
-remove_empty_directories_on_purge
-```
+#### *property* remove_empty_directories_on_purge
 
 Remove empty directories on purge flag.
 
-
 <a id="py_project.ProjectSettings.short_description"></a>
 
-### *property* short_description
-```python
-short_description
-```
+#### *property* short_description
 
 Project short description.
 
-
 <a id="py_project.ProjectSettings.show_conditional_exec_ui"></a>
 
-### *property* show_conditional_exec_ui
-```python
-show_conditional_exec_ui
-```
+#### *property* show_conditional_exec_ui
 
 Conditional execution ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.show_environment_ui"></a>
 
-### *property* show_environment_ui
-```python
-show_environment_ui
-```
+#### *property* show_environment_ui
 
 Environment ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.show_files_ui"></a>
 
-### *property* show_files_ui
-```python
-show_files_ui
-```
+#### *property* show_files_ui
 
 Files ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.show_placeholders_ui"></a>
 
-### *property* show_placeholders_ui
-```python
-show_placeholders_ui
-```
+#### *property* show_placeholders_ui
 
 Placeholders ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.show_run_options_ui"></a>
 
-### *property* show_run_options_ui
-```python
-show_run_options_ui
-```
+#### *property* show_run_options_ui
 
 Run options ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.show_variables_ui"></a>
 
-### *property* show_variables_ui
-```python
-show_variables_ui
-```
+#### *property* show_variables_ui
 
 Variables ui visibility flag.
 
-
 <a id="py_project.ProjectSettings.working_data_storage"></a>
 
-### *property* working_data_storage
-```python
-working_data_storage
-```
+#### *property* working_data_storage
 
 Working data storage mode.
 
-
 <a id="py_project.ProjectSettings.working_directory_location"></a>
 
-### *property* working_directory_location
-```python
-working_directory_location
-```
+#### *property* working_directory_location
 
 Working directory location.
 
@@ -912,15 +754,41 @@ Working directory location.
 
 Enumerates possible project states.
 
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_ABORTED"></a>`PROJECT_STATUS_ABORTED *= py_project.ProjectStatus.PROJECT_STATUS_ABORTED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_ABORT_REQUESTED"></a>`PROJECT_STATUS_ABORT_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_ABORT_REQUESTED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_FINISHED"></a>`PROJECT_STATUS_FINISHED *= py_project.ProjectStatus.PROJECT_STATUS_FINISHED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_IDLE"></a>`PROJECT_STATUS_IDLE *= py_project.ProjectStatus.PROJECT_STATUS_IDLE*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_PAUSED"></a>`PROJECT_STATUS_PAUSED *= py_project.ProjectStatus.PROJECT_STATUS_PAUSED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_PAUSE_REQUESTED"></a>`PROJECT_STATUS_PAUSE_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_PAUSE_REQUESTED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_PROCESSING"></a>`PROJECT_STATUS_PROCESSING *= py_project.ProjectStatus.PROJECT_STATUS_PROCESSING*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_STOPPED"></a>`PROJECT_STATUS_STOPPED *= py_project.ProjectStatus.PROJECT_STATUS_STOPPED*`
-- <a id="py_project.ProjectStatus.PROJECT_STATUS_STOP_REQUESTED"></a>`PROJECT_STATUS_STOP_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_STOP_REQUESTED*`
+<a id="py_project.ProjectStatus.PROJECT_STATUS_ABORTED"></a>
+
+#### PROJECT_STATUS_ABORTED *= py_project.ProjectStatus.PROJECT_STATUS_ABORTED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_ABORT_REQUESTED"></a>
+
+#### PROJECT_STATUS_ABORT_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_ABORT_REQUESTED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_FINISHED"></a>
+
+#### PROJECT_STATUS_FINISHED *= py_project.ProjectStatus.PROJECT_STATUS_FINISHED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_IDLE"></a>
+
+#### PROJECT_STATUS_IDLE *= py_project.ProjectStatus.PROJECT_STATUS_IDLE*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_PAUSED"></a>
+
+#### PROJECT_STATUS_PAUSED *= py_project.ProjectStatus.PROJECT_STATUS_PAUSED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_PAUSE_REQUESTED"></a>
+
+#### PROJECT_STATUS_PAUSE_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_PAUSE_REQUESTED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_PROCESSING"></a>
+
+#### PROJECT_STATUS_PROCESSING *= py_project.ProjectStatus.PROJECT_STATUS_PROCESSING*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_STOPPED"></a>
+
+#### PROJECT_STATUS_STOPPED *= py_project.ProjectStatus.PROJECT_STATUS_STOPPED*
+
+<a id="py_project.ProjectStatus.PROJECT_STATUS_STOP_REQUESTED"></a>
+
+#### PROJECT_STATUS_STOP_REQUESTED *= py_project.ProjectStatus.PROJECT_STATUS_STOP_REQUESTED*
 
 <a id="py_project.ProjectWorkingDataStorage"></a>
 
@@ -930,8 +798,13 @@ Enumerates possible project states.
 
 Enumerates possible project working data storage modes.
 
-- <a id="py_project.ProjectWorkingDataStorage.PROJECT_WDL_EXTERNAL"></a>`PROJECT_WDL_EXTERNAL *= py_project.ProjectWorkingDataStorage.PROJECT_WDL_EXTERNAL*`
-- <a id="py_project.ProjectWorkingDataStorage.PROJECT_WDS_EMBEDDED"></a>`PROJECT_WDS_EMBEDDED *= py_project.ProjectWorkingDataStorage.PROJECT_WDS_EMBEDDED*`
+<a id="py_project.ProjectWorkingDataStorage.PROJECT_WDL_EXTERNAL"></a>
+
+#### PROJECT_WDL_EXTERNAL *= py_project.ProjectWorkingDataStorage.PROJECT_WDL_EXTERNAL*
+
+<a id="py_project.ProjectWorkingDataStorage.PROJECT_WDS_EMBEDDED"></a>
+
+#### PROJECT_WDS_EMBEDDED *= py_project.ProjectWorkingDataStorage.PROJECT_WDS_EMBEDDED*
 
 <a id="py_project.ProjectWorkingDirectoryLocation"></a>
 
@@ -941,5 +814,10 @@ Enumerates possible project working data storage modes.
 
 Enumerates possible project working diretory locations.
 
-- <a id="py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_ALONGSIDE_PROJECT"></a>`PROJECT_WDL_ALONGSIDE_PROJECT *= py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_ALONGSIDE_PROJECT*`
-- <a id="py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_CUSTOM"></a>`PROJECT_WDL_CUSTOM *= py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_CUSTOM*`
+<a id="py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_ALONGSIDE_PROJECT"></a>
+
+#### PROJECT_WDL_ALONGSIDE_PROJECT *= py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_ALONGSIDE_PROJECT*
+
+<a id="py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_CUSTOM"></a>
+
+#### PROJECT_WDL_CUSTOM *= py_project.ProjectWorkingDirectoryLocation.PROJECT_WDL_CUSTOM*

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_random_variables.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_random_variables.md
@@ -4,39 +4,90 @@
 
 ## *class* py_random_variables.FitRV
 
-- <a id="py_random_variables.FitRV.__init__"></a>`__init__()`
-- `__init__(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`
-- `__init__(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- `__init__(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type), arg3: str)`
-- <a id="py_random_variables.FitRV.get_cdf"></a>`get_cdf(arg2: float) → float`
-- <a id="py_random_variables.FitRV.get_cdf_inv"></a>`get_cdf_inv(arg2: float) → float`
-- <a id="py_random_variables.FitRV.get_mean"></a>`get_mean() → float`
-- <a id="py_random_variables.FitRV.get_moments"></a>`get_moments(arg2: int) → float`
-- <a id="py_random_variables.FitRV.get_name"></a>`get_name() → str`
-- <a id="py_random_variables.FitRV.get_num_moments"></a>`get_num_moments() → int`
-- <a id="py_random_variables.FitRV.get_num_parameters"></a>`get_num_parameters() → int`
-- <a id="py_random_variables.FitRV.get_parameter"></a>`get_parameter(arg2: int) → float`
-- <a id="py_random_variables.FitRV.get_pdf"></a>`get_pdf(arg2: float) → float`
-- <a id="py_random_variables.FitRV.get_stddev"></a>`get_stddev() → float`
-- <a id="py_random_variables.FitRV.is_valid"></a>`is_valid() → bool`
-- <a id="py_random_variables.FitRV.set_moments"></a>`set_moments(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
-- <a id="py_random_variables.FitRV.set_parameters"></a>`set_parameters(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))`
+<a id="py_random_variables.FitRV.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+#### \_\_init_\_(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+#### \_\_init_\_(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type), arg3: str)
+
+<a id="py_random_variables.FitRV.get_cdf"></a>
+
+#### get_cdf(arg2: float) → float
+
+<a id="py_random_variables.FitRV.get_cdf_inv"></a>
+
+#### get_cdf_inv(arg2: float) → float
+
+<a id="py_random_variables.FitRV.get_mean"></a>
+
+#### get_mean() → float
+
+<a id="py_random_variables.FitRV.get_moments"></a>
+
+#### get_moments(arg2: int) → float
+
+<a id="py_random_variables.FitRV.get_name"></a>
+
+#### get_name() → str
+
+<a id="py_random_variables.FitRV.get_num_moments"></a>
+
+#### get_num_moments() → int
+
+<a id="py_random_variables.FitRV.get_num_parameters"></a>
+
+#### get_num_parameters() → int
+
+<a id="py_random_variables.FitRV.get_parameter"></a>
+
+#### get_parameter(arg2: int) → float
+
+<a id="py_random_variables.FitRV.get_pdf"></a>
+
+#### get_pdf(arg2: float) → float
+
+<a id="py_random_variables.FitRV.get_stddev"></a>
+
+#### get_stddev() → float
+
+<a id="py_random_variables.FitRV.is_valid"></a>
+
+#### is_valid() → bool
+
+<a id="py_random_variables.FitRV.set_moments"></a>
+
+#### set_moments(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
+
+<a id="py_random_variables.FitRV.set_parameters"></a>
+
+#### set_parameters(arg2: [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type))
 
 <a id="py_random_variables.RVSet"></a>
 
 ## *class* py_random_variables.RVSet
 
-- <a id="py_random_variables.RVSet.__init__"></a>`__init__(parameter: PyParameterManager manager, design: PyOSDesignPoint point to extract from) → object`<br>
-  Extract mixed and stochastic parameters from a design point and convert them into an RVSet.
+<a id="py_random_variables.RVSet.__init__"></a>
+
+#### \_\_init_\_(parameter: PyParameterManager manager, design: PyOSDesignPoint point to extract from) → object
+
+Extract mixed and stochastic parameters from a design point and convert them into an RVSet.
 
 <a id="py_random_variables.RVSet_Independent"></a>
 
 ## *class* py_random_variables.RVSet_Independent
 
-- <a id="py_random_variables.RVSet_Independent.__init__"></a>`__init__()`
+<a id="py_random_variables.RVSet_Independent.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_random_variables.RVSet_Nataf"></a>
 
 ## *class* py_random_variables.RVSet_Nataf
 
-- <a id="py_random_variables.RVSet_Nataf.__init__"></a>`__init__()`
+<a id="py_random_variables.RVSet_Nataf.__init__"></a>
+
+#### \_\_init_\_()

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_reliability_montecarlo.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_reliability_montecarlo.md
@@ -8,7 +8,9 @@ This algorithm implements Monte Carlo sampling.
 The algorithm can be controlled either by a predefined number of samples, or by a desired accuracy (c.o.v.) of the estimator of Pf (or of (1-Pf) if Pf>0.5). In the latter case, the number of required samples will be selected by the algorithm during the iteration. The convergence test is carried out after each request of n parallel designs. If the desired accuracy can not be reached within the maximum allowed number of samples, the algorithm terminates without success.
 If any of the solver requests fails (success_info=false for a specific design) the algorithm either ignores this design, or it counts it as a failure event.
 
-- <a id="py_reliability_montecarlo.ReliabilityMonteCarlo.__init__"></a>`__init__()`
+<a id="py_reliability_montecarlo.ReliabilityMonteCarlo.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="py_reliability_montecarlo.SettingsMonteCarlo"></a>
 
@@ -16,11 +18,32 @@ If any of the solver requests fails (success_info=false for a specific design) t
 
 Reliability algorithm settings for Monte Carlo.
 
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.accuracy"></a>*property* `accuracy`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.automatic_sample_size"></a>*property* `automatic_sample_size`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.min_num_samples"></a>*property* `min_num_samples`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.num_designs_per_sample"></a>*property* `num_designs_per_sample`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.num_total_samples"></a>*property* `num_total_samples`
-- <a id="py_reliability_montecarlo.SettingsMonteCarlo.scaling_factor"></a>*property* `scaling_factor`
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.accuracy"></a>
+
+#### *property* accuracy
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.automatic_sample_size"></a>
+
+#### *property* automatic_sample_size
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.min_num_samples"></a>
+
+#### *property* min_num_samples
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.num_designs_per_sample"></a>
+
+#### *property* num_designs_per_sample
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.num_total_samples"></a>
+
+#### *property* num_total_samples
+
+<a id="py_reliability_montecarlo.SettingsMonteCarlo.scaling_factor"></a>
+
+#### *property* scaling_factor

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_transform.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/py_transform.md
@@ -18,10 +18,21 @@
 
 **Enumeration**
 
-- <a id="py_transform.TransformationFlags.AllProps"></a>`AllProps *= py_transform.TransformationFlags.AllProps*`
-- <a id="py_transform.TransformationFlags.DetProps"></a>`DetProps *= py_transform.TransformationFlags.DetProps*`
-- <a id="py_transform.TransformationFlags.NoTransformation"></a>`NoTransformation *= py_transform.TransformationFlags.NoTransformation*`
-- <a id="py_transform.TransformationFlags.RanProps"></a>`RanProps *= py_transform.TransformationFlags.RanProps*`
+<a id="py_transform.TransformationFlags.AllProps"></a>
+
+#### AllProps *= py_transform.TransformationFlags.AllProps*
+
+<a id="py_transform.TransformationFlags.DetProps"></a>
+
+#### DetProps *= py_transform.TransformationFlags.DetProps*
+
+<a id="py_transform.TransformationFlags.NoTransformation"></a>
+
+#### NoTransformation *= py_transform.TransformationFlags.NoTransformation*
+
+<a id="py_transform.TransformationFlags.RanProps"></a>
+
+#### RanProps *= py_transform.TransformationFlags.RanProps*
 
 <a id="py_transform.VectorToDesign"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/pyvariant.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/pyvariant.md
@@ -6,45 +6,173 @@
 
 **Enumeration**
 
-- <a id="pyvariant.InterpolationType.Linear"></a>`Linear *= pyvariant.InterpolationType.Linear*`
-- <a id="pyvariant.InterpolationType.Quadratic"></a>`Quadratic *= pyvariant.InterpolationType.Quadratic*`
-- <a id="pyvariant.InterpolationType.Spline"></a>`Spline *= pyvariant.InterpolationType.Spline*`
+<a id="pyvariant.InterpolationType.Linear"></a>
+
+#### Linear *= pyvariant.InterpolationType.Linear*
+
+<a id="pyvariant.InterpolationType.Quadratic"></a>
+
+#### Quadratic *= pyvariant.InterpolationType.Quadratic*
+
+<a id="pyvariant.InterpolationType.Spline"></a>
+
+#### Spline *= pyvariant.InterpolationType.Spline*
 
 <a id="pyvariant.VariantD"></a>
 
 ## *class* pyvariant.VariantD
 
-- <a id="pyvariant.VariantD.__add__"></a>`__add__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__complex__"></a>`__complex__() → object`
-- <a id="pyvariant.VariantD.__eq__"></a>`__eq__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__ge__"></a>`__ge__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__getinitargs__"></a>`__getinitargs__() → tuple`
-- <a id="pyvariant.VariantD.__getstate__"></a>`__getstate__() → tuple`
-- <a id="pyvariant.VariantD.__getstate_manages_dict__"></a>`__getstate_manages_dict__ *= True*`
-- <a id="pyvariant.VariantD.__gt__"></a>`__gt__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__init__"></a>`__init__()`<br>
-  [2] Create a scalar variant using Python’s builtin types. Accepts bool, integer, float and complex. [3] Create a vector or matrix by passing a list. Use a nested list to create a matrix. [4] Create a signal or xydata by passing channels and abscissa as nested lists resp. list. [5] Create a signal or xydata by passing channels and abscissa as nested lists resp. list. The matrix containing the channels can be transposed on demand.
-- `__init__(arg2: float, arg3: float)`
-- `__init__(scalar_value: object) → object`
-- `__init__(row: list) → object`
-- `__init__(channels: list, abscissa: list) → object`
-- `__init__(channels: list, abscissa: list, transpose: bool) → object`
-- <a id="pyvariant.VariantD.__le__"></a>`__le__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__lt__"></a>`__lt__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__mul__"></a>`__mul__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__repr__"></a>`__repr__() → object`
-- <a id="pyvariant.VariantD.__safe_for_unpickling__"></a>`__safe_for_unpickling__ *= True*`
-- <a id="pyvariant.VariantD.__setstate__"></a>`__setstate__(arg2: tuple)`
-- <a id="pyvariant.VariantD.__str__"></a>`__str__() → object`
-- <a id="pyvariant.VariantD.__sub__"></a>`__sub__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.__truediv__"></a>`__truediv__(arg2: [VariantD](#pyvariant.VariantD)) → object`
-- <a id="pyvariant.VariantD.get_value"></a>`get_value(row: int) → complex`<br>
-  [0] Return the complex value from index (row). ```python from pyvariant import list_2_variant_vector variant = list_2_variant_vector([1.0, 2.0, 3.0]) row = 1 print('Value from index ({}) is {}.'.format(row, variant.get_value(row).real)) # Value from index (1) is 2.0. ``` [1] Return the complex value from index (row, col). ```python from pyvariant import list_2_variant_xy_data x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3] variant = list_2_variant_xy_data(y_axis, x_axis) row, col = 0, 1 print('Value from index ({}, {}) is {}.'.format(row, col, variant.get_value(row, col).real)) # Value from index (0, 1) is 0.2. ```
-- `get_value(row: int, col: int) → complex`
-- <a id="pyvariant.VariantD.size1"></a>`size1() → int`<br>
-  Return the length of dimension 1. If VariantD is a scalar, size1 is equal to ‘1’. If VariantD is a vector, size1 returns the number of vector entries. If VariantD is a matrix, size1 returns the number of matrix rows. If VariantD is xy-data or a signal, size1 returns the number of y-axes. ```python from pyvariant import list_2_variant_xy_data x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3] variant = list_2_variant_xy_data(y_axis, x_axis) print('size1 of variant is {}.'.format(variant.size1())) # size1 of variant is 1. ```
-- <a id="pyvariant.VariantD.size2"></a>`size2() → int`<br>
-  Return the length of dimension 2. If VariantD is a scalar or vector, size2 is equal to ‘1’. If VariantD is a matrix, size2 returns the number of matrix columns. If VariantD is xydata or a signal, size2 returns the number of y-axis entries. ```python from pyvariant import list_2_variant_xy_data x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3] variant = list_2_variant_xy_data(y_axis, x_axis) print('size2 of variant is {}.'.format(variant.size2())) # size2 of variant is 3. ```
+<a id="pyvariant.VariantD.__add__"></a>
+
+#### \_\_add_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__complex__"></a>
+
+#### \_\_complex_\_() → object
+
+<a id="pyvariant.VariantD.__eq__"></a>
+
+#### \_\_eq_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__ge__"></a>
+
+#### \_\_ge_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__getinitargs__"></a>
+
+#### \_\_getinitargs_\_() → tuple
+
+<a id="pyvariant.VariantD.__getstate__"></a>
+
+#### \_\_getstate_\_() → tuple
+
+<a id="pyvariant.VariantD.__getstate_manages_dict__"></a>
+
+#### \_\_getstate_manages_dict_\_ *= True*
+
+<a id="pyvariant.VariantD.__gt__"></a>
+
+#### \_\_gt_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: float, arg3: float)
+
+#### \_\_init_\_(scalar_value: object) → object
+
+#### \_\_init_\_(row: list) → object
+
+#### \_\_init_\_(channels: list, abscissa: list) → object
+
+#### \_\_init_\_(channels: list, abscissa: list, transpose: bool) → object
+
+[2] Create a scalar variant using Python’s builtin types. Accepts bool, integer, float and complex.
+
+[3] Create a vector or matrix by passing a list. Use a nested list to create a matrix.
+
+[4] Create a signal or xydata by passing channels and abscissa as nested lists resp. list.
+
+[5] Create a signal or xydata by passing channels and abscissa as nested lists resp. list. The matrix containing the channels can be transposed on demand.
+
+<a id="pyvariant.VariantD.__le__"></a>
+
+#### \_\_le_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__lt__"></a>
+
+#### \_\_lt_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__mul__"></a>
+
+#### \_\_mul_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__repr__"></a>
+
+#### \_\_repr_\_() → object
+
+<a id="pyvariant.VariantD.__safe_for_unpickling__"></a>
+
+#### \_\_safe_for_unpickling_\_ *= True*
+
+<a id="pyvariant.VariantD.__setstate__"></a>
+
+#### \_\_setstate_\_(arg2: tuple)
+
+<a id="pyvariant.VariantD.__str__"></a>
+
+#### \_\_str_\_() → object
+
+<a id="pyvariant.VariantD.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.__truediv__"></a>
+
+#### \_\_truediv_\_(arg2: [VariantD](#pyvariant.VariantD)) → object
+
+<a id="pyvariant.VariantD.get_value"></a>
+
+#### get_value(row: int) → complex
+
+#### get_value(row: int, col: int) → complex
+
+[0] Return the complex value from index (row).
+
+```python
+from pyvariant import list_2_variant_vector
+variant = list_2_variant_vector([1.0, 2.0, 3.0])
+row = 1
+print('Value from index ({}) is {}.'.format(row, variant.get_value(row).real))
+# Value from index (1) is 2.0.
+```
+
+[1] Return the complex value from index (row, col).
+
+```python
+from pyvariant import list_2_variant_xy_data
+x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3]
+variant = list_2_variant_xy_data(y_axis, x_axis)
+row, col = 0, 1
+print('Value from index ({}, {}) is {}.'.format(row, col, variant.get_value(row, col).real))
+# Value from index (0, 1) is 0.2.
+```
+
+<a id="pyvariant.VariantD.size1"></a>
+
+#### size1() → int
+
+Return the length of dimension 1.
+If VariantD is a scalar, size1 is equal to ‘1’.
+If VariantD is a vector, size1 returns the number of vector entries.
+If VariantD is a matrix, size1 returns the number of matrix rows.
+If VariantD is xy-data or a signal, size1 returns the number of y-axes.
+
+```python
+from pyvariant import list_2_variant_xy_data
+x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3]
+variant = list_2_variant_xy_data(y_axis, x_axis)
+print('size1 of variant is {}.'.format(variant.size1()))
+# size1 of variant is 1.
+```
+
+<a id="pyvariant.VariantD.size2"></a>
+
+#### size2() → int
+
+Return the length of dimension 2.
+If VariantD is a scalar or vector, size2 is equal to ‘1’.
+If VariantD is a matrix, size2 returns the number of matrix columns.
+If VariantD is xydata or a signal, size2 returns the number of y-axis entries.
+
+```python
+from pyvariant import list_2_variant_xy_data
+x_axis, y_axis = [1.0, 2.0, 3.0], [0.1, 0.2, 0.3]
+variant = list_2_variant_xy_data(y_axis, x_axis)
+print('size2 of variant is {}.'.format(variant.size2()))
+# size2 of variant is 3.
+```
 
 <a id="pyvariant.extract_abscissae"></a>
 

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/reliability.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/reliability.md
@@ -6,8 +6,13 @@
 
 **Enumeration**
 
-- <a id="reliability.LineSearchMethod.Bisection"></a>`Bisection *= reliability.LineSearchMethod.Bisection*`
-- <a id="reliability.LineSearchMethod.RegulaFalsi"></a>`RegulaFalsi *= reliability.LineSearchMethod.RegulaFalsi*`
+<a id="reliability.LineSearchMethod.Bisection"></a>
+
+#### Bisection *= reliability.LineSearchMethod.Bisection*
+
+<a id="reliability.LineSearchMethod.RegulaFalsi"></a>
+
+#### RegulaFalsi *= reliability.LineSearchMethod.RegulaFalsi*
 
 <a id="reliability.ReliabilityAdaptiveSampling"></a>
 
@@ -23,71 +28,202 @@ max_allowed_sigma_
 After sampling the user-defined number of samples in a single step, the median and covariance matrix of the sampling density function of the next step will be determined according to the statistics of the samples lying in the failure domain. A modified eigenvalue decomposition of the covariance matrix ensures positive definiteness. Furthermore, if the C.O.V. of Pf is relatively large, the covariance matrix is scaled such that it is closer to the identity matrix.
 The user defines the number of steps and the number of samples per step. If any of the solver calls fails, the corresponding sample is either ignored or (if one tells the algorithm to interpret the failed run as a failure event) is accounted to the failure domain.
 
-- <a id="reliability.ReliabilityAdaptiveSampling.__init__"></a>`__init__()`
-- <a id="reliability.ReliabilityAdaptiveSampling.get_current_step"></a>`get_current_step() → int`<br>
-  Returns the current iteration step number.
-- <a id="reliability.ReliabilityAdaptiveSampling.get_current_weights"></a>`get_current_weights() → [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type)`<br>
-  Returns the current importance sampling weights.
+<a id="reliability.ReliabilityAdaptiveSampling.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="reliability.ReliabilityAdaptiveSampling.get_current_step"></a>
+
+#### get_current_step() → int
+
+Returns the current iteration step number.
+
+<a id="reliability.ReliabilityAdaptiveSampling.get_current_weights"></a>
+
+#### get_current_weights() → [vector_type](dynardo_py_algorithms.md#dynardo_py_algorithms.vector_type)
+
+Returns the current importance sampling weights.
 
 <a id="reliability.ReliabilityBase"></a>
 
 ## *class* reliability.ReliabilityBase
 
-- <a id="reliability.ReliabilityBase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="reliability.ReliabilityBase.adapt"></a>`adapt()`<br>
-  Creates internally the next set of designs. This is called within the loop after Appraise and prepares the next call of get_next_designs.
-- <a id="reliability.ReliabilityBase.appraise"></a>`appraise()`<br>
-  Performs a search step by the internal reliability algorithm. This is called after simulation and setting results and used inputs. The method reads all given information (and eventually performs one internal search step). After calling this method it should be possible to check the state of the iteration by is_terminated().
-- <a id="reliability.ReliabilityBase.can_provide_probability_of_failure"></a>`can_provide_probability_of_failure() → bool`<br>
-  Returns true when the probability of failure can be calculated.
-- <a id="reliability.ReliabilityBase.finalize"></a>`finalize()`<br>
-  Finalizes the iteration. Does whatever is neccessary to finalize - delete pointers, collect data…
-- <a id="reliability.ReliabilityBase.get_criteria_success_info"></a>`get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)`
-- <a id="reliability.ReliabilityBase.get_estimators_std_dev"></a>`get_estimators_std_dev() → float`<br>
-  Returns the standard deviation of the estimator of the probability of failure. It should be called after finalize(). If this quantity does not make sense (i.e. in case of FORM), it returns zero.
-- <a id="reliability.ReliabilityBase.get_inputs"></a>`get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="reliability.ReliabilityBase.get_iteration_name"></a>`get_iteration_name() → str`<br>
-  Returns the name of the current iteration.
-- <a id="reliability.ReliabilityBase.get_next_design_ids"></a>`get_next_design_ids() → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)`<br>
-  Returns the ids for the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of infos of awaiting designs.
-- <a id="reliability.ReliabilityBase.get_next_design_infos"></a>`get_next_design_infos() → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)`<br>
-  Returns some information for the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of infos of awaiting designs.
-- <a id="reliability.ReliabilityBase.get_next_designs"></a>`get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`<br>
-  Returns the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of awaiting designs.
-- <a id="reliability.ReliabilityBase.get_num_awaiting_designs"></a>`get_num_awaiting_designs() → int`
-- <a id="reliability.ReliabilityBase.get_num_computed_samples"></a>`get_num_computed_samples() → int`
-- <a id="reliability.ReliabilityBase.get_num_function_calls"></a>`get_num_function_calls() → int`
-- <a id="reliability.ReliabilityBase.get_num_inputs"></a>`get_num_inputs() → int`
-- <a id="reliability.ReliabilityBase.get_num_safety_margins"></a>`get_num_safety_margins() → int`
-- <a id="reliability.ReliabilityBase.get_num_successfully_computed_samples"></a>`get_num_successfully_computed_samples() → int`
-- <a id="reliability.ReliabilityBase.get_probability_of_failure"></a>`get_probability_of_failure() → float`<br>
-  Returns the probability of failure.
-- <a id="reliability.ReliabilityBase.get_reliability_index"></a>`get_reliability_index() → float`<br>
-  The default implementation calls GetProbabilityOfFailure and computes beta from that. It should be called after finalize().
-- <a id="reliability.ReliabilityBase.get_rv_set"></a>`get_rv_set() → [RVSet](py_random_variables.md#py_random_variables.RVSet)`
-- <a id="reliability.ReliabilityBase.get_safety_margins"></a>`get_safety_margins() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)`
-- <a id="reliability.ReliabilityBase.get_success_info_as_failure_event"></a>`get_success_info_as_failure_event() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)`
-- <a id="reliability.ReliabilityBase.has_several_iterations"></a>`has_several_iterations() → bool`<br>
-  Returns True if the algorithm produces several design sets.
-- <a id="reliability.ReliabilityBase.has_total_design_set"></a>`has_total_design_set() → bool`<br>
-  Returns True if the algorithm produces a total design set.
-- <a id="reliability.ReliabilityBase.initialize"></a>`initialize(arg2: [SettingsBase](#reliability.SettingsBase))`<br>
-  (re)sets the algorithm using the given definition data (“settings”). It must be called at least once before starting the iteration loop. It may be called several times during the lifetime of an algorithm object (then clears old data, reallocates and resets).
-- <a id="reliability.ReliabilityBase.is_converged"></a>`is_converged() → bool`<br>
-  Returns true if the iteration loop has converged. This method returns true if the algorithm has terminated and converged.
-- <a id="reliability.ReliabilityBase.is_terminated"></a>`is_terminated() → bool`<br>
-  Returns true if the iteration loop must be terminated. This method returns true if the algorithm has finished. If it either converged (or diverged or any other termination criterion is satisfied).
-- <a id="reliability.ReliabilityBase.restart"></a>`restart()`<br>
-  (re)sets the algorithm without touching the settings and maybe time-consuming pre-calculations. Initialize must be called at least once before.
-- <a id="reliability.ReliabilityBase.set_criteria_success_info"></a>`set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))`<br>
-  Sets the success flags of the actually computed designs. It must be called before Appraise. The input argument tells the algorithm for which design point vector the external solver failed (or returned senseless results).
-- <a id="reliability.ReliabilityBase.set_inputs"></a>`set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`<br>
-  Sets the design point vectors of the actually computed designs. It must be called before Appraise.
-- <a id="reliability.ReliabilityBase.set_safety_margins"></a>`set_safety_margins(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))`<br>
-  Sets the safety margin function(s) of the actually computed designs. It must be called before Appraise.
-- <a id="reliability.ReliabilityBase.set_success_info_as_failure_event"></a>`set_success_info_as_failure_event(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))`<br>
-  Sets the failure event flags of the actually computed designs without successful solver run. It must be called before Appraise. The input argument tells the algorithm for which design point vector the value success_info_[i]=false can be interpreted as a failure event.
+<a id="reliability.ReliabilityBase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="reliability.ReliabilityBase.adapt"></a>
+
+#### adapt()
+
+Creates internally the next set of designs. This is called within the loop after Appraise and prepares the next call of get_next_designs.
+
+<a id="reliability.ReliabilityBase.appraise"></a>
+
+#### appraise()
+
+Performs a search step by the internal reliability algorithm. This is called after simulation and setting results and used inputs. The method reads all given information (and eventually performs one internal search step). After calling this method it should be possible to check the state of the iteration by is_terminated().
+
+<a id="reliability.ReliabilityBase.can_provide_probability_of_failure"></a>
+
+#### can_provide_probability_of_failure() → bool
+
+Returns true when the probability of failure can be calculated.
+
+<a id="reliability.ReliabilityBase.finalize"></a>
+
+#### finalize()
+
+Finalizes the iteration. Does whatever is neccessary to finalize - delete pointers, collect data…
+
+<a id="reliability.ReliabilityBase.get_criteria_success_info"></a>
+
+#### get_criteria_success_info() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)
+
+<a id="reliability.ReliabilityBase.get_estimators_std_dev"></a>
+
+#### get_estimators_std_dev() → float
+
+Returns the standard deviation of the estimator of the probability of failure. It should be called after finalize(). If this quantity does not make sense (i.e. in case of FORM), it returns zero.
+
+<a id="reliability.ReliabilityBase.get_inputs"></a>
+
+#### get_inputs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="reliability.ReliabilityBase.get_iteration_name"></a>
+
+#### get_iteration_name() → str
+
+Returns the name of the current iteration.
+
+<a id="reliability.ReliabilityBase.get_next_design_ids"></a>
+
+#### get_next_design_ids() → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)
+
+Returns the ids for the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of infos of awaiting designs.
+
+<a id="reliability.ReliabilityBase.get_next_design_infos"></a>
+
+#### get_next_design_infos() → [uintVec](stdcpp_python_export.md#stdcpp_python_export.uintVec)
+
+Returns some information for the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of infos of awaiting designs.
+
+<a id="reliability.ReliabilityBase.get_next_designs"></a>
+
+#### get_next_designs() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+Returns the next set of design vectors for which responses must be computed. This method is called at the begin of the iteration loop. It returns a reference to the internally stored set of awaiting designs.
+
+<a id="reliability.ReliabilityBase.get_num_awaiting_designs"></a>
+
+#### get_num_awaiting_designs() → int
+
+<a id="reliability.ReliabilityBase.get_num_computed_samples"></a>
+
+#### get_num_computed_samples() → int
+
+<a id="reliability.ReliabilityBase.get_num_function_calls"></a>
+
+#### get_num_function_calls() → int
+
+<a id="reliability.ReliabilityBase.get_num_inputs"></a>
+
+#### get_num_inputs() → int
+
+<a id="reliability.ReliabilityBase.get_num_safety_margins"></a>
+
+#### get_num_safety_margins() → int
+
+<a id="reliability.ReliabilityBase.get_num_successfully_computed_samples"></a>
+
+#### get_num_successfully_computed_samples() → int
+
+<a id="reliability.ReliabilityBase.get_probability_of_failure"></a>
+
+#### get_probability_of_failure() → float
+
+Returns the probability of failure.
+
+<a id="reliability.ReliabilityBase.get_reliability_index"></a>
+
+#### get_reliability_index() → float
+
+The default implementation calls GetProbabilityOfFailure and computes beta from that. It should be called after finalize().
+
+<a id="reliability.ReliabilityBase.get_rv_set"></a>
+
+#### get_rv_set() → [RVSet](py_random_variables.md#py_random_variables.RVSet)
+
+<a id="reliability.ReliabilityBase.get_safety_margins"></a>
+
+#### get_safety_margins() → [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type)
+
+<a id="reliability.ReliabilityBase.get_success_info_as_failure_event"></a>
+
+#### get_success_info_as_failure_event() → [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type)
+
+<a id="reliability.ReliabilityBase.has_several_iterations"></a>
+
+#### has_several_iterations() → bool
+
+Returns True if the algorithm produces several design sets.
+
+<a id="reliability.ReliabilityBase.has_total_design_set"></a>
+
+#### has_total_design_set() → bool
+
+Returns True if the algorithm produces a total design set.
+
+<a id="reliability.ReliabilityBase.initialize"></a>
+
+#### initialize(arg2: [SettingsBase](#reliability.SettingsBase))
+
+(re)sets the algorithm using the given definition data (“settings”). It must be called at least once before starting the iteration loop. It may be called several times during the lifetime of an algorithm object (then clears old data, reallocates and resets).
+
+<a id="reliability.ReliabilityBase.is_converged"></a>
+
+#### is_converged() → bool
+
+Returns true if the iteration loop has converged. This method returns true if the algorithm has terminated and converged.
+
+<a id="reliability.ReliabilityBase.is_terminated"></a>
+
+#### is_terminated() → bool
+
+Returns true if the iteration loop must be terminated. This method returns true if the algorithm has finished. If it either converged (or diverged or any other termination criterion is satisfied).
+
+<a id="reliability.ReliabilityBase.restart"></a>
+
+#### restart()
+
+(re)sets the algorithm without touching the settings and maybe time-consuming pre-calculations. Initialize must be called at least once before.
+
+<a id="reliability.ReliabilityBase.set_criteria_success_info"></a>
+
+#### set_criteria_success_info(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))
+
+Sets the success flags of the actually computed designs. It must be called before Appraise. The input argument tells the algorithm for which design point vector the external solver failed (or returned senseless results).
+
+<a id="reliability.ReliabilityBase.set_inputs"></a>
+
+#### set_inputs(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+Sets the design point vectors of the actually computed designs. It must be called before Appraise.
+
+<a id="reliability.ReliabilityBase.set_safety_margins"></a>
+
+#### set_safety_margins(arg2: [matrix_type](dynardo_py_algorithms.md#dynardo_py_algorithms.matrix_type))
+
+Sets the safety margin function(s) of the actually computed designs. It must be called before Appraise.
+
+<a id="reliability.ReliabilityBase.set_success_info_as_failure_event"></a>
+
+#### set_success_info_as_failure_event(arg2: [bitset_type](dynardo_py_algorithms.md#dynardo_py_algorithms.bitset_type))
+
+Sets the failure event flags of the actually computed designs without successful solver run. It must be called before Appraise. The input argument tells the algorithm for which design point vector the value success_info_[i]=false can be interpreted as a failure event.
 
 <a id="reliability.ReliabilityMonteCarlo"></a>
 
@@ -97,7 +233,9 @@ This algorithm implements Monte Carlo sampling.
 The algorithm can be controlled either by a predefined number of samples, or by a desired accuracy (c.o.v.) of the estimator of Pf (or of (1-Pf) if Pf>0.5). In the latter case, the number of required samples will be selected by the algorithm during the iteration. The convergence test is carried out after each request of n parallel designs. If the desired accuracy can not be reached within the maximum allowed number of samples, the algorithm terminates without success.
 If any of the solver requests fails (success_info=false for a specific design) the algorithm either ignores this design, or it counts it as a failure event.
 
-- <a id="reliability.ReliabilityMonteCarlo.__init__"></a>`__init__()`
+<a id="reliability.ReliabilityMonteCarlo.__init__"></a>
+
+#### \_\_init_\_()
 
 <a id="reliability.SettingsARSMDS"></a>
 
@@ -105,13 +243,31 @@ If any of the solver requests fails (success_info=false for a specific design) t
 
 Reliability algorithm settings for ARSM with Directional Sampling.
 
-- <a id="reliability.SettingsARSMDS.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsARSMDS.blow_up"></a>*property* `blow_up`
-- <a id="reliability.SettingsARSMDS.num_directions"></a>*property* `num_directions`
-- <a id="reliability.SettingsARSMDS.num_steps"></a>*property* `num_steps`
-- <a id="reliability.SettingsARSMDS.num_supports_initial_step"></a>*property* `num_supports_initial_step`
-- <a id="reliability.SettingsARSMDS.num_supports_per_step"></a>*property* `num_supports_per_step`
+<a id="reliability.SettingsARSMDS.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsARSMDS.blow_up"></a>
+
+#### *property* blow_up
+
+<a id="reliability.SettingsARSMDS.num_directions"></a>
+
+#### *property* num_directions
+
+<a id="reliability.SettingsARSMDS.num_steps"></a>
+
+#### *property* num_steps
+
+<a id="reliability.SettingsARSMDS.num_supports_initial_step"></a>
+
+#### *property* num_supports_initial_step
+
+<a id="reliability.SettingsARSMDS.num_supports_per_step"></a>
+
+#### *property* num_supports_per_step
 
 <a id="reliability.SettingsAdaptiveSampling"></a>
 
@@ -119,16 +275,43 @@ Reliability algorithm settings for ARSM with Directional Sampling.
 
 Reliability algorithm settings for Adaptive Sampling.
 
-- <a id="reliability.SettingsAdaptiveSampling.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsAdaptiveSampling.accuracy"></a>*property* `accuracy`
-- <a id="reliability.SettingsAdaptiveSampling.automatic_sample_size"></a>*property* `automatic_sample_size`
-- <a id="reliability.SettingsAdaptiveSampling.initial_scale_factor"></a>*property* `initial_scale_factor`
-- <a id="reliability.SettingsAdaptiveSampling.num_designs_per_sample"></a>*property* `num_designs_per_sample`
-- <a id="reliability.SettingsAdaptiveSampling.num_steps"></a>*property* `num_steps`
-- <a id="reliability.SettingsAdaptiveSampling.num_total_samples_per_step"></a>*property* `num_total_samples_per_step`
-- <a id="reliability.SettingsAdaptiveSampling.use_standard_density"></a>*property* `use_standard_density`
-- <a id="reliability.SettingsAdaptiveSampling.write_weights"></a>*property* `write_weights`
+<a id="reliability.SettingsAdaptiveSampling.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsAdaptiveSampling.accuracy"></a>
+
+#### *property* accuracy
+
+<a id="reliability.SettingsAdaptiveSampling.automatic_sample_size"></a>
+
+#### *property* automatic_sample_size
+
+<a id="reliability.SettingsAdaptiveSampling.initial_scale_factor"></a>
+
+#### *property* initial_scale_factor
+
+<a id="reliability.SettingsAdaptiveSampling.num_designs_per_sample"></a>
+
+#### *property* num_designs_per_sample
+
+<a id="reliability.SettingsAdaptiveSampling.num_steps"></a>
+
+#### *property* num_steps
+
+<a id="reliability.SettingsAdaptiveSampling.num_total_samples_per_step"></a>
+
+#### *property* num_total_samples_per_step
+
+<a id="reliability.SettingsAdaptiveSampling.use_standard_density"></a>
+
+#### *property* use_standard_density
+
+<a id="reliability.SettingsAdaptiveSampling.write_weights"></a>
+
+#### *property* write_weights
 
 <a id="reliability.SettingsBase"></a>
 
@@ -136,18 +319,50 @@ Reliability algorithm settings for Adaptive Sampling.
 
 Base class that define the reliability problem.
 
-- <a id="reliability.SettingsBase.__init__"></a>`__init__()`<br>
-  Raises an exception This class cannot be instantiated from Python
-- <a id="reliability.SettingsBase.check_settings"></a>`check_settings()`<br>
-  Check if settings are correct. Raises an error if they are not.
-- <a id="reliability.SettingsBase.num_estimated_function_calls"></a>*property* `num_estimated_function_calls`
-- <a id="reliability.SettingsBase.num_inputs"></a>*property* `num_inputs`
-- <a id="reliability.SettingsBase.num_safety_margins"></a>*property* `num_safety_margins`
-- <a id="reliability.SettingsBase.rand_generator_seed"></a>*property* `rand_generator_seed`
-- <a id="reliability.SettingsBase.rvset"></a>*property* `rvset`
-- <a id="reliability.SettingsBase.set_defaults"></a>`set_defaults()`
-- <a id="reliability.SettingsBase.write_histories"></a>*property* `write_histories`
-- <a id="reliability.SettingsBase.write_input_importance"></a>*property* `write_input_importance`
+<a id="reliability.SettingsBase.__init__"></a>
+
+#### \_\_init_\_()
+
+Raises an exception
+This class cannot be instantiated from Python
+
+<a id="reliability.SettingsBase.check_settings"></a>
+
+#### check_settings()
+
+Check if settings are correct. Raises an error if they are not.
+
+<a id="reliability.SettingsBase.num_estimated_function_calls"></a>
+
+#### *property* num_estimated_function_calls
+
+<a id="reliability.SettingsBase.num_inputs"></a>
+
+#### *property* num_inputs
+
+<a id="reliability.SettingsBase.num_safety_margins"></a>
+
+#### *property* num_safety_margins
+
+<a id="reliability.SettingsBase.rand_generator_seed"></a>
+
+#### *property* rand_generator_seed
+
+<a id="reliability.SettingsBase.rvset"></a>
+
+#### *property* rvset
+
+<a id="reliability.SettingsBase.set_defaults"></a>
+
+#### set_defaults()
+
+<a id="reliability.SettingsBase.write_histories"></a>
+
+#### *property* write_histories
+
+<a id="reliability.SettingsBase.write_input_importance"></a>
+
+#### *property* write_input_importance
 
 <a id="reliability.SettingsDirectionalSampling"></a>
 
@@ -155,14 +370,35 @@ Base class that define the reliability problem.
 
 Reliability algorithm settings for directional sampling.
 
-- <a id="reliability.SettingsDirectionalSampling.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsDirectionalSampling.linesearch_accuracy"></a>*property* `linesearch_accuracy`
-- <a id="reliability.SettingsDirectionalSampling.linesearch_method"></a>*property* `linesearch_method`
-- <a id="reliability.SettingsDirectionalSampling.linesearch_num_parallel_presample"></a>*property* `linesearch_num_parallel_presample`
-- <a id="reliability.SettingsDirectionalSampling.num_directions"></a>*property* `num_directions`
-- <a id="reliability.SettingsDirectionalSampling.num_parallel"></a>*property* `num_parallel`
-- <a id="reliability.SettingsDirectionalSampling.search_direction_sampling_method"></a>*property* `search_direction_sampling_method`
+<a id="reliability.SettingsDirectionalSampling.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsDirectionalSampling.linesearch_accuracy"></a>
+
+#### *property* linesearch_accuracy
+
+<a id="reliability.SettingsDirectionalSampling.linesearch_method"></a>
+
+#### *property* linesearch_method
+
+<a id="reliability.SettingsDirectionalSampling.linesearch_num_parallel_presample"></a>
+
+#### *property* linesearch_num_parallel_presample
+
+<a id="reliability.SettingsDirectionalSampling.num_directions"></a>
+
+#### *property* num_directions
+
+<a id="reliability.SettingsDirectionalSampling.num_parallel"></a>
+
+#### *property* num_parallel
+
+<a id="reliability.SettingsDirectionalSampling.search_direction_sampling_method"></a>
+
+#### *property* search_direction_sampling_method
 
 <a id="reliability.SettingsFORM"></a>
 
@@ -170,12 +406,25 @@ Reliability algorithm settings for directional sampling.
 
 Reliability algorithm settings for Form/OptimizerNLPQLP
 
-- <a id="reliability.SettingsFORM.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsFORM.max_search_runs"></a>*property* `max_search_runs`
-- <a id="reliability.SettingsFORM.num_presamples"></a>*property* `num_presamples`
-- <a id="reliability.SettingsFORM.optimizer_settings"></a>*property* `optimizer_settings`<br>
-  FORM’s NLPQLP settings. Cannot be copied.
+<a id="reliability.SettingsFORM.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsFORM.max_search_runs"></a>
+
+#### *property* max_search_runs
+
+<a id="reliability.SettingsFORM.num_presamples"></a>
+
+#### *property* num_presamples
+
+<a id="reliability.SettingsFORM.optimizer_settings"></a>
+
+#### *property* optimizer_settings
+
+FORM’s NLPQLP settings. Cannot be copied.
 
 <a id="reliability.SettingsISPUD"></a>
 
@@ -183,18 +432,49 @@ Reliability algorithm settings for Form/OptimizerNLPQLP
 
 Reliability algorithm settings for ISPUD( Importance sampling using the design point).
 
-- <a id="reliability.SettingsISPUD.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsISPUD.accuracy"></a>*property* `accuracy`
-- <a id="reliability.SettingsISPUD.automatic_sample_size"></a>*property* `automatic_sample_size`
-- <a id="reliability.SettingsISPUD.form_settings"></a>*property* `form_settings`<br>
-  ISPUD’s FORM settings. Cannot be copied.
-- <a id="reliability.SettingsISPUD.num_designs_per_sample"></a>*property* `num_designs_per_sample`
-- <a id="reliability.SettingsISPUD.num_total_samples"></a>*property* `num_total_samples`
-- <a id="reliability.SettingsISPUD.use_median_sampling"></a>*property* `use_median_sampling`
-- <a id="reliability.SettingsISPUD.use_start_designs"></a>*property* `use_start_designs`
-- <a id="reliability.SettingsISPUD.vary_discrete_rvs"></a>*property* `vary_discrete_rvs`
-- <a id="reliability.SettingsISPUD.write_weights"></a>*property* `write_weights`
+<a id="reliability.SettingsISPUD.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsISPUD.accuracy"></a>
+
+#### *property* accuracy
+
+<a id="reliability.SettingsISPUD.automatic_sample_size"></a>
+
+#### *property* automatic_sample_size
+
+<a id="reliability.SettingsISPUD.form_settings"></a>
+
+#### *property* form_settings
+
+ISPUD’s FORM settings. Cannot be copied.
+
+<a id="reliability.SettingsISPUD.num_designs_per_sample"></a>
+
+#### *property* num_designs_per_sample
+
+<a id="reliability.SettingsISPUD.num_total_samples"></a>
+
+#### *property* num_total_samples
+
+<a id="reliability.SettingsISPUD.use_median_sampling"></a>
+
+#### *property* use_median_sampling
+
+<a id="reliability.SettingsISPUD.use_start_designs"></a>
+
+#### *property* use_start_designs
+
+<a id="reliability.SettingsISPUD.vary_discrete_rvs"></a>
+
+#### *property* vary_discrete_rvs
+
+<a id="reliability.SettingsISPUD.write_weights"></a>
+
+#### *property* write_weights
 
 <a id="reliability.SettingsMonteCarlo"></a>
 
@@ -202,11 +482,32 @@ Reliability algorithm settings for ISPUD( Importance sampling using the design p
 
 Reliability algorithm settings for Monte Carlo.
 
-- <a id="reliability.SettingsMonteCarlo.__init__"></a>`__init__()`
-- `__init__(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)`
-- <a id="reliability.SettingsMonteCarlo.accuracy"></a>*property* `accuracy`
-- <a id="reliability.SettingsMonteCarlo.automatic_sample_size"></a>*property* `automatic_sample_size`
-- <a id="reliability.SettingsMonteCarlo.min_num_samples"></a>*property* `min_num_samples`
-- <a id="reliability.SettingsMonteCarlo.num_designs_per_sample"></a>*property* `num_designs_per_sample`
-- <a id="reliability.SettingsMonteCarlo.num_total_samples"></a>*property* `num_total_samples`
-- <a id="reliability.SettingsMonteCarlo.scaling_factor"></a>*property* `scaling_factor`
+<a id="reliability.SettingsMonteCarlo.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [RVSet](py_random_variables.md#py_random_variables.RVSet), arg3: int)
+
+<a id="reliability.SettingsMonteCarlo.accuracy"></a>
+
+#### *property* accuracy
+
+<a id="reliability.SettingsMonteCarlo.automatic_sample_size"></a>
+
+#### *property* automatic_sample_size
+
+<a id="reliability.SettingsMonteCarlo.min_num_samples"></a>
+
+#### *property* min_num_samples
+
+<a id="reliability.SettingsMonteCarlo.num_designs_per_sample"></a>
+
+#### *property* num_designs_per_sample
+
+<a id="reliability.SettingsMonteCarlo.num_total_samples"></a>
+
+#### *property* num_total_samples
+
+<a id="reliability.SettingsMonteCarlo.scaling_factor"></a>
+
+#### *property* scaling_factor

--- a/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/stdcpp_python_export.md
+++ b/docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/stdcpp_python_export.md
@@ -6,20 +6,45 @@
 
 **Enumeration**
 
-- <a id="stdcpp_python_export.BasePathMode.ABSOLUTE_PATH"></a>`ABSOLUTE_PATH *= stdcpp_python_export.BasePathMode.ABSOLUTE_PATH*`
-- <a id="stdcpp_python_export.BasePathMode.NUM_BASEPATH_MODES"></a>`NUM_BASEPATH_MODES *= stdcpp_python_export.BasePathMode.NUM_BASEPATH_MODES*`
-- <a id="stdcpp_python_export.BasePathMode.PROJECT_RELATIVE"></a>`PROJECT_RELATIVE *= stdcpp_python_export.BasePathMode.PROJECT_RELATIVE*`
-- <a id="stdcpp_python_export.BasePathMode.PROJECT_WORKING_DIR_RELATIVE"></a>`PROJECT_WORKING_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.PROJECT_WORKING_DIR_RELATIVE*`
-- <a id="stdcpp_python_export.BasePathMode.REFERENCE_FILES_DIR_RELATIVE"></a>`REFERENCE_FILES_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.REFERENCE_FILES_DIR_RELATIVE*`
-- <a id="stdcpp_python_export.BasePathMode.WORKING_DIR_RELATIVE"></a>`WORKING_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.WORKING_DIR_RELATIVE*`
+<a id="stdcpp_python_export.BasePathMode.ABSOLUTE_PATH"></a>
+
+#### ABSOLUTE_PATH *= stdcpp_python_export.BasePathMode.ABSOLUTE_PATH*
+
+<a id="stdcpp_python_export.BasePathMode.NUM_BASEPATH_MODES"></a>
+
+#### NUM_BASEPATH_MODES *= stdcpp_python_export.BasePathMode.NUM_BASEPATH_MODES*
+
+<a id="stdcpp_python_export.BasePathMode.PROJECT_RELATIVE"></a>
+
+#### PROJECT_RELATIVE *= stdcpp_python_export.BasePathMode.PROJECT_RELATIVE*
+
+<a id="stdcpp_python_export.BasePathMode.PROJECT_WORKING_DIR_RELATIVE"></a>
+
+#### PROJECT_WORKING_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.PROJECT_WORKING_DIR_RELATIVE*
+
+<a id="stdcpp_python_export.BasePathMode.REFERENCE_FILES_DIR_RELATIVE"></a>
+
+#### REFERENCE_FILES_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.REFERENCE_FILES_DIR_RELATIVE*
+
+<a id="stdcpp_python_export.BasePathMode.WORKING_DIR_RELATIVE"></a>
+
+#### WORKING_DIR_RELATIVE *= stdcpp_python_export.BasePathMode.WORKING_DIR_RELATIVE*
 
 <a id="stdcpp_python_export.DoublePair"></a>
 
 ## *class* stdcpp_python_export.DoublePair
 
-- <a id="stdcpp_python_export.DoublePair.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.DoublePair.first"></a>*property* `first`
-- <a id="stdcpp_python_export.DoublePair.second"></a>*property* `second`
+<a id="stdcpp_python_export.DoublePair.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.DoublePair.first"></a>
+
+#### *property* first
+
+<a id="stdcpp_python_export.DoublePair.second"></a>
+
+#### *property* second
 
 <a id="stdcpp_python_export.MakeVariableNameValid"></a>
 
@@ -31,9 +56,15 @@
 
 ## *class* stdcpp_python_export.Path
 
-- <a id="stdcpp_python_export.Path.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- <a id="stdcpp_python_export.Path.__str__"></a>`__str__() → str`
+<a id="stdcpp_python_export.Path.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+<a id="stdcpp_python_export.Path.__str__"></a>
+
+#### \_\_str_\_() → str
 
 <a id="stdcpp_python_export.PathSet"></a>
 
@@ -41,47 +72,121 @@
 
 A mutable set.
 
-- <a id="stdcpp_python_export.PathSet.__and__"></a>`__and__(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.PathSet.__contains__"></a>`__contains__(arg2: [Path](#stdcpp_python_export.Path)) → bool`
-- <a id="stdcpp_python_export.PathSet.__delitem__"></a>`__delitem__(arg2: [Path](#stdcpp_python_export.Path))`
-- <a id="stdcpp_python_export.PathSet.__hash__"></a>`__hash__()`
-- <a id="stdcpp_python_export.PathSet.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.PathSet.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.PathSet.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.PathSet.__or__"></a>`__or__(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return the union of this set and other.
-- <a id="stdcpp_python_export.PathSet.__sub__"></a>`__sub__(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.PathSet.__xor__"></a>`__xor__(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.PathSet.add"></a>`add(element: [Path](#stdcpp_python_export.Path))`<br>
-  Add element.
-- <a id="stdcpp_python_export.PathSet.difference"></a>`difference(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.PathSet.intersection"></a>`intersection(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.PathSet.remove"></a>`remove(element: [Path](#stdcpp_python_export.Path))`<br>
-  Remove element.
-- <a id="stdcpp_python_export.PathSet.symmetric_difference"></a>`symmetric_difference(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.PathSet.union"></a>`union(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)`<br>
-  Return the union of this set and other.
+<a id="stdcpp_python_export.PathSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.PathSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: [Path](#stdcpp_python_export.Path)) → bool
+
+<a id="stdcpp_python_export.PathSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: [Path](#stdcpp_python_export.Path))
+
+<a id="stdcpp_python_export.PathSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="stdcpp_python_export.PathSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.PathSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.PathSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.PathSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return the union of this set and other.
+
+<a id="stdcpp_python_export.PathSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.PathSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.PathSet.add"></a>
+
+#### add(element: [Path](#stdcpp_python_export.Path))
+
+Add element.
+
+<a id="stdcpp_python_export.PathSet.difference"></a>
+
+#### difference(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.PathSet.intersection"></a>
+
+#### intersection(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.PathSet.remove"></a>
+
+#### remove(element: [Path](#stdcpp_python_export.Path))
+
+Remove element.
+
+<a id="stdcpp_python_export.PathSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.PathSet.union"></a>
+
+#### union(other: [PathSet](#stdcpp_python_export.PathSet)) → [PathSet](#stdcpp_python_export.PathSet)
+
+Return the union of this set and other.
 
 <a id="stdcpp_python_export.RelativeSplittedPath"></a>
 
 ## *class* stdcpp_python_export.RelativeSplittedPath
 
-- <a id="stdcpp_python_export.RelativeSplittedPath.__init__"></a>`__init__()`
-- `__init__(arg2: [Path](#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](#stdcpp_python_export.Path), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode))`
-- `__init__(arg2: [Path](#stdcpp_python_export.Path), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode), arg4: [Path](#stdcpp_python_export.Path))`
-- `__init__(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath))`
-- `__init__(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode))`
-- `__init__(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode), arg4: [Path](#stdcpp_python_export.Path))`
-- <a id="stdcpp_python_export.RelativeSplittedPath.base_path"></a>*property* `base_path`
-- <a id="stdcpp_python_export.RelativeSplittedPath.base_path_mode"></a>*property* `base_path_mode`
-- <a id="stdcpp_python_export.RelativeSplittedPath.splitted_path"></a>*property* `splitted_path`
+<a id="stdcpp_python_export.RelativeSplittedPath.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: [Path](#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](#stdcpp_python_export.Path), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode))
+
+#### \_\_init_\_(arg2: [Path](#stdcpp_python_export.Path), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode), arg4: [Path](#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath))
+
+#### \_\_init_\_(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode))
+
+#### \_\_init_\_(arg2: [SplittedPath](#stdcpp_python_export.SplittedPath), arg3: [BasePathMode](#stdcpp_python_export.BasePathMode), arg4: [Path](#stdcpp_python_export.Path))
+
+<a id="stdcpp_python_export.RelativeSplittedPath.base_path"></a>
+
+#### *property* base_path
+
+<a id="stdcpp_python_export.RelativeSplittedPath.base_path_mode"></a>
+
+#### *property* base_path_mode
+
+<a id="stdcpp_python_export.RelativeSplittedPath.splitted_path"></a>
+
+#### *property* splitted_path
 
 <a id="stdcpp_python_export.SizeSet"></a>
 
@@ -89,73 +194,197 @@ A mutable set.
 
 A mutable set.
 
-- <a id="stdcpp_python_export.SizeSet.__and__"></a>`__and__(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.SizeSet.__contains__"></a>`__contains__(arg2: int) → bool`
-- <a id="stdcpp_python_export.SizeSet.__delitem__"></a>`__delitem__(arg2: int)`
-- <a id="stdcpp_python_export.SizeSet.__hash__"></a>`__hash__()`
-- <a id="stdcpp_python_export.SizeSet.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.SizeSet.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.SizeSet.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.SizeSet.__or__"></a>`__or__(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return the union of this set and other.
-- <a id="stdcpp_python_export.SizeSet.__sub__"></a>`__sub__(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.SizeSet.__xor__"></a>`__xor__(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.SizeSet.add"></a>`add(element: int)`<br>
-  Add element.
-- <a id="stdcpp_python_export.SizeSet.difference"></a>`difference(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.SizeSet.intersection"></a>`intersection(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.SizeSet.remove"></a>`remove(element: int)`<br>
-  Remove element.
-- <a id="stdcpp_python_export.SizeSet.symmetric_difference"></a>`symmetric_difference(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.SizeSet.union"></a>`union(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)`<br>
-  Return the union of this set and other.
+<a id="stdcpp_python_export.SizeSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.SizeSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: int) → bool
+
+<a id="stdcpp_python_export.SizeSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: int)
+
+<a id="stdcpp_python_export.SizeSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="stdcpp_python_export.SizeSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.SizeSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.SizeSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.SizeSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return the union of this set and other.
+
+<a id="stdcpp_python_export.SizeSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.SizeSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.SizeSet.add"></a>
+
+#### add(element: int)
+
+Add element.
+
+<a id="stdcpp_python_export.SizeSet.difference"></a>
+
+#### difference(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.SizeSet.intersection"></a>
+
+#### intersection(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.SizeSet.remove"></a>
+
+#### remove(element: int)
+
+Remove element.
+
+<a id="stdcpp_python_export.SizeSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.SizeSet.union"></a>
+
+#### union(other: [SizeSet](#stdcpp_python_export.SizeSet)) → [SizeSet](#stdcpp_python_export.SizeSet)
+
+Return the union of this set and other.
 
 <a id="stdcpp_python_export.SplittedPath"></a>
 
 ## *class* stdcpp_python_export.SplittedPath
 
-- <a id="stdcpp_python_export.SplittedPath.__init__"></a>`__init__()`
-- `__init__(arg2: str)`
-- `__init__(arg2: str, arg3: str)`
-- `__init__(arg2: [Path](#stdcpp_python_export.Path))`
-- `__init__(arg2: [Path](#stdcpp_python_export.Path), arg3: [Path](#stdcpp_python_export.Path))`
-- <a id="stdcpp_python_export.SplittedPath.__str__"></a>`__str__() → str`
-- <a id="stdcpp_python_export.SplittedPath.head"></a>*property* `head`
-- <a id="stdcpp_python_export.SplittedPath.isSplitted"></a>`isSplitted() → bool`
-- <a id="stdcpp_python_export.SplittedPath.joined"></a>`joined() → [Path](#stdcpp_python_export.Path)`
-- <a id="stdcpp_python_export.SplittedPath.tail"></a>*property* `tail`
+<a id="stdcpp_python_export.SplittedPath.__init__"></a>
+
+#### \_\_init_\_()
+
+#### \_\_init_\_(arg2: str)
+
+#### \_\_init_\_(arg2: str, arg3: str)
+
+#### \_\_init_\_(arg2: [Path](#stdcpp_python_export.Path))
+
+#### \_\_init_\_(arg2: [Path](#stdcpp_python_export.Path), arg3: [Path](#stdcpp_python_export.Path))
+
+<a id="stdcpp_python_export.SplittedPath.__str__"></a>
+
+#### \_\_str_\_() → str
+
+<a id="stdcpp_python_export.SplittedPath.head"></a>
+
+#### *property* head
+
+<a id="stdcpp_python_export.SplittedPath.isSplitted"></a>
+
+#### isSplitted() → bool
+
+<a id="stdcpp_python_export.SplittedPath.joined"></a>
+
+#### joined() → [Path](#stdcpp_python_export.Path)
+
+<a id="stdcpp_python_export.SplittedPath.tail"></a>
+
+#### *property* tail
 
 <a id="stdcpp_python_export.StrList"></a>
 
 ## *class* stdcpp_python_export.StrList
 
-- <a id="stdcpp_python_export.StrList.StrExportList"></a>`StrExportList() → [StrList](#stdcpp_python_export.StrList)`
-- <a id="stdcpp_python_export.StrList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.StrList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.StrList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.StrList.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.StrList.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.StrList.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.StrList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.StrList.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.StrList.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.StrList.push_back"></a>`push_back(arg2: str)`
-- <a id="stdcpp_python_export.StrList.size"></a>`size() → int`
-- <a id="stdcpp_python_export.StrList.sort"></a>`sort()`
+<a id="stdcpp_python_export.StrList.StrExportList"></a>
+
+#### StrExportList() → [StrList](#stdcpp_python_export.StrList)
+
+<a id="stdcpp_python_export.StrList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.StrList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.StrList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.StrList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.StrList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.StrList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.StrList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.StrList.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.StrList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.StrList.push_back"></a>
+
+#### push_back(arg2: str)
+
+<a id="stdcpp_python_export.StrList.size"></a>
+
+#### size() → int
+
+<a id="stdcpp_python_export.StrList.sort"></a>
+
+#### sort()
 
 <a id="stdcpp_python_export.StrPair"></a>
 
 ## *class* stdcpp_python_export.StrPair
 
-- <a id="stdcpp_python_export.StrPair.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.StrPair.first"></a>*property* `first`
-- <a id="stdcpp_python_export.StrPair.second"></a>*property* `second`
+<a id="stdcpp_python_export.StrPair.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.StrPair.first"></a>
+
+#### *property* first
+
+<a id="stdcpp_python_export.StrPair.second"></a>
+
+#### *property* second
 
 <a id="stdcpp_python_export.StrSet"></a>
 
@@ -163,58 +392,161 @@ A mutable set.
 
 A mutable set.
 
-- <a id="stdcpp_python_export.StrSet.__and__"></a>`__and__(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.StrSet.__contains__"></a>`__contains__(arg2: str) → bool`
-- <a id="stdcpp_python_export.StrSet.__delitem__"></a>`__delitem__(arg2: str)`
-- <a id="stdcpp_python_export.StrSet.__hash__"></a>`__hash__()`
-- <a id="stdcpp_python_export.StrSet.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.StrSet.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.StrSet.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.StrSet.__or__"></a>`__or__(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return the union of this set and other.
-- <a id="stdcpp_python_export.StrSet.__sub__"></a>`__sub__(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.StrSet.__xor__"></a>`__xor__(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.StrSet.add"></a>`add(element: str)`<br>
-  Add element.
-- <a id="stdcpp_python_export.StrSet.difference"></a>`difference(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.StrSet.intersection"></a>`intersection(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.StrSet.remove"></a>`remove(element: str)`<br>
-  Remove element.
-- <a id="stdcpp_python_export.StrSet.symmetric_difference"></a>`symmetric_difference(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.StrSet.union"></a>`union(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)`<br>
-  Return the union of this set and other.
+<a id="stdcpp_python_export.StrSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.StrSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: str) → bool
+
+<a id="stdcpp_python_export.StrSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: str)
+
+<a id="stdcpp_python_export.StrSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="stdcpp_python_export.StrSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.StrSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.StrSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.StrSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return the union of this set and other.
+
+<a id="stdcpp_python_export.StrSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.StrSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.StrSet.add"></a>
+
+#### add(element: str)
+
+Add element.
+
+<a id="stdcpp_python_export.StrSet.difference"></a>
+
+#### difference(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.StrSet.intersection"></a>
+
+#### intersection(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.StrSet.remove"></a>
+
+#### remove(element: str)
+
+Remove element.
+
+<a id="stdcpp_python_export.StrSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.StrSet.union"></a>
+
+#### union(other: [StrSet](#stdcpp_python_export.StrSet)) → [StrSet](#stdcpp_python_export.StrSet)
+
+Return the union of this set and other.
 
 <a id="stdcpp_python_export.WStrList"></a>
 
 ## *class* stdcpp_python_export.WStrList
 
-- <a id="stdcpp_python_export.WStrList.StrExportList"></a>`StrExportList() → [WStrList](#stdcpp_python_export.WStrList)`
-- <a id="stdcpp_python_export.WStrList.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.WStrList.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.WStrList.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.WStrList.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.WStrList.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.WStrList.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.WStrList.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.WStrList.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.WStrList.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.WStrList.push_back"></a>`push_back(arg2: str)`
-- <a id="stdcpp_python_export.WStrList.size"></a>`size() → int`
-- <a id="stdcpp_python_export.WStrList.sort"></a>`sort()`
+<a id="stdcpp_python_export.WStrList.StrExportList"></a>
+
+#### StrExportList() → [WStrList](#stdcpp_python_export.WStrList)
+
+<a id="stdcpp_python_export.WStrList.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.WStrList.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.WStrList.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.WStrList.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.WStrList.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.WStrList.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.WStrList.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.WStrList.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.WStrList.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.WStrList.push_back"></a>
+
+#### push_back(arg2: str)
+
+<a id="stdcpp_python_export.WStrList.size"></a>
+
+#### size() → int
+
+<a id="stdcpp_python_export.WStrList.sort"></a>
+
+#### sort()
 
 <a id="stdcpp_python_export.WStrPair"></a>
 
 ## *class* stdcpp_python_export.WStrPair
 
-- <a id="stdcpp_python_export.WStrPair.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.WStrPair.first"></a>*property* `first`
-- <a id="stdcpp_python_export.WStrPair.second"></a>*property* `second`
+<a id="stdcpp_python_export.WStrPair.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.WStrPair.first"></a>
+
+#### *property* first
+
+<a id="stdcpp_python_export.WStrPair.second"></a>
+
+#### *property* second
 
 <a id="stdcpp_python_export.WStrSet"></a>
 
@@ -222,48 +554,137 @@ A mutable set.
 
 A mutable set.
 
-- <a id="stdcpp_python_export.WStrSet.__and__"></a>`__and__(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.WStrSet.__contains__"></a>`__contains__(arg2: str) → bool`
-- <a id="stdcpp_python_export.WStrSet.__delitem__"></a>`__delitem__(arg2: str)`
-- <a id="stdcpp_python_export.WStrSet.__hash__"></a>`__hash__()`
-- <a id="stdcpp_python_export.WStrSet.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.WStrSet.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.WStrSet.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.WStrSet.__or__"></a>`__or__(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return the union of this set and other.
-- <a id="stdcpp_python_export.WStrSet.__sub__"></a>`__sub__(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.WStrSet.__xor__"></a>`__xor__(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.WStrSet.add"></a>`add(element: str)`<br>
-  Add element.
-- <a id="stdcpp_python_export.WStrSet.difference"></a>`difference(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return elements of this set that are not in other.
-- <a id="stdcpp_python_export.WStrSet.intersection"></a>`intersection(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return the intersection of this set and other.
-- <a id="stdcpp_python_export.WStrSet.remove"></a>`remove(element: str)`<br>
-  Remove element.
-- <a id="stdcpp_python_export.WStrSet.symmetric_difference"></a>`symmetric_difference(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return elements that are either in this set or in other but not in both.
-- <a id="stdcpp_python_export.WStrSet.union"></a>`union(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)`<br>
-  Return the union of this set and other.
+<a id="stdcpp_python_export.WStrSet.__and__"></a>
+
+#### \_\_and_\_(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.WStrSet.__contains__"></a>
+
+#### \_\_contains_\_(arg2: str) → bool
+
+<a id="stdcpp_python_export.WStrSet.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: str)
+
+<a id="stdcpp_python_export.WStrSet.__hash__"></a>
+
+#### \_\_hash_\_()
+
+<a id="stdcpp_python_export.WStrSet.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.WStrSet.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.WStrSet.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.WStrSet.__or__"></a>
+
+#### \_\_or_\_(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return the union of this set and other.
+
+<a id="stdcpp_python_export.WStrSet.__sub__"></a>
+
+#### \_\_sub_\_(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.WStrSet.__xor__"></a>
+
+#### \_\_xor_\_(arg2: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.WStrSet.add"></a>
+
+#### add(element: str)
+
+Add element.
+
+<a id="stdcpp_python_export.WStrSet.difference"></a>
+
+#### difference(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return elements of this set that are not in other.
+
+<a id="stdcpp_python_export.WStrSet.intersection"></a>
+
+#### intersection(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return the intersection of this set and other.
+
+<a id="stdcpp_python_export.WStrSet.remove"></a>
+
+#### remove(element: str)
+
+Remove element.
+
+<a id="stdcpp_python_export.WStrSet.symmetric_difference"></a>
+
+#### symmetric_difference(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return elements that are either in this set or in other but not in both.
+
+<a id="stdcpp_python_export.WStrSet.union"></a>
+
+#### union(other: [WStrSet](#stdcpp_python_export.WStrSet)) → [WStrSet](#stdcpp_python_export.WStrSet)
+
+Return the union of this set and other.
 
 <a id="stdcpp_python_export.boolVec"></a>
 
 ## *class* stdcpp_python_export.boolVec
 
-- <a id="stdcpp_python_export.boolVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.boolVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.boolVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.boolVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.boolVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.boolVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.boolVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.boolVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.boolVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.boolVec.push_back"></a>`push_back(arg2: bool)`
-- <a id="stdcpp_python_export.boolVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.boolVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.boolVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.boolVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.boolVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.boolVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.boolVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.boolVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.boolVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.boolVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.boolVec.push_back"></a>
+
+#### push_back(arg2: bool)
+
+<a id="stdcpp_python_export.boolVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.bool_list_to_vec"></a>
 
@@ -297,33 +718,97 @@ A mutable set.
 
 ## *class* stdcpp_python_export.doubleVec
 
-- <a id="stdcpp_python_export.doubleVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.doubleVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.doubleVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.doubleVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.doubleVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.doubleVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.doubleVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.doubleVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.doubleVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.doubleVec.push_back"></a>`push_back(arg2: float)`
-- <a id="stdcpp_python_export.doubleVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.doubleVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.doubleVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.doubleVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.doubleVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.doubleVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.doubleVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.doubleVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.doubleVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.doubleVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.doubleVec.push_back"></a>
+
+#### push_back(arg2: float)
+
+<a id="stdcpp_python_export.doubleVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.doubleVecVec"></a>
 
 ## *class* stdcpp_python_export.doubleVecVec
 
-- <a id="stdcpp_python_export.doubleVecVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.doubleVecVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.doubleVecVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.doubleVecVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.doubleVecVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.doubleVecVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.doubleVecVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.doubleVecVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.doubleVecVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.doubleVecVec.push_back"></a>`push_back(arg2: [doubleVec](#stdcpp_python_export.doubleVec))`
-- <a id="stdcpp_python_export.doubleVecVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.doubleVecVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.doubleVecVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.doubleVecVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.doubleVecVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.doubleVecVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.doubleVecVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.doubleVecVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.doubleVecVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.doubleVecVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.doubleVecVec.push_back"></a>
+
+#### push_back(arg2: [doubleVec](#stdcpp_python_export.doubleVec))
+
+<a id="stdcpp_python_export.doubleVecVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.doubleVec_list_to_vec"></a>
 
@@ -341,17 +826,49 @@ A mutable set.
 
 ## *class* stdcpp_python_export.intVec
 
-- <a id="stdcpp_python_export.intVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.intVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.intVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.intVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.intVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.intVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.intVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.intVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.intVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.intVec.push_back"></a>`push_back(arg2: int)`
-- <a id="stdcpp_python_export.intVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.intVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.intVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.intVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.intVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.intVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.intVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.intVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.intVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.intVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.intVec.push_back"></a>
+
+#### push_back(arg2: int)
+
+<a id="stdcpp_python_export.intVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.int_list_to_vec"></a>
 
@@ -375,44 +892,109 @@ A mutable set.
 
 ## *class* stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry
 
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.__repr__"></a>`__repr__() → object`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.data"></a>`data() → bool`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.key"></a>`key() → str`
+<a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.__repr__"></a>
+
+#### \_\_repr_\_() → object
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.data"></a>
+
+#### data() → bool
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_bool_map_entry.key"></a>
+
+#### key() → str
 
 <a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry"></a>
 
 ## *class* stdcpp_python_export.map_indexing_suite_string_to_double_map_entry
 
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.__repr__"></a>`__repr__() → object`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.data"></a>`data() → float`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.key"></a>`key() → str`
+<a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.__repr__"></a>
+
+#### \_\_repr_\_() → object
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.data"></a>
+
+#### data() → float
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_double_map_entry.key"></a>
+
+#### key() → str
 
 <a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry"></a>
 
 ## *class* stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry
 
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.__repr__"></a>`__repr__() → object`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.data"></a>`data() → int`
-- <a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.key"></a>`key() → str`
+<a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.__repr__"></a>
+
+#### \_\_repr_\_() → object
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.data"></a>
+
+#### data() → int
+
+<a id="stdcpp_python_export.map_indexing_suite_string_to_uint_map_entry.key"></a>
+
+#### key() → str
 
 <a id="stdcpp_python_export.stringVec"></a>
 
 ## *class* stdcpp_python_export.stringVec
 
-- <a id="stdcpp_python_export.stringVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.stringVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.stringVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.stringVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.stringVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.stringVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.stringVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.stringVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.stringVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.stringVec.push_back"></a>`push_back(arg2: str)`
-- <a id="stdcpp_python_export.stringVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.stringVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.stringVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.stringVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.stringVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.stringVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.stringVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.stringVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.stringVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.stringVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.stringVec.push_back"></a>
+
+#### push_back(arg2: str)
+
+<a id="stdcpp_python_export.stringVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.string_list_to_vec"></a>
 
@@ -422,53 +1004,145 @@ A mutable set.
 
 ## *class* stdcpp_python_export.string_to_bool_map
 
-- <a id="stdcpp_python_export.string_to_bool_map.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.string_to_bool_map.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.string_to_bool_map.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.string_to_bool_map.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.string_to_bool_map.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.string_to_bool_map.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.string_to_bool_map.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
+<a id="stdcpp_python_export.string_to_bool_map.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.string_to_bool_map.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.string_to_bool_map.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.string_to_bool_map.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.string_to_bool_map.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.string_to_bool_map.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.string_to_bool_map.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
 
 <a id="stdcpp_python_export.string_to_double_map"></a>
 
 ## *class* stdcpp_python_export.string_to_double_map
 
-- <a id="stdcpp_python_export.string_to_double_map.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.string_to_double_map.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.string_to_double_map.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.string_to_double_map.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.string_to_double_map.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.string_to_double_map.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.string_to_double_map.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
+<a id="stdcpp_python_export.string_to_double_map.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.string_to_double_map.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.string_to_double_map.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.string_to_double_map.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.string_to_double_map.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.string_to_double_map.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.string_to_double_map.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
 
 <a id="stdcpp_python_export.string_to_uint_map"></a>
 
 ## *class* stdcpp_python_export.string_to_uint_map
 
-- <a id="stdcpp_python_export.string_to_uint_map.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.string_to_uint_map.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.string_to_uint_map.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.string_to_uint_map.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.string_to_uint_map.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.string_to_uint_map.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.string_to_uint_map.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
+<a id="stdcpp_python_export.string_to_uint_map.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.string_to_uint_map.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.string_to_uint_map.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.string_to_uint_map.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.string_to_uint_map.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.string_to_uint_map.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.string_to_uint_map.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
 
 <a id="stdcpp_python_export.uintVec"></a>
 
 ## *class* stdcpp_python_export.uintVec
 
-- <a id="stdcpp_python_export.uintVec.__contains__"></a>`__contains__(arg2: object) → bool`
-- <a id="stdcpp_python_export.uintVec.__delitem__"></a>`__delitem__(arg2: object)`
-- <a id="stdcpp_python_export.uintVec.__getitem__"></a>`__getitem__(arg2: object) → object`
-- <a id="stdcpp_python_export.uintVec.__init__"></a>`__init__()`
-- <a id="stdcpp_python_export.uintVec.__iter__"></a>`__iter__() → object`
-- <a id="stdcpp_python_export.uintVec.__len__"></a>`__len__() → int`
-- <a id="stdcpp_python_export.uintVec.__setitem__"></a>`__setitem__(arg2: object, arg3: object)`
-- <a id="stdcpp_python_export.uintVec.append"></a>`append(arg2: object)`
-- <a id="stdcpp_python_export.uintVec.extend"></a>`extend(arg2: object)`
-- <a id="stdcpp_python_export.uintVec.push_back"></a>`push_back(arg2: int)`
-- <a id="stdcpp_python_export.uintVec.size"></a>`size() → int`
+<a id="stdcpp_python_export.uintVec.__contains__"></a>
+
+#### \_\_contains_\_(arg2: object) → bool
+
+<a id="stdcpp_python_export.uintVec.__delitem__"></a>
+
+#### \_\_delitem_\_(arg2: object)
+
+<a id="stdcpp_python_export.uintVec.__getitem__"></a>
+
+#### \_\_getitem_\_(arg2: object) → object
+
+<a id="stdcpp_python_export.uintVec.__init__"></a>
+
+#### \_\_init_\_()
+
+<a id="stdcpp_python_export.uintVec.__iter__"></a>
+
+#### \_\_iter_\_() → object
+
+<a id="stdcpp_python_export.uintVec.__len__"></a>
+
+#### \_\_len_\_() → int
+
+<a id="stdcpp_python_export.uintVec.__setitem__"></a>
+
+#### \_\_setitem_\_(arg2: object, arg3: object)
+
+<a id="stdcpp_python_export.uintVec.append"></a>
+
+#### append(arg2: object)
+
+<a id="stdcpp_python_export.uintVec.extend"></a>
+
+#### extend(arg2: object)
+
+<a id="stdcpp_python_export.uintVec.push_back"></a>
+
+#### push_back(arg2: int)
+
+<a id="stdcpp_python_export.uintVec.size"></a>
+
+#### size() → int
 
 <a id="stdcpp_python_export.uint_list_to_vec"></a>
 


### PR DESCRIPTION
## Summary

- Reverts readability reformat commit `c59dae1fb` for `2026.R1.SP00` Python API module reference pages.
- Restores markdown cross-reference links outside code spans so Dev Portal link parsing works again (33 module files).
- Aligns `main` with `sandbox` for `2026.R1.SP00/modules/` — sandbox was restored earlier via `41212e837`.

## Test plan

- [ ] Verify the doc set renders correctly on the developer portal
- [ ] Confirm TOC navigation works end-to-end
- [ ] Verify all internal cross-links resolve correctly
- [ ] After merge: `git diff origin/main origin/sandbox -- versions/2026.R1.SP00/modules/` should be empty

## Notes for reviewer

Companion PR for SP03 production fix: #506 (still open). This PR is independent — different version folder; merge order does not block.

Root cause: readability reformat wrapped member signatures in backticks, breaking Dev Portal link parsing.

**Files changed:** 33 files under `docs/optislang/osl-python-api/versions/2026.R1.SP00/modules/`
